### PR TITLE
`ObjectIds` for different types of objects are different types

### DIFF
--- a/icechunk/src/format/manifest.rs
+++ b/icechunk/src/format/manifest.rs
@@ -6,8 +6,8 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    ChunkIndices, ChunkLength, ChunkOffset, Flags, IcechunkFormatError, IcechunkResult,
-    NodeId, ObjectId,
+    ChunkId, ChunkIndices, ChunkLength, ChunkOffset, Flags, IcechunkFormatError,
+    IcechunkResult, ManifestId, NodeId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -15,7 +15,7 @@ pub struct ManifestExtents(pub Vec<ChunkIndices>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManifestRef {
-    pub object_id: ObjectId,
+    pub object_id: ManifestId,
     pub flags: Flags,
     pub extents: ManifestExtents,
 }
@@ -77,7 +77,7 @@ pub struct VirtualChunkRef {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ChunkRef {
-    pub id: ObjectId,
+    pub id: ChunkId,
     pub offset: ChunkOffset,
     pub length: ChunkLength,
 }

--- a/icechunk/src/format/mod.rs
+++ b/icechunk/src/format/mod.rs
@@ -2,14 +2,15 @@ use core::fmt;
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
+    marker::PhantomData,
     ops::Bound,
     path::PathBuf,
 };
 
 use bytes::Bytes;
 use itertools::Itertools;
+use rand::{thread_rng, Rng};
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_with::serde_as;
 use thiserror::Error;
 
 use crate::metadata::DataType;
@@ -21,35 +22,67 @@ pub mod snapshot;
 pub type Path = PathBuf;
 
 /// The id of a file in object store
-// FIXME: should this be passed by ref everywhere?
-#[serde_as]
 #[derive(Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ObjectId(pub [u8; 16]); // FIXME: this doesn't need to be this big
+pub struct ObjectId<const SIZE: usize, T>(pub [u8; SIZE], PhantomData<T>);
 
-impl ObjectId {
+#[allow(dead_code)]
+trait ObjectTag {}
+
+#[derive(Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SnapshotTag;
+
+#[derive(Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManifestTag;
+
+#[derive(Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ChunkTag;
+
+#[derive(Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AttributesTag;
+
+impl ObjectTag for SnapshotTag {}
+impl ObjectTag for ManifestTag {}
+impl ObjectTag for ChunkTag {}
+impl ObjectTag for AttributesTag {}
+
+// A 1e-9 conflict probability requires 2^33 ~ 8.5 bn chunks
+// using this site for the calculations: https://www.bdayprob.com/
+pub type SnapshotId = ObjectId<12, SnapshotTag>;
+pub type ManifestId = ObjectId<12, ManifestTag>;
+pub type ChunkId = ObjectId<12, ChunkTag>;
+pub type AttributesId = ObjectId<12, AttributesTag>;
+
+impl<const SIZE: usize, T> ObjectId<SIZE, T> {
     pub fn random() -> Self {
-        Self(rand::random())
+        let mut buf = [0u8; SIZE];
+        thread_rng().fill(&mut buf[..]);
+        Self(buf, PhantomData)
     }
 
-    pub const FAKE: Self = Self([0; 16]);
+    pub fn new(buf: [u8; SIZE]) -> Self {
+        Self(buf, PhantomData)
+    }
+
+    pub const FAKE: Self = Self([0; SIZE], PhantomData);
 }
 
-impl fmt::Debug for ObjectId {
+impl<const SIZE: usize, T> fmt::Debug for ObjectId<SIZE, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:02x}", self.0.iter().format(""))
     }
 }
 
-impl TryFrom<&[u8]> for ObjectId {
+impl<const SIZE: usize, T> TryFrom<&[u8]> for ObjectId<SIZE, T> {
     type Error = &'static str;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let buf = value.try_into();
-        buf.map(ObjectId).map_err(|_| "Invalid ObjectId buffer length")
+        buf.map(|buf| ObjectId(buf, PhantomData))
+            .map_err(|_| "Invalid ObjectId buffer length")
     }
 }
 
