### PR TITLE
Rust Icechunk learns how to collect garbage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-types-convert"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f280f434214856abace637b1f944d50ccca216814813acd195cdd7f206ce17f"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "chrono",
+ "futures-core",
+]
+
+[[package]]
 name = "aws-smithy-xml"
 version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1205,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-types-convert",
  "base32",
  "base64 0.22.1",
  "bytes",

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -39,6 +39,7 @@ aws-sdk-s3 = "1.53.0"
 aws-config = "1.5.7"
 aws-credential-types = "1.2.1"
 typed-path = "0.9.2"
+aws-smithy-types-convert = { version = "0.60.8", features = ["convert-chrono", "convert-streams"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/icechunk/src/lib.rs
+++ b/icechunk/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod change_set;
 pub mod format;
 pub mod metadata;
+pub mod ops;
 pub mod refs;
 pub mod repository;
 pub mod storage;

--- a/icechunk/src/ops/gc.rs
+++ b/icechunk/src/ops/gc.rs
@@ -1,0 +1,296 @@
+use std::{collections::HashSet, future::ready, iter};
+
+use chrono::{DateTime, Utc};
+use futures::{stream, Stream, StreamExt, TryStreamExt};
+use tokio::pin;
+
+use crate::{
+    format::{ChunkId, ManifestId, SnapshotId},
+    refs::{list_refs, RefError},
+    repository::ChunkPayload,
+    storage::ListInfo,
+    Storage, StorageError,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Action {
+    Keep,
+    DeleteIfCreatedBefore(DateTime<Utc>),
+}
+
+#[derive(Debug)]
+pub struct GCConfig {
+    extra_roots: HashSet<SnapshotId>,
+    dangling_chunks: Action,
+    dangling_manifests: Action,
+    dangling_attributes: Action,
+    dangling_transaction_logs: Action,
+    dangling_snapshots: Action,
+}
+
+impl GCConfig {
+    pub fn new(
+        extra_roots: HashSet<SnapshotId>,
+        dangling_chunks: Action,
+        dangling_manifests: Action,
+        dangling_attributes: Action,
+        dangling_transaction_logs: Action,
+        dangling_snapshots: Action,
+    ) -> Self {
+        GCConfig {
+            extra_roots,
+            dangling_chunks,
+            dangling_manifests,
+            dangling_attributes,
+            dangling_transaction_logs,
+            dangling_snapshots,
+        }
+    }
+    pub fn clean_all(
+        chunks_age: DateTime<Utc>,
+        metadata_age: DateTime<Utc>,
+        extra_roots: Option<HashSet<SnapshotId>>,
+    ) -> Self {
+        use Action::DeleteIfCreatedBefore as D;
+        Self::new(
+            extra_roots.unwrap_or_default(),
+            D(chunks_age),
+            D(metadata_age),
+            D(metadata_age),
+            D(metadata_age),
+            D(metadata_age),
+        )
+    }
+
+    fn action_needed(&self) -> bool {
+        [
+            &self.dangling_chunks,
+            &self.dangling_manifests,
+            &self.dangling_attributes,
+            &self.dangling_transaction_logs,
+            &self.dangling_snapshots,
+        ]
+        .into_iter()
+        .any(|action| action != &Action::Keep)
+    }
+
+    pub fn deletes_chunks(&self) -> bool {
+        self.dangling_chunks != Action::Keep
+    }
+
+    pub fn deletes_manifests(&self) -> bool {
+        self.dangling_manifests != Action::Keep
+    }
+
+    pub fn deletes_attributes(&self) -> bool {
+        self.dangling_attributes != Action::Keep
+    }
+
+    pub fn deletes_transaction_logs(&self) -> bool {
+        self.dangling_transaction_logs != Action::Keep
+    }
+
+    pub fn deletes_snapshots(&self) -> bool {
+        self.dangling_snapshots != Action::Keep
+    }
+
+    fn must_delete_chunk(&self, chunk: &ListInfo<ChunkId>) -> bool {
+        match self.dangling_chunks {
+            Action::DeleteIfCreatedBefore(before) => chunk.created_at < before,
+            _ => false,
+        }
+    }
+
+    fn must_delete_manifest(&self, manifest: &ListInfo<ManifestId>) -> bool {
+        match self.dangling_manifests {
+            Action::DeleteIfCreatedBefore(before) => manifest.created_at < before,
+            _ => false,
+        }
+    }
+
+    fn must_delete_snapshot(&self, snapshot: &ListInfo<SnapshotId>) -> bool {
+        match self.dangling_snapshots {
+            Action::DeleteIfCreatedBefore(before) => snapshot.created_at < before,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct GCSummary {
+    pub chunks_deleted: usize,
+    pub manifests_deleted: usize,
+    pub snapshots_deleted: usize,
+    pub attributes_deleted: usize,
+    pub transaction_logs_deleted: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GCError {
+    #[error("ref error {0}")]
+    Ref(#[from] RefError),
+    #[error("storage error {0}")]
+    Storage(#[from] StorageError),
+}
+
+pub type GCResult<A> = Result<A, GCError>;
+
+pub async fn garbage_collect(
+    storage: &(dyn Storage + Send + Sync),
+    config: &GCConfig,
+) -> GCResult<GCSummary> {
+    // TODO: this function could have much more parallelism
+    if !config.action_needed() {
+        return Ok(GCSummary::default());
+    }
+
+    let all_snaps = pointed_snapshots(storage, &config.extra_roots).await?;
+
+    // FIXME: add attribute files
+    // FIXME: add transaction log files
+    let mut keep_chunks = HashSet::new();
+    let mut keep_manifests = HashSet::new();
+    let mut keep_snapshots = HashSet::new();
+
+    pin!(all_snaps);
+    while let Some(snap_id) = all_snaps.try_next().await? {
+        let snap = storage.fetch_snapshot(&snap_id).await?;
+        if config.deletes_snapshots() {
+            keep_snapshots.insert(snap_id);
+        }
+
+        if config.deletes_manifests() {
+            keep_manifests.extend(snap.manifest_files.iter().map(|mf| mf.id.clone()));
+        }
+
+        if config.deletes_chunks() {
+            for manifest_file in snap.manifest_files.iter() {
+                let manifest_id = &manifest_file.id;
+                let manifest = storage.fetch_manifests(manifest_id).await?;
+                let chunk_ids =
+                    manifest.chunks().values().filter_map(|payload| match payload {
+                        ChunkPayload::Ref(chunk_ref) => Some(chunk_ref.id.clone()),
+                        _ => None,
+                    });
+                keep_chunks.extend(chunk_ids);
+            }
+        }
+    }
+
+    let mut summary = GCSummary::default();
+
+    if config.deletes_snapshots() {
+        summary.snapshots_deleted = gc_snapshots(storage, config, keep_snapshots).await?;
+    }
+    if config.deletes_manifests() {
+        summary.manifests_deleted = gc_manifests(storage, config, keep_manifests).await?;
+    }
+    if config.deletes_chunks() {
+        summary.chunks_deleted = gc_chunks(storage, config, keep_chunks).await?;
+    }
+
+    Ok(summary)
+}
+
+async fn all_roots<'a>(
+    storage: &'a (dyn Storage + Send + Sync),
+    extra_roots: &'a HashSet<SnapshotId>,
+) -> GCResult<impl Stream<Item = GCResult<SnapshotId>> + 'a> {
+    let all_refs = list_refs(storage).await?;
+    // TODO: this could be optimized by not following the ancestry of snapshots that we have
+    // already seen
+    let roots =
+        stream::iter(all_refs)
+            .then(move |r| async move {
+                r.fetch(storage).await.map(|ref_data| ref_data.snapshot)
+            })
+            .err_into()
+            .chain(stream::iter(extra_roots.iter().cloned()).map(Ok));
+    Ok(roots)
+}
+
+async fn pointed_snapshots<'a>(
+    storage: &'a (dyn Storage + Send + Sync),
+    extra_roots: &'a HashSet<SnapshotId>,
+) -> GCResult<impl Stream<Item = GCResult<SnapshotId>> + 'a> {
+    let roots = all_roots(storage, extra_roots).await?;
+    Ok(roots
+        .and_then(move |snap_id| async move {
+            let snap = storage.fetch_snapshot(&snap_id).await?;
+            // FIXME: this should be global ancestry, not local
+            let parents = snap.local_ancestry().map(|parent| parent.id);
+            Ok(stream::iter(iter::once(snap_id).chain(parents))
+                .map(Ok::<SnapshotId, GCError>))
+        })
+        .try_flatten())
+}
+
+async fn gc_chunks(
+    storage: &(dyn Storage + Send + Sync),
+    config: &GCConfig,
+    keep_ids: HashSet<ChunkId>,
+) -> GCResult<usize> {
+    let to_delete = storage
+        .list_chunks()
+        .await?
+        // TODO: don't skip over errors
+        .filter_map(move |chunk| {
+            ready(chunk.ok().and_then(|chunk| {
+                if config.must_delete_chunk(&chunk) && !keep_ids.contains(&chunk.id) {
+                    Some(chunk.id.clone())
+                } else {
+                    None
+                }
+            }))
+        })
+        .boxed();
+    Ok(storage.delete_chunks(to_delete).await?)
+}
+
+async fn gc_manifests(
+    storage: &(dyn Storage + Send + Sync),
+    config: &GCConfig,
+    keep_ids: HashSet<ManifestId>,
+) -> GCResult<usize> {
+    let to_delete = storage
+        .list_manifests()
+        .await?
+        // TODO: don't skip over errors
+        .filter_map(move |manifest| {
+            ready(manifest.ok().and_then(|manifest| {
+                if config.must_delete_manifest(&manifest)
+                    && !keep_ids.contains(&manifest.id)
+                {
+                    Some(manifest.id.clone())
+                } else {
+                    None
+                }
+            }))
+        })
+        .boxed();
+    Ok(storage.delete_manifests(to_delete).await?)
+}
+
+async fn gc_snapshots(
+    storage: &(dyn Storage + Send + Sync),
+    config: &GCConfig,
+    keep_ids: HashSet<SnapshotId>,
+) -> GCResult<usize> {
+    let to_delete = storage
+        .list_snapshots()
+        .await?
+        // TODO: don't skip over errors
+        .filter_map(move |snapshot| {
+            ready(snapshot.ok().and_then(|snapshot| {
+                if config.must_delete_snapshot(&snapshot)
+                    && !keep_ids.contains(&snapshot.id)
+                {
+                    Some(snapshot.id.clone())
+                } else {
+                    None
+                }
+            }))
+        })
+        .boxed();
+    Ok(storage.delete_snapshots(to_delete).await?)
+}

--- a/icechunk/src/ops/mod.rs
+++ b/icechunk/src/ops/mod.rs
@@ -1,0 +1,1 @@
+pub mod gc;

--- a/icechunk/src/refs.rs
+++ b/icechunk/src/refs.rs
@@ -66,6 +66,16 @@ impl Ref {
             },
         }
     }
+
+    pub async fn fetch(
+        &self,
+        storage: &(dyn Storage + Send + Sync),
+    ) -> RefResult<RefData> {
+        match self {
+            Ref::Tag(name) => fetch_tag(storage, name).await,
+            Ref::Branch(name) => fetch_branch_tip(storage, name).await,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -214,7 +214,7 @@ impl Repository {
             return Err(RepositoryError::AlreadyInitialized);
         }
         let new_snapshot = Snapshot::empty();
-        let new_snapshot_id = ObjectId::random();
+        let new_snapshot_id = new_snapshot.metadata.id.clone();
         storage.write_snapshot(new_snapshot_id.clone(), Arc::new(new_snapshot)).await?;
         update_branch(
             storage.as_ref(),
@@ -314,7 +314,7 @@ impl Repository {
         let parent = self.storage.fetch_snapshot(self.snapshot_id()).await?;
         let last = parent.metadata.clone();
         let it = if parent.short_term_history.len() < parent.total_parents as usize {
-            // TODO: implement splitting of snapshot history
+            // FIXME: implement splitting of snapshot history
             Either::Left(parent.local_ancestry().chain(iter::once_with(|| todo!())))
         } else {
             Either::Right(parent.local_ancestry())

--- a/icechunk/src/storage/caching.rs
+++ b/icechunk/src/storage/caching.rs
@@ -164,40 +164,19 @@ impl Storage for MemCachingStorage {
         self.backend.ref_versions(ref_name).await
     }
 
-    async fn list_chunks(
-        &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>> {
-        self.backend.list_chunks().await
+    async fn list_objects<'a>(
+        &'a self,
+        prefix: &str,
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        self.backend.list_objects(prefix).await
     }
 
-    async fn list_manifests(
+    async fn delete_objects(
         &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>> {
-        self.backend.list_manifests().await
-    }
-
-    async fn list_snapshots(
-        &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>> {
-        self.backend.list_snapshots().await
-    }
-
-    async fn delete_chunks(&self, ids: BoxStream<'_, ChunkId>) -> StorageResult<usize> {
-        self.backend.delete_chunks(ids).await
-    }
-
-    async fn delete_manifests(
-        &self,
-        ids: BoxStream<'_, ManifestId>,
+        prefix: &str,
+        ids: BoxStream<'_, String>,
     ) -> StorageResult<usize> {
-        self.backend.delete_manifests(ids).await
-    }
-
-    async fn delete_snapshots(
-        &self,
-        ids: BoxStream<'_, SnapshotId>,
-    ) -> StorageResult<usize> {
-        self.backend.delete_snapshots(ids).await
+        self.backend.delete_objects(prefix, ids).await
     }
 }
 

--- a/icechunk/src/storage/caching.rs
+++ b/icechunk/src/storage/caching.rs
@@ -13,7 +13,7 @@ use crate::{
     private,
 };
 
-use super::{Storage, StorageError, StorageResult};
+use super::{ListInfo, Storage, StorageError, StorageResult};
 
 #[derive(Debug)]
 pub struct MemCachingStorage {
@@ -162,6 +162,42 @@ impl Storage for MemCachingStorage {
         ref_name: &str,
     ) -> StorageResult<BoxStream<StorageResult<String>>> {
         self.backend.ref_versions(ref_name).await
+    }
+
+    async fn list_chunks(
+        &self,
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>> {
+        self.backend.list_chunks().await
+    }
+
+    async fn list_manifests(
+        &self,
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>> {
+        self.backend.list_manifests().await
+    }
+
+    async fn list_snapshots(
+        &self,
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>> {
+        self.backend.list_snapshots().await
+    }
+
+    async fn delete_chunks(&self, ids: BoxStream<'_, ChunkId>) -> StorageResult<usize> {
+        self.backend.delete_chunks(ids).await
+    }
+
+    async fn delete_manifests(
+        &self,
+        ids: BoxStream<'_, ManifestId>,
+    ) -> StorageResult<usize> {
+        self.backend.delete_manifests(ids).await
+    }
+
+    async fn delete_snapshots(
+        &self,
+        ids: BoxStream<'_, SnapshotId>,
+    ) -> StorageResult<usize> {
+        self.backend.delete_snapshots(ids).await
     }
 }
 

--- a/icechunk/src/storage/logging.rs
+++ b/icechunk/src/storage/logging.rs
@@ -133,39 +133,18 @@ impl Storage for LoggingStorage {
         self.backend.ref_versions(ref_name).await
     }
 
-    async fn list_chunks(
-        &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>> {
-        self.backend.list_chunks().await
+    async fn list_objects<'a>(
+        &'a self,
+        prefix: &str,
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        self.backend.list_objects(prefix).await
     }
 
-    async fn list_manifests(
+    async fn delete_objects(
         &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>> {
-        self.backend.list_manifests().await
-    }
-
-    async fn list_snapshots(
-        &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>> {
-        self.backend.list_snapshots().await
-    }
-
-    async fn delete_chunks(&self, ids: BoxStream<'_, ChunkId>) -> StorageResult<usize> {
-        self.backend.delete_chunks(ids).await
-    }
-
-    async fn delete_manifests(
-        &self,
-        ids: BoxStream<'_, ManifestId>,
+        prefix: &str,
+        ids: BoxStream<'_, String>,
     ) -> StorageResult<usize> {
-        self.backend.delete_manifests(ids).await
-    }
-
-    async fn delete_snapshots(
-        &self,
-        ids: BoxStream<'_, SnapshotId>,
-    ) -> StorageResult<usize> {
-        self.backend.delete_snapshots(ids).await
+        self.backend.delete_objects(prefix, ids).await
     }
 }

--- a/icechunk/src/storage/logging.rs
+++ b/icechunk/src/storage/logging.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 
-use super::{Storage, StorageError, StorageResult};
+use super::{ListInfo, Storage, StorageError, StorageResult};
 use crate::{
     format::{
         attributes::AttributesTable, manifest::Manifest, snapshot::Snapshot,
@@ -131,5 +131,41 @@ impl Storage for LoggingStorage {
         ref_name: &str,
     ) -> StorageResult<BoxStream<StorageResult<String>>> {
         self.backend.ref_versions(ref_name).await
+    }
+
+    async fn list_chunks(
+        &self,
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>> {
+        self.backend.list_chunks().await
+    }
+
+    async fn list_manifests(
+        &self,
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>> {
+        self.backend.list_manifests().await
+    }
+
+    async fn list_snapshots(
+        &self,
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>> {
+        self.backend.list_snapshots().await
+    }
+
+    async fn delete_chunks(&self, ids: BoxStream<'_, ChunkId>) -> StorageResult<usize> {
+        self.backend.delete_chunks(ids).await
+    }
+
+    async fn delete_manifests(
+        &self,
+        ids: BoxStream<'_, ManifestId>,
+    ) -> StorageResult<usize> {
+        self.backend.delete_manifests(ids).await
+    }
+
+    async fn delete_snapshots(
+        &self,
+        ids: BoxStream<'_, SnapshotId>,
+    ) -> StorageResult<usize> {
+        self.backend.delete_snapshots(ids).await
     }
 }

--- a/icechunk/src/storage/mod.rs
+++ b/icechunk/src/storage/mod.rs
@@ -9,7 +9,7 @@ use aws_sdk_s3::{
 };
 use chrono::{DateTime, Utc};
 use core::fmt;
-use futures::stream::BoxStream;
+use futures::{stream::BoxStream, Stream, StreamExt, TryStreamExt};
 use std::{ffi::OsString, sync::Arc};
 
 use async_trait::async_trait;
@@ -71,6 +71,12 @@ pub struct ListInfo<Id> {
     pub created_at: DateTime<Utc>,
 }
 
+const SNAPSHOT_PREFIX: &str = "snapshots/";
+const MANIFEST_PREFIX: &str = "manifests/";
+// const ATTRIBUTES_PREFIX: &str = "attributes/";
+const CHUNK_PREFIX: &str = "chunks/";
+const REF_PREFIX: &str = "refs";
+
 /// Fetch and write the parquet files that represent the repository in object store
 ///
 /// Different implementation can cache the files differently, or not at all.
@@ -115,23 +121,75 @@ pub trait Storage: fmt::Debug + private::Sealed {
         bytes: Bytes,
     ) -> StorageResult<()>;
 
+    async fn list_objects<'a>(
+        &'a self,
+        prefix: &str,
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>>;
+
+    /// Delete a stream of objects, by their id string representations
+    async fn delete_objects(
+        &self,
+        prefix: &str,
+        ids: BoxStream<'_, String>,
+    ) -> StorageResult<usize>;
+
     async fn list_chunks(
         &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>>;
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>> {
+        Ok(translate_list_infos(self.list_objects(CHUNK_PREFIX).await?))
+    }
+
     async fn list_manifests(
         &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>>;
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>> {
+        Ok(translate_list_infos(self.list_objects(MANIFEST_PREFIX).await?))
+    }
+
     async fn list_snapshots(
         &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>>;
+    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>> {
+        Ok(translate_list_infos(self.list_objects(SNAPSHOT_PREFIX).await?))
+    }
 
-    async fn delete_chunks(&self, ids: BoxStream<'_, ChunkId>) -> StorageResult<usize>;
+    async fn delete_chunks(
+        &self,
+        chunks: BoxStream<'_, ChunkId>,
+    ) -> StorageResult<usize> {
+        self.delete_objects(CHUNK_PREFIX, chunks.map(|id| id.to_string()).boxed()).await
+    }
+
     async fn delete_manifests(
         &self,
-        ids: BoxStream<'_, ManifestId>,
-    ) -> StorageResult<usize>;
+        chunks: BoxStream<'_, ManifestId>,
+    ) -> StorageResult<usize> {
+        self.delete_objects(MANIFEST_PREFIX, chunks.map(|id| id.to_string()).boxed())
+            .await
+    }
+
     async fn delete_snapshots(
         &self,
-        ids: BoxStream<'_, SnapshotId>,
-    ) -> StorageResult<usize>;
+        chunks: BoxStream<'_, SnapshotId>,
+    ) -> StorageResult<usize> {
+        self.delete_objects(SNAPSHOT_PREFIX, chunks.map(|id| id.to_string()).boxed())
+            .await
+    }
+}
+
+fn convert_list_item<Id>(item: ListInfo<String>) -> Option<ListInfo<Id>>
+where
+    Id: for<'b> TryFrom<&'b str>,
+{
+    let id = Id::try_from(item.id.as_str()).ok()?;
+    let created_at = item.created_at;
+    Some(ListInfo { created_at, id })
+}
+
+fn translate_list_infos<'a, Id>(
+    s: impl Stream<Item = StorageResult<ListInfo<String>>> + Send + 'a,
+) -> BoxStream<'a, StorageResult<ListInfo<Id>>>
+where
+    Id: for<'b> TryFrom<&'b str> + Send + 'a,
+{
+    // FIXME: flag error, don't skip
+    s.try_filter_map(|info| async move { Ok(convert_list_item(info)) }).boxed()
 }

--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -28,7 +28,10 @@ use std::{
     },
 };
 
-use super::{ListInfo, Storage, StorageError, StorageResult};
+use super::{
+    ListInfo, Storage, StorageError, StorageResult, CHUNK_PREFIX, MANIFEST_PREFIX,
+    REF_PREFIX, SNAPSHOT_PREFIX,
+};
 
 // Get Range is object_store specific, keep it with this module
 impl From<&ByteRange> for Option<GetRange> {
@@ -43,12 +46,6 @@ impl From<&ByteRange> for Option<GetRange> {
         }
     }
 }
-
-const SNAPSHOT_PREFIX: &str = "snapshots/";
-const MANIFEST_PREFIX: &str = "manifests/";
-// const ATTRIBUTES_PREFIX: &str = "attributes/";
-const CHUNK_PREFIX: &str = "chunks/";
-const REF_PREFIX: &str = "refs";
 
 #[derive(Debug)]
 pub struct ObjectStorage {
@@ -107,15 +104,18 @@ impl ObjectStorage {
             .await?)
     }
 
+    fn get_path_str(&self, file_prefix: &str, id: &str) -> ObjectPath {
+        let path = format!("{}/{}/{}", self.prefix, file_prefix, id);
+        ObjectPath::from(path)
+    }
+
     fn get_path<const SIZE: usize, T: FileTypeTag>(
         &self,
         file_prefix: &str,
         id: &ObjectId<SIZE, T>,
     ) -> ObjectPath {
-        // TODO: be careful about allocation here
         // we serialize the url using crockford
-        let path = format!("{}/{}/{}", self.prefix, file_prefix, id);
-        ObjectPath::from(path)
+        self.get_path_str(file_prefix, id.to_string().as_str())
     }
 
     fn get_snapshot_path(&self, id: &SnapshotId) -> ObjectPath {
@@ -156,52 +156,15 @@ impl ObjectStorage {
             .boxed()
     }
 
-    fn list_objects<'a, Id>(
-        &'a self,
-        prefix: &str,
-    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<Id>>>>
-    where
-        Id: for<'b> TryFrom<&'b str> + Send + 'a,
-    {
-        let prefix = ObjectPath::from(format!("{}/{}", self.prefix.as_str(), prefix));
-        let stream = self
-            .store
-            .list(Some(&prefix))
-            // TODO: we should signal error instead of filtering
-            .try_filter_map(|object| ready(Ok(object_to_list_info(&object))))
-            .err_into();
-        Ok(stream.boxed())
-    }
-
-    async fn delete_batch<const SIZE: usize, T: FileTypeTag + Sync>(
+    async fn delete_batch(
         &self,
         prefix: &str,
-        batch: Vec<ObjectId<SIZE, T>>,
+        batch: Vec<String>,
     ) -> StorageResult<usize> {
-        let keys = batch.iter().map(|id| Ok(self.get_path(prefix, id)));
+        let keys = batch.iter().map(|id| Ok(self.get_path_str(prefix, id)));
         let results = self.store.delete_stream(stream::iter(keys).boxed());
         // FIXME: flag errors instead of skipping them
         Ok(results.filter(|res| ready(res.is_ok())).count().await)
-    }
-
-    async fn delete_objects<const SIZE: usize, T: FileTypeTag + Sync>(
-        &self,
-        prefix: &str,
-        ids: BoxStream<'_, ObjectId<SIZE, T>>,
-    ) -> StorageResult<usize> {
-        let deleted = AtomicUsize::new(0);
-        ids.chunks(1_000)
-            // FIXME: configurable concurrency
-            .for_each_concurrent(10, |batch| {
-                let deleted = &deleted;
-                async move {
-                    // FIXME: handle error instead of skipping
-                    let new_deletes = self.delete_batch(prefix, batch).await.unwrap_or(0);
-                    deleted.fetch_add(new_deletes, Ordering::Release);
-                }
-            })
-            .await;
-        Ok(deleted.into_inner())
     }
 }
 
@@ -413,52 +376,43 @@ impl Storage for ObjectStorage {
             .map(|_| ())
     }
 
-    async fn list_chunks(
-        &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ChunkId>>>> {
-        self.list_objects(CHUNK_PREFIX)
+    async fn list_objects<'a>(
+        &'a self,
+        prefix: &str,
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        let prefix = ObjectPath::from(format!("{}/{}", self.prefix.as_str(), prefix));
+        let stream = self
+            .store
+            .list(Some(&prefix))
+            // TODO: we should signal error instead of filtering
+            .try_filter_map(|object| ready(Ok(object_to_list_info(&object))))
+            .err_into();
+        Ok(stream.boxed())
     }
 
-    async fn list_manifests(
+    async fn delete_objects(
         &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<ManifestId>>>> {
-        self.list_objects(MANIFEST_PREFIX)
-    }
-
-    async fn list_snapshots(
-        &self,
-    ) -> StorageResult<BoxStream<StorageResult<ListInfo<SnapshotId>>>> {
-        self.list_objects(SNAPSHOT_PREFIX)
-    }
-
-    async fn delete_chunks(
-        &self,
-        chunks: BoxStream<'_, ChunkId>,
+        prefix: &str,
+        ids: BoxStream<'_, String>,
     ) -> StorageResult<usize> {
-        self.delete_objects(CHUNK_PREFIX, chunks).await
-    }
-
-    async fn delete_manifests(
-        &self,
-        chunks: BoxStream<'_, ManifestId>,
-    ) -> StorageResult<usize> {
-        self.delete_objects(MANIFEST_PREFIX, chunks).await
-    }
-
-    async fn delete_snapshots(
-        &self,
-        chunks: BoxStream<'_, SnapshotId>,
-    ) -> StorageResult<usize> {
-        self.delete_objects(SNAPSHOT_PREFIX, chunks).await
+        let deleted = AtomicUsize::new(0);
+        ids.chunks(1_000)
+            // FIXME: configurable concurrency
+            .for_each_concurrent(10, |batch| {
+                let deleted = &deleted;
+                async move {
+                    // FIXME: handle error instead of skipping
+                    let new_deletes = self.delete_batch(prefix, batch).await.unwrap_or(0);
+                    deleted.fetch_add(new_deletes, Ordering::Release);
+                }
+            })
+            .await;
+        Ok(deleted.into_inner())
     }
 }
 
-fn object_to_list_info<'a, Id>(object: &ObjectMeta) -> Option<ListInfo<Id>>
-where
-    Id: for<'b> TryFrom<&'b str> + Send + 'a,
-{
+fn object_to_list_info(object: &ObjectMeta) -> Option<ListInfo<String>> {
     let created_at = object.last_modified;
-    let id_str = object.location.filename()?;
-    let id = Id::try_from(id_str).ok()?;
+    let id = object.location.filename()?.to_string();
     Some(ListInfo { id, created_at })
 }

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -1,0 +1,132 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::{num::NonZeroU64, sync::Arc};
+
+use bytes::Bytes;
+use chrono::Utc;
+use futures::StreamExt;
+use icechunk::{
+    format::{ByteRange, ChunkId, ChunkIndices, Path},
+    metadata::{ChunkKeyEncoding, ChunkShape, DataType, FillValue},
+    ops::gc::{garbage_collect, GCConfig, GCSummary},
+    refs::update_branch,
+    repository::{get_chunk, ZarrArrayMetadata},
+    storage::s3::{S3Config, S3Credentials, S3Storage, StaticS3Credentials},
+    Repository, Storage,
+};
+use pretty_assertions::assert_eq;
+
+fn minio_s3_config() -> S3Config {
+    S3Config {
+        region: Some("us-east-1".to_string()),
+        endpoint: Some("http://localhost:9000".to_string()),
+        credentials: S3Credentials::Static(StaticS3Credentials {
+            access_key_id: "minio123".into(),
+            secret_access_key: "minio123".into(),
+            session_token: None,
+        }),
+        allow_http: true,
+    }
+}
+
+#[tokio::test]
+/// Create a repo with two commits, reset the branch to "forget" the last commit, run gc
+///
+/// It runs [`garbage_collect`] to verify it's doing its job.
+pub async fn test_gc() -> Result<(), Box<dyn std::error::Error>> {
+    let storage: Arc<dyn Storage + Send + Sync> = Arc::new(
+        S3Storage::new_s3_store(
+            "testbucket".to_string(),
+            format!("{:?}", ChunkId::random()),
+            Some(&minio_s3_config()),
+        )
+        .await
+        .expect("Creating minio storage failed"),
+    );
+    let mut repo = Repository::init(Arc::clone(&storage), false)
+        .await?
+        .with_inline_threshold_bytes(0)
+        .build();
+
+    repo.add_group(Path::root()).await?;
+    let zarr_meta = ZarrArrayMetadata {
+        shape: vec![1100],
+        data_type: DataType::Int8,
+        chunk_shape: ChunkShape(vec![NonZeroU64::new(1).expect("Cannot create NonZero")]),
+        chunk_key_encoding: ChunkKeyEncoding::Slash,
+        fill_value: FillValue::Int8(0),
+        codecs: vec![],
+        storage_transformers: None,
+        dimension_names: None,
+    };
+
+    let array_path: Path = "/array".try_into().unwrap();
+    repo.add_array(array_path.clone(), zarr_meta.clone()).await?;
+    // we write more than 1k chunks to go beyond the chunk size for object listing and delete
+    for idx in 0..1100 {
+        let bytes = Bytes::copy_from_slice(&42i8.to_be_bytes());
+        let payload = repo.get_chunk_writer()(bytes.clone()).await?;
+        repo.set_chunk_ref(array_path.clone(), ChunkIndices(vec![idx]), Some(payload))
+            .await?;
+    }
+
+    let first_snap_id = repo.commit("main", "first", None).await?;
+    assert_eq!(storage.list_chunks().await?.count().await, 1100);
+
+    // overwrite 10 chunks
+    for idx in 0..10 {
+        let bytes = Bytes::copy_from_slice(&0i8.to_be_bytes());
+        let payload = repo.get_chunk_writer()(bytes.clone()).await?;
+        repo.set_chunk_ref(array_path.clone(), ChunkIndices(vec![idx]), Some(payload))
+            .await?;
+    }
+    let second_snap_id = repo.commit("main", "second", None).await?;
+    assert_eq!(storage.list_chunks().await?.count().await, 1110);
+
+    // verify doing gc without dangling objects doesn't change the repo
+    let now = Utc::now();
+    let gc_config = GCConfig::clean_all(now, now, None);
+    let summary = garbage_collect(storage.as_ref(), &gc_config).await?;
+    assert_eq!(summary, GCSummary::default());
+    assert_eq!(storage.list_chunks().await?.count().await, 1110);
+    for idx in 0..10 {
+        let bytes = get_chunk(
+            repo.get_chunk_reader(&array_path, &ChunkIndices(vec![idx]), &ByteRange::ALL)
+                .await?,
+        )
+        .await?
+        .unwrap();
+        assert_eq!(&0i8.to_be_bytes(), bytes.as_ref());
+    }
+
+    // Reset the branch to leave the latest commit dangling
+    update_branch(storage.as_ref(), "main", first_snap_id, Some(&second_snap_id), false)
+        .await?;
+
+    // we still have all the chunks
+    assert_eq!(storage.list_chunks().await?.count().await, 1110);
+
+    let summary = garbage_collect(storage.as_ref(), &gc_config).await?;
+    assert_eq!(summary.chunks_deleted, 10);
+    assert_eq!(summary.manifests_deleted, 1);
+    assert_eq!(summary.snapshots_deleted, 1);
+
+    // 10 chunks should be drop
+    assert_eq!(storage.list_chunks().await?.count().await, 1100);
+    assert_eq!(storage.list_manifests().await?.count().await, 1);
+    assert_eq!(storage.list_snapshots().await?.count().await, 2);
+
+    // Opening the repo on main should give the right data
+    let repo = Repository::from_branch_tip(Arc::clone(&storage), "main").await?.build();
+    for idx in 0..10 {
+        let bytes = get_chunk(
+            repo.get_chunk_reader(&array_path, &ChunkIndices(vec![idx]), &ByteRange::ALL)
+                .await?,
+        )
+        .await?
+        .unwrap();
+        assert_eq!(&42i8.to_be_bytes(), bytes.as_ref());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
We call garbage collection to the process where dangling objects are
deleted from object store.

We define a dangling object as a chunk, manifest, snapshot, attributes
or transaction log file that cannot be reached by navigating the
parent relationship starting from all possible refs.

There are currently two mechanisms that create dangling objects:

- Abandoning a session without committing it
- Resetting a branch leaving snapshots behind

In the future, we'll introduce more mechanisms that "generate" garbage,
with the objective of reducing storage costs. One example, would be
squashing commits when version resolution is not relevant.

Garbage collection is an inherently dangerous process. It's the only
time at which Icechunk actually deletes data from object store. As such,
it must be executed carefully.

There is an unavoidable race condition in garbage collection: Icechunk
has no way to distinguish a new object from a dangling one, if that
object was created after the garbage collection process has traced the refs.

To solve that issue, the garbage collection process only deletes objects
that have been created some time ago. Users can pass a timestamp as
configuration to the collection process. This timestamp must be  older
than the start time of the oldest possible writing session open. For
example, if the longest writing sessions last 48 hours, a safe timestamp
would be `now - 7 days`.