### PR TITLE
Our Minio storage doesn't support create-if-not-exists

### DIFF
--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -126,10 +126,6 @@ impl ObjectStorage {
             builder
         };
 
-        // FIXME: this is a hack to pretend we do this only for S3
-        // this will go away once object_store supports create-if-not-exist on S3
-        let supports_create_if_not_exists = endpoint.is_some();
-
         let builder = if let Some(endpoint) = endpoint {
             builder.with_endpoint(endpoint).with_allow_http(true)
         } else {
@@ -141,7 +137,8 @@ impl ObjectStorage {
             store: Arc::new(store),
             prefix: prefix.into(),
             artificially_sort_refs_in_mem: false,
-            supports_create_if_not_exists,
+            // FIXME: this will go away once object_store supports create-if-not-exist on S3
+            supports_create_if_not_exists: false,
         })
     }
 


### PR DESCRIPTION
Because we are using the S3 object_store implementation.