### PR TITLE
Fix non-conformant "attributes" metadata

### DIFF
--- a/icechunk-python/tests/test_zarr/test_store/test_icechunk_store.py
+++ b/icechunk-python/tests/test_zarr/test_store/test_icechunk_store.py
@@ -10,7 +10,7 @@ from zarr.core.common import AccessModeLiteral
 from zarr.core.sync import collect_aiterator
 from zarr.testing.store import StoreTests
 
-DEFAULT_GROUP_METADATA = b'{"zarr_format":3,"node_type":"group","attributes":null}'
+DEFAULT_GROUP_METADATA = b'{"zarr_format":3,"node_type":"group"}'
 ARRAY_METADATA = (
     b'{"zarr_format":3,"node_type":"array","attributes":{"foo":42},'
     b'"shape":[2,2,2],"data_type":"int32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1,1,1]}},'

--- a/icechunk/src/zarr.rs
+++ b/icechunk/src/zarr.rs
@@ -1143,6 +1143,7 @@ struct ArrayMetadata {
     zarr_format: u8,
     #[serde(deserialize_with = "validate_array_node_type")]
     node_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     attributes: Option<UserAttributes>,
     #[serde(flatten)]
     #[serde_as(as = "TryFromInto<ZarrArrayMetadataSerialzer>")]
@@ -1283,6 +1284,7 @@ struct GroupMetadata {
     zarr_format: u8,
     #[serde(deserialize_with = "validate_group_node_type")]
     node_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     attributes: Option<UserAttributes>,
 }
 
@@ -1727,7 +1729,7 @@ mod tests {
         assert_eq!(
             store.get("zarr.json", &ByteRange::ALL).await.unwrap(),
             Bytes::copy_from_slice(
-                br#"{"zarr_format":3,"node_type":"group","attributes":null}"#
+                br#"{"zarr_format":3,"node_type":"group"}"#
             )
         );
 

--- a/icechunk/src/zarr.rs
+++ b/icechunk/src/zarr.rs
@@ -1728,9 +1728,7 @@ mod tests {
             .await?;
         assert_eq!(
             store.get("zarr.json", &ByteRange::ALL).await.unwrap(),
-            Bytes::copy_from_slice(
-                br#"{"zarr_format":3,"node_type":"group"}"#
-            )
+            Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"group"}"#)
         );
 
         store.set("a/b/zarr.json", Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group", "attributes": {"spam":"ham", "eggs":42}}"#)).await?;


### PR DESCRIPTION
I believe `"attributes": null` in array/group metadata is not conformant to the Zarr V3 specification. If empty, it must be omitted entirely or be `"attributes": {}`.

https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#attributes

> The following members are optional:
>
> `attributes`
> The value must be an object. The object may contain any key/value pairs, where the key must be a string and the value can be an arbitrary JSON literal. Intended to allow storage of arbitrary user metadata.