### PR TITLE
Use absolute URL for logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Icechunk
 
-![Icechunk logo](docs/docs/assets/logo.svg)
+![Icechunk logo](https://github.com/earth-mover/icechunk/blob/main/docs/docs/assets/logo.svg)
 
 Icechunk is a transactional storage engine for Zarr designed for use on cloud object storage.
 <!--home-start-->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Icechunk
 
-![Icechunk logo](https://github.com/earth-mover/icechunk/blob/main/docs/docs/assets/logo.svg)
+![Icechunk logo](https://raw.githubusercontent.com/earth-mover/icechunk/refs/heads/main/docs/docs/assets/logo.svg)
 
 Icechunk is a transactional storage engine for Zarr designed for use on cloud object storage.
 <!--home-start-->


### PR DESCRIPTION
This will help our page on PyPI (and Crates?) find the logo asset.