### PR TITLE
New Dataset config variable unsafe_overwrite_refs

### DIFF
--- a/icechunk/src/storage/caching.rs
+++ b/icechunk/src/storage/caching.rs
@@ -207,8 +207,13 @@ impl Storage for MemCachingStorage {
         self.backend.ref_names().await
     }
 
-    async fn write_ref(&self, ref_key: &str, bytes: Bytes) -> StorageResult<()> {
-        self.backend.write_ref(ref_key, bytes).await
+    async fn write_ref(
+        &self,
+        ref_key: &str,
+        overwrite_refs: bool,
+        bytes: Bytes,
+    ) -> StorageResult<()> {
+        self.backend.write_ref(ref_key, overwrite_refs, bytes).await
     }
 
     async fn ref_versions(&self, ref_name: &str) -> BoxStream<StorageResult<String>> {

--- a/icechunk/src/storage/logging.rs
+++ b/icechunk/src/storage/logging.rs
@@ -109,8 +109,13 @@ impl Storage for LoggingStorage {
         self.backend.ref_names().await
     }
 
-    async fn write_ref(&self, ref_key: &str, bytes: Bytes) -> StorageResult<()> {
-        self.backend.write_ref(ref_key, bytes).await
+    async fn write_ref(
+        &self,
+        ref_key: &str,
+        overwrite_refs: bool,
+        bytes: Bytes,
+    ) -> StorageResult<()> {
+        self.backend.write_ref(ref_key, overwrite_refs, bytes).await
     }
 
     async fn ref_versions(&self, ref_name: &str) -> BoxStream<StorageResult<String>> {

--- a/icechunk/src/storage/mod.rs
+++ b/icechunk/src/storage/mod.rs
@@ -80,5 +80,10 @@ pub trait Storage: fmt::Debug {
     async fn get_ref(&self, ref_key: &str) -> StorageResult<Bytes>;
     async fn ref_names(&self) -> StorageResult<Vec<String>>;
     async fn ref_versions(&self, ref_name: &str) -> BoxStream<StorageResult<String>>;
-    async fn write_ref(&self, ref_key: &str, bytes: Bytes) -> StorageResult<()>;
+    async fn write_ref(
+        &self,
+        ref_key: &str,
+        overwrite_refs: bool,
+        bytes: Bytes,
+    ) -> StorageResult<()>;
 }

--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -264,9 +264,15 @@ impl Storage for ObjectStorage {
             .boxed()
     }
 
-    async fn write_ref(&self, ref_key: &str, bytes: Bytes) -> StorageResult<()> {
+    async fn write_ref(
+        &self,
+        ref_key: &str,
+        overwrite_refs: bool,
+        bytes: Bytes,
+    ) -> StorageResult<()> {
         let key = self.ref_key(ref_key);
-        let opts = PutOptions { mode: PutMode::Create, ..PutOptions::default() };
+        let mode = if overwrite_refs { PutMode::Overwrite } else { PutMode::Create };
+        let opts = PutOptions { mode, ..PutOptions::default() };
 
         self.store
             .put_opts(&key, PutPayload::from_bytes(bytes), opts)


### PR DESCRIPTION
Set to false by default. For use in object stores that don't support create-object-if-not-exists (or where WE don't support it).