### PR TITLE
Better deletion tracking in ChangeSet

### DIFF
--- a/icechunk-python/tests/test_store.py
+++ b/icechunk-python/tests/test_store.py
@@ -1,0 +1,15 @@
+import icechunk
+import zarr
+
+
+async def test_store_clear() -> None:
+    store = icechunk.IcechunkStore.create(
+        storage=icechunk.StorageConfig.memory("test"),
+        config=icechunk.StoreConfig(inline_chunk_threshold_bytes=1),
+    )
+
+    zarr.group(store=store)
+    store.commit("created node /")
+    await store.clear()
+    zarr.group(store=store)
+    assert len([_ async for _ in store.list_prefix("/")]) == 1

--- a/icechunk/src/change_set.rs
+++ b/icechunk/src/change_set.rs
@@ -146,19 +146,8 @@ impl ChangeSet {
     }
 
     pub fn is_deleted(&self, path: &Path, node_id: &NodeId) -> bool {
-        dbg!(format!("checking is_deleted for {0} & {1}", path, node_id));
         let key = (path.clone(), node_id.clone());
-        self.deleted_groups.contains(&key)
-            || self.deleted_arrays.contains(&key)
-            || path.ancestors().skip(1).any(|parent| {
-                self.get_group(&parent).is_some_and(|parent_node_id| {
-                    dbg!(format!(
-                        "checking ancestor {0}, node_id: {1}",
-                        parent, parent_node_id
-                    ));
-                    self.is_deleted(&parent, parent_node_id)
-                })
-            })
+        self.deleted_groups.contains(&key) || self.deleted_arrays.contains(&key)
     }
 
     pub fn has_updated_attributes(&self, node_id: &NodeId) -> bool {

--- a/icechunk/src/conflicts/basic_solver.rs
+++ b/icechunk/src/conflicts/basic_solver.rs
@@ -90,10 +90,10 @@ impl BasicConflictSolver {
                     ChunkDoubleUpdate{..} if self.on_chunk_conflict == VersionSelection::Fail
                 ) ||
                 matches!(conflict,
-                    DeleteOfUpdatedArray(_) if self.fail_on_delete_of_updated_array
+                         DeleteOfUpdatedArray{..} if self.fail_on_delete_of_updated_array
                 ) ||
                 matches!(conflict,
-                    DeleteOfUpdatedGroup(_) if self.fail_on_delete_of_updated_group
+                    DeleteOfUpdatedGroup{..} if self.fail_on_delete_of_updated_group
                 )
             },
         );
@@ -136,11 +136,11 @@ impl BasicConflictSolver {
                         VersionSelection::Fail => panic!("Bug in conflict resolution: UserAttributesDoubleUpdate flagged as unrecoverable")
                     }
                 }
