### PR TITLE
Fix sdist readme packaging error

### DIFF
--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -45,6 +45,7 @@ test = [
 features = ["pyo3/extension-module"]
 module-name = "icechunk._icechunk_python"
 python-source = "python"
+exclude = ["README.md"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
maturin 1.77 changed the error behavior and thats why the sdist error popped up this weekend 