### PR TITLE
Disallow deleting main branch

### DIFF
--- a/icechunk-python/tests/test_stateful_repo_ops.py
+++ b/icechunk-python/tests/test_stateful_repo_ops.py
@@ -345,16 +345,21 @@ class VersionControlStateMachine(RuleBasedStateMachine):
             self.session = self.repo.writable_session(branch)
             self.model.checkout_branch(branch)
 
-    # @rule(branch=consumes(branches))
-    # def delete_branch(self, branch):
-    #     note(f"Deleting branch {branch!r}")
-    #     if branch in self.model.branches:
-    #         self.repo.delete_branch(branch)
-    #         self.model.delete_branch(branch)
-    #     else:
-    #         note("Expecting error.")
-    #         with pytest.raises(ValueError):
-    #             self.repo.delete_branch(branch)
+    #     @rule(branch=consumes(branches))
+    #     def delete_branch(self, branch):
+    #         note(f"Deleting branch {branch!r}")
+    #         if branch in self.model.branches:
+    #             if branch == "main":
+    #                 note("Expecting error.")
+    #                 with pytest.raises(IcechunkError):
+    #                     self.repo.delete_branch(branch)
+    #             else:
+    #                 self.repo.delete_branch(branch)
+    #                 self.model.delete_branch(branch)
+    #         else:
+    #             note("Expecting error.")
+    #             with pytest.raises(IcechunkError):
+    #                 self.repo.delete_branch(branch)
 
     @invariant()
     def check_list_prefix_from_root(self):

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -72,7 +72,7 @@ pub enum RepositoryError {
     IOError(#[from] std::io::Error),
     #[error("a concurrent task failed {0}")]
     ConcurrencyError(#[from] JoinError),
-    #[error("bain branch cannot be deleted")]
+    #[error("main branch cannot be deleted")]
     CannotDeleteMain,
 }
 
@@ -380,7 +380,7 @@ impl Repository {
     /// This will remove the branch reference and the branch history. It will not remove the
     /// chunks or snapshots associated with the branch.
     pub async fn delete_branch(&self, branch: &str) -> RepositoryResult<()> {
-        if branch != "main" {
+        if branch != Ref::DEFAULT_BRANCH {
             delete_branch(self.storage.as_ref(), &self.storage_settings, branch).await?;
             Ok(())
         } else {


### PR DESCRIPTION
Main branch is used to detect repository existence, so it shouldn't be deleted. It is also the default in several functions.

Closes: #515