### PR TITLE
Better `Path` type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "test-strategy",
  "thiserror",
  "tokio",
+ "typed-path",
  "url",
 ]
 
@@ -2412,6 +2413,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c0c7479c430935701ff2532e3091e6680ec03f2f89ffcd9988b08e885b90a5"
 
 [[package]]
 name = "typenum"

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -31,6 +31,7 @@ rmpv = { version = "1.3.0", features = ["serde", "with-serde"] }
 aws-sdk-s3 = "1.53.0"
 aws-config = "1.5.7"
 aws-credential-types = "1.2.1"
+typed-path = "0.9.2"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/icechunk/examples/low_level_dataset.rs
+++ b/icechunk/examples/low_level_dataset.rs
@@ -49,9 +49,9 @@ ds.add_group("/group2".into()).await?;
 "#,
     );
 
-    ds.add_group("/".into()).await?;
-    ds.add_group("/group1".into()).await?;
-    ds.add_group("/group2".into()).await?;
+    ds.add_group(Path::root()).await?;
+    ds.add_group("/group1".try_into().unwrap()).await?;
+    ds.add_group("/group2".try_into().unwrap()).await?;
 
     println!();
     print_nodes(&ds).await?;
@@ -129,7 +129,7 @@ ds.add_array(array1_path.clone(), zarr_meta1).await?;
             Some("t".to_string()),
         ]),
     };
-    let array1_path: Path = "/group1/array1".into();
+    let array1_path: Path = "/group1/array1".try_into().unwrap();
     ds.add_array(array1_path.clone(), zarr_meta1).await?;
     println!();
     print_nodes(&ds).await?;
@@ -292,7 +292,7 @@ async fn print_nodes(ds: &Repository) -> Result<(), StoreError> {
             format!(
                 "|{:10?}|{:15}|{:10?}\n",
                 node.node_type(),
-                node.path.to_str().unwrap(),
+                node.path.to_string(),
                 node.user_attributes,
             )
         })

--- a/icechunk/src/change_set.rs
+++ b/icechunk/src/change_set.rs
@@ -2,7 +2,6 @@ use std::{
     collections::{HashMap, HashSet},
     iter,
     mem::take,
-    path::Path as StdPath,
 };
 
 use itertools::Either;
@@ -117,10 +116,10 @@ impl ChangeSet {
         }
     }
 