-                DeleteOfUpdatedArray(_) => {
+                DeleteOfUpdatedArray { .. } => {
                     assert!(!self.fail_on_delete_of_updated_array);
                     // this is a no-op, the solution is to still delete the array
                 }
-                DeleteOfUpdatedGroup(_) => {
+                DeleteOfUpdatedGroup { .. } => {
                     assert!(!self.fail_on_delete_of_updated_group);
                     // this is a no-op, the solution is to still delete the group
                 }

--- a/icechunk/src/conflicts/basic_solver.rs
+++ b/icechunk/src/conflicts/basic_solver.rs
@@ -90,7 +90,7 @@ impl BasicConflictSolver {
                     ChunkDoubleUpdate{..} if self.on_chunk_conflict == VersionSelection::Fail
                 ) ||
                 matches!(conflict,
-                     DeleteOfUpdatedArray{..} if self.fail_on_delete_of_updated_array
+                    DeleteOfUpdatedArray{..} if self.fail_on_delete_of_updated_array
                 ) ||
                 matches!(conflict,
                     DeleteOfUpdatedGroup{..} if self.fail_on_delete_of_updated_group

--- a/icechunk/src/conflicts/basic_solver.rs
+++ b/icechunk/src/conflicts/basic_solver.rs
@@ -90,7 +90,7 @@ impl BasicConflictSolver {
                     ChunkDoubleUpdate{..} if self.on_chunk_conflict == VersionSelection::Fail
                 ) ||
                 matches!(conflict,
-                         DeleteOfUpdatedArray{..} if self.fail_on_delete_of_updated_array
+                     DeleteOfUpdatedArray{..} if self.fail_on_delete_of_updated_array
                 ) ||
                 matches!(conflict,
                     DeleteOfUpdatedGroup{..} if self.fail_on_delete_of_updated_group

--- a/icechunk/src/conflicts/detector.rs
+++ b/icechunk/src/conflicts/detector.rs
@@ -170,7 +170,6 @@ impl ConflictSolver for ConflictDetector {
             current_changes.deleted_arrays().map(Ok),
         )
         .try_filter_map(|(path, _node_id)| async {
-            // FIXME: reuse node_id?
             let id = match previous_repo.get_node(path).await {
                 Ok(node) => Some(node.id),
                 Err(RepositoryError::NodeNotFound { .. }) => None,

--- a/icechunk/src/conflicts/mod.rs
+++ b/icechunk/src/conflicts/mod.rs
@@ -36,8 +36,14 @@ pub enum Conflict {
         path: Path,
         node_id: NodeId,
     },
-    DeleteOfUpdatedArray(Path),
-    DeleteOfUpdatedGroup(Path),
+    DeleteOfUpdatedArray {
+        path: Path,
+        node_id: NodeId,
+    },
+    DeleteOfUpdatedGroup {
+        path: Path,
+        node_id: NodeId,
+    },
     // FIXME: we are missing the case of current change deleting a group and previous change
     // creating something new under it
 }

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -609,6 +609,7 @@ impl Repository {
     }
 
     pub async fn clear(&mut self) -> RepositoryResult<()> {
+        #[allow(clippy::expect_used)]
         self.delete_group(Path::try_from("/").expect("should not fail")).await?;
         Ok(())
     }

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -609,15 +609,7 @@ impl Repository {
     }
 
     pub async fn clear(&mut self) -> RepositoryResult<()> {
-        let to_delete: Vec<(NodeType, Path)> =
-            self.list_nodes().await?.map(|node| (node.node_type(), node.path)).collect();
-
-        for (t, p) in to_delete {
-            match t {
-                NodeType::Group => self.delete_group(p).await?,
-                NodeType::Array => self.delete_array(p).await?,
-            }
-        }
+        self.delete_group(Path::try_from("/").expect("should not fail")).await?;
         Ok(())
     }
 
@@ -922,7 +914,9 @@ impl From<Repository> for ChangeSet {
 }
 
 pub fn is_prefix_match(key: &str, prefix: &str) -> bool {
-    match key.strip_prefix(prefix) {
+    let tomatch =
+        if prefix != &String::from('/') { key.strip_prefix(prefix) } else { Some(key) };
+    match tomatch {
         None => false,
         Some(rest) => {
             // we have a few cases

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -611,8 +611,16 @@ impl Repository {
     }
 
     pub async fn clear(&mut self) -> RepositoryResult<()> {
-        #[allow(clippy::expect_used)]
-        self.delete_group(Path::try_from("/").expect("should not fail")).await?;
+        // TODO: can this be a delete_group("/") instead?
+        let to_delete: Vec<(NodeType, Path)> =
+            self.list_nodes().await?.map(|node| (node.node_type(), node.path)).collect();
+
+        for (t, p) in to_delete {
+            match t {
+                NodeType::Group => self.delete_group(p).await?,
+                NodeType::Array => self.delete_array(p).await?,
+            }
+        }
         Ok(())
     }
 

--- a/icechunk/src/zarr.rs
+++ b/icechunk/src/zarr.rs
@@ -29,10 +29,10 @@ use crate::{
     },
     refs::{update_branch, BranchVersion, Ref, RefError},
     repository::{
-        get_chunk, raise_if_invalid_snapshot_id, ArrayShape, ChunkIndices,
-        ChunkKeyEncoding, ChunkPayload, ChunkShape, Codec, DataType, DimensionNames,
-        FillValue, Path, RepositoryError, RepositoryResult, StorageTransformer,
-        UserAttributes, ZarrArrayMetadata,
+        get_chunk, is_prefix_match, raise_if_invalid_snapshot_id, ArrayShape,
+        ChunkIndices, ChunkKeyEncoding, ChunkPayload, ChunkShape, Codec, DataType,
+        DimensionNames, FillValue, Path, RepositoryError, RepositoryResult,
+        StorageTransformer, UserAttributes, ZarrArrayMetadata,
     },
     storage::{
         s3::{S3Config, S3Storage},
@@ -300,20 +300,6 @@ pub enum StoreError {
     UncommittedChanges,
     #[error("unknown store error: `{0}`")]
     Unknown(Box<dyn std::error::Error + Send + Sync>),
-}
-
-fn is_prefix_match(key: &str, prefix: &str) -> bool {
-    match key.strip_prefix(prefix) {
-        None => false,
-        Some(rest) => {
-            // we have a few cases
-            prefix.is_empty()   // if prefix was empty anything matches
-                || rest.is_empty()  // if stripping prefix left empty we have a match
-                || rest.starts_with('/') // next component so we match
-                                         // what we don't include is other matches,
-                                         // we want to catch prefix/foo but not prefix-foo
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/icechunk/src/zarr.rs
+++ b/icechunk/src/zarr.rs
@@ -911,10 +911,10 @@ impl Store {
             let repository = Arc::clone(&self.repository).read_owned().await;
             // TODO: this is inefficient because it filters based on the prefix, instead of only
             // generating items that could potentially match
-            for await maybe_path_chunk in  repository.all_chunks().await.map_err(StoreError::RepositoryError)? {
+            for await maybe_path_chunk in repository.all_chunks().await.map_err(StoreError::RepositoryError)? {
                 // FIXME: utf8 handling
                 match maybe_path_chunk {
-                    Ok((path,chunk)) => {
+                    Ok((path, chunk)) => {
                         let chunk_key = Key::Chunk { node_path: path, coords: chunk.coord }.to_string();
                         if is_prefix_match(&chunk_key, prefix) {
                             yield chunk_key;


### PR DESCRIPTION
Now track both Path and NodeId rather than just Path. This helps us handle tricky cases where a committed node is updated, deleted, and created again in the same session.