### PR TITLE
Update to pyo3 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,12 +1021,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1615,16 +1609,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
 dependencies = [
  "cfg-if",
  "chrono",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1634,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe0b015461c5136532f42908d6bf4b079da1aedfbffa8b0b5d4cbc59c2fdf8"
+checksum = "2529f0be73ffd2be0cc43c013a640796558aa12d7ca0aab5cc14f375b4733031"
 dependencies = [
  "futures",
  "once_cell",
@@ -1647,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1657,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1667,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1679,11 +1673,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -2145,7 +2139,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -22,12 +22,12 @@ bytes = "1.7.2"
 chrono = { version = "0.4.38" }
 futures = "0.3.30"
 icechunk = { path = "../icechunk", version = "0.1.0-alpha.4" }
-pyo3 = { version = "0.21", features = [
+pyo3 = { version = "0.22", features = [
   "chrono",
   "extension-module",
   "experimental-async",
 ] }
-pyo3-async-runtimes = { version = "0.21.0", features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.22.0", features = ["tokio-runtime"] }
 async-stream = "0.3.5"
 thiserror = "1.0.64"
 tokio = "1.40"

--- a/icechunk-python/src/errors.rs
+++ b/icechunk-python/src/errors.rs
@@ -14,13 +14,18 @@ use thiserror::Error;
 /// the errors where this is returned from a python class
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
+#[allow(dead_code)]
 pub(crate) enum PyIcechunkStoreError {
+    #[error("key not found error: {0}")]
+    KeyNotFound(String),
     #[error("store error: {0}")]
     StoreError(#[from] StoreError),
     #[error("repository Error: {0}")]
     RepositoryError(#[from] RepositoryError),
     #[error("icechunk format error: {0}")]
     IcechunkFormatError(#[from] IcechunkFormatError),
+    #[error("value error: {0}")]
+    PyValueError(String),
     #[error("error: {0}")]
     PyError(#[from] PyErr),
     #[error("{0}")]
@@ -30,6 +35,9 @@ pub(crate) enum PyIcechunkStoreError {
 impl From<PyIcechunkStoreError> for PyErr {
     fn from(error: PyIcechunkStoreError) -> Self {
         match error {
+            PyIcechunkStoreError::KeyNotFound(_) => {
+                KeyNotFound::new_err(error.to_string())
+            }
             PyIcechunkStoreError::PyError(err) => err,
             _ => PyValueError::new_err(error.to_string()),
         }

--- a/icechunk-python/src/errors.rs
+++ b/icechunk-python/src/errors.rs
@@ -15,16 +15,12 @@ use thiserror::Error;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
 pub(crate) enum PyIcechunkStoreError {
-    #[error("key not found error: {0}")]
-    KeyNotFound(#[from] KeyNotFound),
     #[error("store error: {0}")]
     StoreError(#[from] StoreError),
     #[error("repository Error: {0}")]
     RepositoryError(#[from] RepositoryError),
     #[error("icechunk format error: {0}")]
     IcechunkFormatError(#[from] IcechunkFormatError),
-    #[error("value error: {0}")]
-    PyValueError(#[from] PyValueError),
     #[error("error: {0}")]
     PyError(#[from] PyErr),
     #[error("{0}")]
@@ -33,7 +29,10 @@ pub(crate) enum PyIcechunkStoreError {
 
 impl From<PyIcechunkStoreError> for PyErr {
     fn from(error: PyIcechunkStoreError) -> Self {
-        PyValueError::new_err(error.to_string())
+        match error {
+            PyIcechunkStoreError::PyError(err) => err,
+            _ => PyValueError::new_err(error.to_string()),
+        }
     }
 }
 

--- a/icechunk-python/src/lib.rs
+++ b/icechunk-python/src/lib.rs
@@ -83,6 +83,12 @@ impl From<&PyStoreConfig> for StoreOptions {
 #[pymethods]
 impl PyStoreConfig {
     #[new]
+    #[pyo3(signature = (
+        get_partial_values_concurrency = None,
+        inline_chunk_threshold_bytes = None,
+        unsafe_overwrite_refs = None,
+        virtual_ref_config = None,
+    ))]
     fn new(
         get_partial_values_concurrency: Option<u16>,
         inline_chunk_threshold_bytes: Option<u16>,
@@ -656,6 +662,7 @@ impl PyIcechunkStore {
         })
     }
 
+    #[pyo3(signature = (key, byte_range = None))]
     fn get<'py>(
         &'py self,
         py: Python<'py>,

--- a/icechunk-python/src/storage.rs
+++ b/icechunk-python/src/storage.rs
@@ -36,6 +36,11 @@ impl From<&PyS3Credentials> for StaticS3Credentials {
 #[pymethods]
 impl PyS3Credentials {
     #[new]
+    #[pyo3(signature = (
+        access_key_id,
+        secret_access_key,
+        session_token = None,
+    ))]
     fn new(
         access_key_id: String,
         secret_access_key: String,
@@ -67,6 +72,7 @@ pub enum PyStorageConfig {
 #[pymethods]
 impl PyStorageConfig {
     #[classmethod]
+    #[pyo3(signature = (prefix = None))]
     fn memory(_cls: &Bound<'_, PyType>, prefix: Option<String>) -> Self {
         PyStorageConfig::Memory { prefix }
     }
@@ -77,6 +83,13 @@ impl PyStorageConfig {
     }
 
     #[classmethod]
+    #[pyo3(signature = (
+        bucket,
+        prefix,
+        endpoint_url = None,
+        allow_http = None,
+        region = None,
+    ))]
     fn s3_from_env(
         _cls: &Bound<'_, PyType>,
         bucket: String,
@@ -97,6 +110,14 @@ impl PyStorageConfig {
     }
 
     #[classmethod]
+    #[pyo3(signature = (
+        bucket,
+        prefix,
+        credentials,
+        endpoint_url = None,
+        allow_http = None,
+        region = None,
+    ))]
     fn s3_from_config(
         _cls: &Bound<'_, PyType>,
         bucket: String,
@@ -118,6 +139,13 @@ impl PyStorageConfig {
     }
 
     #[classmethod]
+    #[pyo3(signature = (
+        bucket,
+        prefix,
+        endpoint_url = None,
+        allow_http = None,
+        region = None,
+    ))]
     fn s3_anonymous(
         _cls: &Bound<'_, PyType>,
         bucket: String,
@@ -210,6 +238,13 @@ impl PyVirtualRefConfig {
     }
 
     #[classmethod]
+    #[pyo3(signature = (
+        credentials,
+        endpoint_url = None,
+        allow_http = None,
+        region = None,
+        anon = None,
+    ))]
     fn s3_from_config(
         _cls: &Bound<'_, PyType>,
         credentials: PyS3Credentials,
@@ -228,6 +263,11 @@ impl PyVirtualRefConfig {
     }
 
     #[classmethod]
+    #[pyo3(signature = (
+        endpoint_url = None,
+        allow_http = None,
+        region = None,
+    ))]
     fn s3_anonymous(
         _cls: &Bound<'_, PyType>,
         endpoint_url: Option<String>,


### PR DESCRIPTION
For https://github.com/earth-mover/icechunk/issues/266.

### Change list 

- Updates to `pyo3` 0.22 and `pyo3-async-runtimes` 0.22.
- pyo3 0.22 deprecated the default behavior of `Option<T>` defaulting to `None`, so now you have to explicitly specify this in `pyo3(signature)`
- Upgrading to `pyo3` 0.22 broke the `PyIcechunkStoreError` enum because the pyerr's don't implement `Debug`. An alternative way to fix this is to just remove the `derive(Debug)`, but I'd suggest storing _Rust error types_ in your Rust error enum, and then converting to `PyErr` as needed in the `From` impl.