### PR TITLE
More strict group/array metadata serialization

### DIFF
--- a/icechunk/src/zarr.rs
+++ b/icechunk/src/zarr.rs
@@ -751,7 +751,7 @@ where
     if value != "array" {
         return Err(de::Error::invalid_value(
             de::Unexpected::Str(value.as_str()),
-            &"the word 'arary'",
+            &"the word 'array'",
         ));
     }
 


### PR DESCRIPTION
Now we require the right `node_type`