### PR TITLE
Add python version to package exports

### DIFF
--- a/icechunk-python/python/icechunk/__init__.py
+++ b/icechunk-python/python/icechunk/__init__.py
@@ -8,6 +8,7 @@ from zarr.core.common import AccessModeLiteral, BytesLike
 from zarr.core.sync import SyncMixin
 
 from ._icechunk_python import (
+    __version__,
     PyIcechunkStore,
     S3Credentials,
     SnapshotMetadata,
@@ -21,6 +22,7 @@ from ._icechunk_python import (
 )
 
 __all__ = [
+    "__version__",
     "IcechunkStore",
     "StorageConfig",
     "S3Credentials",

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -235,3 +235,5 @@ async def pyicechunk_store_open_existing(
 def pyicechunk_store_from_bytes(
     bytes: bytes, read_only: bool
 ) -> PyIcechunkStore: ...
+
+__version__: str

--- a/icechunk-python/src/lib.rs
+++ b/icechunk-python/src/lib.rs
@@ -753,6 +753,7 @@ impl PyIcechunkStore {
 /// The icechunk Python module implemented in Rust.
 #[pymodule]
 fn _icechunk_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PyStorageConfig>()?;
     m.add_class::<PyIcechunkStore>()?;
     m.add_class::<PyS3Credentials>()?;


### PR DESCRIPTION
Close #157

The key thing to know here is that the version of the python package must match the version of the rust pyo3/maturin crate, so we forward from there as the source of truth instead of a pyproject plugin