-impl TryFrom<&str> for ObjectId {
+impl<const SIZE: usize, T> TryFrom<&str> for ObjectId<SIZE, T> {
     type Error = &'static str;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
@@ -59,26 +92,26 @@ impl TryFrom<&str> for ObjectId {
     }
 }
 
-impl From<&ObjectId> for String {
-    fn from(value: &ObjectId) -> Self {
+impl<const SIZE: usize, T> From<&ObjectId<SIZE, T>> for String {
+    fn from(value: &ObjectId<SIZE, T>) -> Self {
         base32::encode(base32::Alphabet::Crockford, &value.0)
     }
 }
 
-impl Display for ObjectId {
+impl<const SIZE: usize, T> Display for ObjectId<SIZE, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", String::from(self))
     }
 }
 
-impl Serialize for ObjectId {
+impl<const SIZE: usize, T> Serialize for ObjectId<SIZE, T> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // Just use the string representation
         serializer.serialize_str(&String::from(self))
     }
 }
 
-impl<'de> Deserialize<'de> for ObjectId {
+impl<'de, const SIZE: usize, T> Deserialize<'de> for ObjectId<SIZE, T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         // Because we implement TryFrom<&str> for ObjectId, we can use it here instead of
         // having to implement a custom deserializer
@@ -196,16 +229,13 @@ mod tests {
 
     #[test]
     fn test_object_id_serialization() {
-        let sid = ObjectId([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        let sid = SnapshotId::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        assert_eq!(serde_json::to_string(&sid).unwrap(), r#""000G40R40M30E209185G""#);
+        assert_eq!(String::from(&sid), "000G40R40M30E209185G");
+        assert_eq!(sid, SnapshotId::try_from("000G40R40M30E209185G").unwrap());
+        let sid = SnapshotId::random();
         assert_eq!(
-            serde_json::to_string(&sid).unwrap(),
-            r#""000G40R40M30E209185GR38E1W""#
-        );
-        assert_eq!(String::from(&sid), "000G40R40M30E209185GR38E1W");
-        assert_eq!(sid, ObjectId::try_from("000G40R40M30E209185GR38E1W").unwrap());
-        let sid = ObjectId::random();
-        assert_eq!(
-            serde_json::from_slice::<ObjectId>(
+            serde_json::from_slice::<SnapshotId>(
                 serde_json::to_vec(&sid).unwrap().as_slice()
             )
             .unwrap(),

--- a/icechunk/src/format/snapshot.rs
+++ b/icechunk/src/format/snapshot.rs
@@ -14,13 +14,13 @@ use crate::metadata::{
 };
 
 use super::{
-    manifest::ManifestRef, Flags, IcechunkFormatError, IcechunkResult, NodeId, ObjectId,
-    Path, TableOffset,
+    manifest::ManifestRef, AttributesId, Flags, IcechunkFormatError, IcechunkResult,
+    NodeId, ObjectId, Path, SnapshotId, TableOffset,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UserAttributesRef {
-    pub object_id: ObjectId,
+    pub object_id: AttributesId,
     pub location: TableOffset,
     pub flags: Flags,
 }
@@ -74,7 +74,7 @@ impl NodeSnapshot {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotMetadata {
-    pub id: ObjectId,
+    pub id: SnapshotId,
     pub written_at: DateTime<Utc>,
     pub message: String,
 }

--- a/icechunk/src/storage/mod.rs
+++ b/icechunk/src/storage/mod.rs
@@ -18,14 +18,12 @@ pub use caching::MemCachingStorage;
 pub use object_store::ObjectStorage;
 
 use crate::format::{
-    attributes::AttributesTable, manifest::Manifest, snapshot::Snapshot, ByteRange,
-    ObjectId, Path,
+    attributes::AttributesTable, manifest::Manifest, snapshot::Snapshot, AttributesId,
+    ByteRange, ChunkId, ManifestId, Path, SnapshotId,
 };
 
 #[derive(Debug, Error)]
 pub enum StorageError {
-    #[error("object not found `{0:?}`")]
-    NotFound(ObjectId),
     #[error("error contacting object store {0}")]
     ObjectStore(#[from] ::object_store::Error),
     #[error("messagepack decode error: {0}")]
@@ -52,31 +50,30 @@ type StorageResult<A> = Result<A, StorageError>;
 /// Implementations are free to assume files are never overwritten.
 #[async_trait]
 pub trait Storage: fmt::Debug {
-    async fn fetch_snapshot(&self, id: &ObjectId) -> StorageResult<Arc<Snapshot>>;
+    async fn fetch_snapshot(&self, id: &SnapshotId) -> StorageResult<Arc<Snapshot>>;
     async fn fetch_attributes(
         &self,
-        id: &ObjectId,
+        id: &AttributesId,
     ) -> StorageResult<Arc<AttributesTable>>; // FIXME: format flags
-    async fn fetch_manifests(&self, id: &ObjectId) -> StorageResult<Arc<Manifest>>; // FIXME: format flags
-    async fn fetch_chunk(&self, id: &ObjectId, range: &ByteRange)
-        -> StorageResult<Bytes>; // FIXME: format flags
+    async fn fetch_manifests(&self, id: &ManifestId) -> StorageResult<Arc<Manifest>>; // FIXME: format flags
+    async fn fetch_chunk(&self, id: &ChunkId, range: &ByteRange) -> StorageResult<Bytes>; // FIXME: format flags
 
     async fn write_snapshot(
         &self,
-        id: ObjectId,
+        id: SnapshotId,
         table: Arc<Snapshot>,
     ) -> StorageResult<()>;
     async fn write_attributes(
         &self,
-        id: ObjectId,
+        id: AttributesId,
         table: Arc<AttributesTable>,
     ) -> StorageResult<()>;
     async fn write_manifests(
         &self,
-        id: ObjectId,
+        id: ManifestId,
         table: Arc<Manifest>,
     ) -> StorageResult<()>;
-    async fn write_chunk(&self, id: ObjectId, bytes: Bytes) -> StorageResult<()>;
+    async fn write_chunk(&self, id: ChunkId, bytes: Bytes) -> StorageResult<()>;
 
     async fn get_ref(&self, ref_key: &str) -> StorageResult<Bytes>;
     async fn ref_names(&self) -> StorageResult<Vec<String>>;

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -4,12 +4,12 @@ mod tests {
     use icechunk::{
         format::{
             manifest::{VirtualChunkLocation, VirtualChunkRef},
-            ByteRange, ChunkIndices,
+            ByteRange, ChunkId, ChunkIndices,
         },
         metadata::{ChunkKeyEncoding, ChunkShape, DataType, FillValue},
         repository::{get_chunk, ChunkPayload, ZarrArrayMetadata},
         storage::{object_store::S3Credentials, ObjectStorage},
-        zarr::{AccessMode, ObjectId},
+        zarr::AccessMode,
         Repository, Storage, Store,
     };
     use std::sync::Arc;
@@ -23,7 +23,7 @@ mod tests {
         let storage: Arc<dyn Storage + Send + Sync> = Arc::new(
             ObjectStorage::new_s3_store(
                 "testbucket".to_string(),
-                format!("{:?}", ObjectId::random()),
+                format!("{:?}", ChunkId::random()),
                 Some(S3Credentials {
                     access_key_id: "minio123".into(),
                     secret_access_key: "minio123".into(),


### PR DESCRIPTION
This helps avoiding bugs, the type of bug I did implementing the caching storage.

Also in this PR, moving from 16 to 12 bytes to represent (all) object ids.