-    pub fn is_deleted(&self, path: &StdPath) -> bool {
+    pub fn is_deleted(&self, path: &Path) -> bool {
         self.deleted_groups.contains(path)
             || self.deleted_arrays.contains(path)
-            || path.ancestors().skip(1).any(|parent| self.is_deleted(parent))
+            || path.ancestors().skip(1).any(|parent| self.is_deleted(&parent))
     }
 
     pub fn has_updated_attributes(&self, node_id: &NodeId) -> bool {

--- a/icechunk/src/format/snapshot.rs
+++ b/icechunk/src/format/snapshot.rs
@@ -313,25 +313,25 @@ mod tests {
         let oid = ObjectId::random();
         let nodes = vec![
             NodeSnapshot {
-                path: "/".into(),
+                path: Path::root(),
                 id: 1,
                 user_attributes: None,
                 node_data: NodeData::Group,
             },
             NodeSnapshot {
-                path: "/a".into(),
+                path: "/a".try_into().unwrap(),
                 id: 2,
                 user_attributes: None,
                 node_data: NodeData::Group,
             },
             NodeSnapshot {
-                path: "/b".into(),
+                path: "/b".try_into().unwrap(),
                 id: 3,
                 user_attributes: None,
                 node_data: NodeData::Group,
             },
             NodeSnapshot {
-                path: "/b/c".into(),
+                path: "/b/c".try_into().unwrap(),
                 id: 4,
                 user_attributes: Some(UserAttributesSnapshot::Inline(
                     UserAttributes::try_new(br#"{"foo": "some inline"}"#).unwrap(),
@@ -339,7 +339,7 @@ mod tests {
                 node_data: NodeData::Group,
             },
             NodeSnapshot {
-                path: "/b/array1".into(),
+                path: "/b/array1".try_into().unwrap(),
                 id: 5,
                 user_attributes: Some(UserAttributesSnapshot::Ref(UserAttributesRef {
                     object_id: oid.clone(),
@@ -351,13 +351,13 @@ mod tests {
                 ),
             },
             NodeSnapshot {
-                path: "/array2".into(),
+                path: "/array2".try_into().unwrap(),
                 id: 6,
                 user_attributes: None,
                 node_data: NodeData::Array(zarr_meta2.clone(), vec![]),
             },
             NodeSnapshot {
-                path: "/b/array3".into(),
+                path: "/b/array3".try_into().unwrap(),
                 id: 7,
                 user_attributes: None,
                 node_data: NodeData::Array(zarr_meta3.clone(), vec![]),
@@ -377,15 +377,17 @@ mod tests {
         let st = Snapshot::from_iter(&initial, None, manifests, vec![], nodes);
 
         assert_eq!(
-            st.get_node(&"/nonexistent".into()),
-            Err(IcechunkFormatError::NodeNotFound { path: "/nonexistent".into() })
+            st.get_node(&"/nonexistent".try_into().unwrap()),
+            Err(IcechunkFormatError::NodeNotFound {
+                path: "/nonexistent".try_into().unwrap()
+            })
         );
 
-        let node = st.get_node(&"/b/c".into());
+        let node = st.get_node(&"/b/c".try_into().unwrap());
         assert_eq!(
             node,
             Ok(&NodeSnapshot {
-                path: "/b/c".into(),
+                path: "/b/c".try_into().unwrap(),
                 id: 4,
                 user_attributes: Some(UserAttributesSnapshot::Inline(
                     UserAttributes::try_new(br#"{"foo": "some inline"}"#).unwrap(),
@@ -393,21 +395,21 @@ mod tests {
                 node_data: NodeData::Group,
             }),
         );
-        let node = st.get_node(&"/".into());
+        let node = st.get_node(&Path::root());
         assert_eq!(
             node,
             Ok(&NodeSnapshot {
-                path: "/".into(),
+                path: Path::root(),
                 id: 1,
                 user_attributes: None,
                 node_data: NodeData::Group,
             }),
         );
-        let node = st.get_node(&"/b/array1".into());
+        let node = st.get_node(&"/b/array1".try_into().unwrap());
         assert_eq!(
             node,
             Ok(&NodeSnapshot {
-                path: "/b/array1".into(),
+                path: "/b/array1".try_into().unwrap(),
                 id: 5,
                 user_attributes: Some(UserAttributesSnapshot::Ref(UserAttributesRef {
                     object_id: oid,
@@ -416,21 +418,21 @@ mod tests {
                 node_data: NodeData::Array(zarr_meta1.clone(), vec![man_ref1, man_ref2]),
             }),
         );
-        let node = st.get_node(&"/array2".into());
+        let node = st.get_node(&"/array2".try_into().unwrap());
         assert_eq!(
             node,
             Ok(&NodeSnapshot {
-                path: "/array2".into(),
+                path: "/array2".try_into().unwrap(),
                 id: 6,
                 user_attributes: None,
                 node_data: NodeData::Array(zarr_meta2.clone(), vec![]),
             }),
         );
-        let node = st.get_node(&"/b/array3".into());
+        let node = st.get_node(&"/b/array3".try_into().unwrap());
         assert_eq!(
             node,
             Ok(&NodeSnapshot {
-                path: "/b/array3".into(),
+                path: "/b/array3".try_into().unwrap(),
                 id: 7,
                 user_attributes: None,
                 node_data: NodeData::Array(zarr_meta3.clone(), vec![]),

--- a/icechunk/src/strategies.rs
+++ b/icechunk/src/strategies.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
-use std::path::PathBuf;
 use std::sync::Arc;
 
+use prop::string::string_regex;
 use proptest::prelude::*;
 use proptest::{collection::vec, option, strategy::Strategy};
 
@@ -15,7 +15,10 @@ use crate::{ObjectStorage, Repository};
 
 pub fn node_paths() -> impl Strategy<Value = Path> {
     // FIXME: Add valid paths
-    any::<PathBuf>()
+    #[allow(clippy::expect_used)]
+    vec(string_regex("[a-zA-Z0-9]*").expect("invalid regex"), 0..10).prop_map(|v| {
+        format!("/{}", v.join("/")).try_into().expect("invalid Path string")
+    })
 }
 
 prop_compose! {

--- a/icechunk/tests/test_distributed_writes.rs
+++ b/icechunk/tests/test_distributed_writes.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 use pretty_assertions::assert_eq;
 use std::{num::NonZeroU64, ops::Range, sync::Arc};
 
@@ -66,14 +67,17 @@ async fn write_chunks(
                 .collect();
             let payload =
                 repo.get_chunk_writer()(Bytes::copy_from_slice(bytes.as_slice())).await?;
-            repo.set_chunk_ref("/array".into(), ChunkIndices(vec![x, y]), Some(payload))
-                .await?;
+            repo.set_chunk_ref(
+                "/array".try_into().unwrap(),
+                ChunkIndices(vec![x, y]),
+                Some(payload),
+            )
+            .await?;
         }
     }
     Ok(repo)
 }
 
-#[allow(clippy::unwrap_used)]
 async fn verify(
     repo: Repository,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -81,7 +85,7 @@ async fn verify(
         for y in 0..(SIZE / 2) as u32 {
             let bytes = get_chunk(
                 repo.get_chunk_reader(
-                    &"/array".into(),
+                    &"/array".try_into().unwrap(),
                     &ChunkIndices(vec![x, y]),
                     &ByteRange::ALL,
                 )
@@ -132,7 +136,7 @@ async fn test_distributed_writes() -> Result<(), Box<dyn std::error::Error + Sen
         dimension_names: None,
     };
 
-    let new_array_path: Path = "/array".to_string().into();
+    let new_array_path: Path = "/array".try_into().unwrap();
     repo1.add_array(new_array_path.clone(), zarr_meta.clone()).await?;
     repo1.commit("main", "create array", None).await?;
 

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -4,7 +4,7 @@ mod tests {
     use icechunk::{
         format::{
             manifest::{VirtualChunkLocation, VirtualChunkRef},
-            ByteRange, ChunkId, ChunkIndices,
+            ByteRange, ChunkId, ChunkIndices, Path,
         },
         metadata::{ChunkKeyEncoding, ChunkShape, DataType, FillValue},
         repository::{get_chunk, ChunkPayload, ZarrArrayMetadata},
@@ -16,8 +16,8 @@ mod tests {
         zarr::AccessMode,
         Repository, Storage, Store,
     };
-    use std::{error::Error, num::NonZeroU64, path::PathBuf};
-    use std::{path::Path, sync::Arc};
+    use std::{error::Error, num::NonZeroU64};
+    use std::{path::Path as StdPath, sync::Arc};
     use tempfile::TempDir;
 
     use bytes::Bytes;
@@ -67,7 +67,7 @@ mod tests {
                 .expect(&format!("putting chunk to {} failed", &path));
         }
     }
-    async fn create_local_repository(path: &Path) -> Repository {
+    async fn create_local_repository(path: &StdPath) -> Repository {
         let storage: Arc<dyn Storage + Send + Sync> = Arc::new(
             ObjectStorage::new_local_store(path).expect("Creating local storage failed"),
         );
@@ -153,7 +153,7 @@ mod tests {
             length: 5,
         });
 
-        let new_array_path: PathBuf = "/array".to_string().into();
+        let new_array_path: Path = "/array".try_into().unwrap();
         ds.add_array(new_array_path.clone(), zarr_meta.clone()).await.unwrap();
 
         ds.set_chunk_ref(
@@ -263,7 +263,7 @@ mod tests {
             length: 5,
         });
 
-        let new_array_path: PathBuf = "/array".to_string().into();
+        let new_array_path: Path = "/array".try_into().unwrap();
         ds.add_array(new_array_path.clone(), zarr_meta.clone()).await.unwrap();
 
         ds.set_chunk_ref(


### PR DESCRIPTION
We were using `PathBuf`, which has platform dependent behavior. Now we use a platform independent type, and verify correctness using a smart constructor.

Closes #149 