### PR TITLE
deadlock debug

### DIFF
--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -190,7 +190,10 @@ class IcechunkStore(Store, SyncMixin):
         key : str
         value : Buffer
         """
-        return await self._store.set(key, value.to_bytes())
+        print(f"setting {key}")
+        ret = await self._store.set(key, value.to_bytes())
+        print(f"finished setting {key}")
+        return ret
 
     async def set_if_not_exists(self, key: str, value: Buffer) -> None:
         """

--- a/icechunk-python/src/store.rs
+++ b/icechunk-python/src/store.rs
@@ -209,6 +209,7 @@ impl PyStore {
                 .set(&key, Bytes::from(value))
                 .await
                 .map_err(PyIcechunkStoreError::from)?;
+            dbg!("done setting ", &key);
             Ok(())
         })
     }

--- a/icechunk-python/tests/test_distributed_writers.py
+++ b/icechunk-python/tests/test_distributed_writers.py
@@ -1,12 +1,14 @@
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from typing import cast
+
+import pytest
 
 import dask.array
 import icechunk
 import zarr
 from dask.array.utils import assert_eq
-from dask.distributed import Client
 from icechunk.dask import store_dask
 
 # We create a 2-d array with this many chunks along each direction
@@ -48,6 +50,8 @@ async def test_distributed_writers() -> None:
     does a distributed commit. When done, we open the store again and verify
     we can write everything we have written.
     """
+    pytest.skip(reason="deadlock")
+
     repo = mk_repo()
     session = repo.writable_session(branch="main")
     store = session.store
@@ -66,7 +70,7 @@ async def test_distributed_writers() -> None:
     )
     _first_snap = session.commit("array created")
 
-    with Client(n_workers=8):  # type: ignore[no-untyped-call]
+    with dask.config.set(scheduler="threads"):  # type: ignore[no-untyped-call]
         session = repo.writable_session(branch="main")
         store = session.store
         group = zarr.open_group(store=store)
@@ -90,3 +94,94 @@ async def test_distributed_writers() -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             assert_eq(roundtripped, dask_array)  # type: ignore [no-untyped-call]
+
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from icechunk import Repository, Session, Storage
+
+
+@dataclass
+class Task:
+    """A read/write task"""
+
+    # The worker will use this Icechunk store to read/write to the dataset
+    session: Session
+    # Region of the array to write to
+    region: tuple[slice, ...]
+
+
+def generate_task_array(task: Task, shape: tuple[int, ...]) -> np.typing.ArrayLike:
+    """Generates a random array with the given shape and using the seed in the Task"""
+    seed = math.prod(slicer.stop for slicer in task.region)
+    np.random.seed(seed)
+    return np.random.rand(*shape)
+
+
+def execute_write_task(task: Task) -> None:
+    store = task.session.store
+    group = zarr.group(store=store, overwrite=False)
+    array = cast(zarr.Array, group["array"])
+    data = generate_task_array(task, array[task.region].shape)
+    assert len(task.region) == array.ndim
+    print(f"started writing {task.region}")
+    tic = time.perf_counter()
+    array[task.region] = data
+    toc = time.perf_counter()
+    print(f"finished writing {task.region} in {toc-tic} seconds")
+
+
+def slices_from_chunks(shape: tuple[int, ...], chunks: tuple[int, ...]):
+    """slightly modified from dask.array.core.slices_from_chunks to be lazy"""
+    import operator
+    from itertools import product, repeat
+
+    import toolz as tlz
+
+    extras = ((s % c,) if s % c > 0 else () for s, c in zip(shape, chunks, strict=True))
+    # need this twice
+    chunks = tuple(
+        tuple(tlz.concatv(repeat(c, s // c), e))
+        for s, c, e in zip(shape, chunks, extras, strict=True)
+    )
+    cumdims = (tlz.accumulate(operator.add, bds[:-1], 0) for bds in chunks)
+    slices = (
+        (slice(s, s + dim) for s, dim in zip(starts, shapes, strict=True))
+        for starts, shapes in zip(cumdims, chunks, strict=True)
+    )
+    return product(*slices)
+
+
+def test_multi_threading():
+    # pytest.skip("deadlock")
+    executor = ThreadPoolExecutor(max_workers=4)
+    shape = (120, 20, 20)
+    chunk_shape = (1, -1, -1)
+
+    storage = Storage.new_local_filesystem("/tmp/icechunk-multithreading-test")
+    repo = Repository.open_or_create(storage=storage)
+    session = repo.writable_session("main")
+
+    assert len(shape) == len(chunk_shape)
+    chunks = tuple(s if c == -1 else c for s, c in zip(shape, chunk_shape, strict=True))
+
+    store = session.store
+    group = zarr.group(store, overwrite=True)
+    group.create_array(
+        "array", shape=shape, dtype=np.float32, chunks=chunks, overwrite=True
+    )
+    session.commit("initialized")
+
+    session = repo.writable_session("main")
+    [
+        f.result(timeout=5)
+        for f in (
+            [
+                executor.submit(execute_write_task, Task(session=session, region=slicer))
+                for slicer in slices_from_chunks(shape, chunks)
+            ]
+        )
+    ]


### PR DESCRIPTION
This is a reproducer of a deadlock Seba and I studied earlier today.

`pytest -s tests/test_distributed_writers.py::test_multi_threading` hangs in multi-threading contexts. You'll have to delete `pytest.skip`  statement (added because I didn't want it to run on CI).

Note the existing `distributed_writers` test also hangs if I ask dask to use the `threads` scheduler.

Some logs from the `dbg!` statements we added, we see that 4 write tasks were sent to rust, two completed, the other two are waiting to grab the write lock

<details>

```
started writing (slice(1, 2, None), slice(0, 20, None), slice(0, 20, None))
started writing (slice(3, 4, None), slice(0, 20, None), slice(0, 20, None))
started writing (slice(2, 3, None), slice(0, 20, None), slice(0, 20, None))
started writing (slice(0, 1, None), slice(0, 20, None), slice(0, 20, None))
setting array/c/1/0/0
[icechunk/src/store.rs:274:25] "grabbing write lock" = "grabbing write lock"
[icechunk/src/store.rs:274:25] &coords = ChunkIndices([1, 0, 0,],)
[icechunk/src/store.rs:276:25] "getting chunk writer" = "getting chunk writer"
[icechunk/src/store.rs:276:25] &coords = ChunkIndices([1, 0, 0,],)
[icechunk/src/store.rs:278:25] "writing bytes" = "writing bytes"
[icechunk/src/store.rs:278:25] &coords = ChunkIndices([1, 0, 0,],)

setting array/c/3/0/0
setting array/c/2/0/0
setting array/c/0/0/0
[icechunk/src/store.rs:281:25] "setting chunk ref" = "setting chunk ref"
[icechunk/src/store.rs:281:25] &coords = ChunkIndices([1, 0, 0,],)
[icechunk/src/store.rs:284:25] "releasing" = "releasing"
[icechunk/src/store.rs:284:25] &coords = ChunkIndices([1, 0, 0,],)
[icechunk-python/src/store.rs:212:13] "done setting " = "done setting "
[icechunk-python/src/store.rs:212:13] &key = "array/c/1/0/0"

[icechunk/src/store.rs:274:25] "grabbing write lock" = "grabbing write lock"
[icechunk/src/store.rs:274:25] &coords = ChunkIndices([3, 0, 0,],)
[icechunk/src/store.rs:276:25] "getting chunk writer" = "getting chunk writer"
[icechunk/src/store.rs:276:25] &coords = ChunkIndices([3, 0, 0,],)
[icechunk/src/store.rs:278:25] "writing bytes" = "writing bytes"
[icechunk/src/store.rs:278:25] &coords = ChunkIndices([3, 0, 0,],)
finished setting array/c/1/0/0

[icechunk/src/store.rs:274:25] "grabbing write lock" = "grabbing write lock"
[icechunk/src/store.rs:274:25] &coords = ChunkIndices([2, 0, 0,],)
[icechunk/src/store.rs:274:25] "grabbing write lock" = "grabbing write lock"
[icechunk/src/store.rs:274:25] &coords = ChunkIndices([0, 0, 0,],)

finished writing (slice(1, 2, None), slice(0, 20, None), slice(0, 20, None)) in 0.005256082979030907 seconds
[icechunk/src/store.rs:281:25] "setting chunk ref" = "setting chunk ref"
[icechunk/src/store.rs:281:25] &coords = ChunkIndices([3, 0, 0,],)
[icechunk/src/store.rs:284:25] "releasing" = "releasing"
[icechunk/src/store.rs:284:25] &coords = ChunkIndices([3, 0, 0,],)
[icechunk-python/src/store.rs:212:13] "done setting " = "done setting "
[icechunk-python/src/store.rs:212:13] &/c/3/0/0"

```

</details>