### PR TITLE
Update python ci

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -6,10 +6,6 @@
 name: Python CI
 
 on:
-  release:
-    types:
-      # published triggers for both releases and prereleases
-      - published
   workflow_dispatch:
   schedule:
     # run every day at 4am
@@ -181,14 +177,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
* Removes pypi token to force using openid connect
* Triggers release only on wrokflow dispatch now 