### PR TITLE
Add `validate_container` argument to set_virtual_ref

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -256,14 +256,7 @@ class PyStore:
         offset: int,
         length: int,
         checksum: str | datetime.datetime | None = None,
-    ) -> None: ...
-    async def async_set_virtual_ref(
-        self,
-        key: str,
-        location: str,
-        offset: int,
-        length: int,
-        checksum: str | datetime.datetime | None = None,
+        validate_container: bool = False,
     ) -> None: ...
     async def delete(self, key: str) -> None: ...
     async def delete_dir(self, prefix: str) -> None: ...

--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -203,34 +203,6 @@ class IcechunkStore(Store, SyncMixin):
         """
         return await self._store.set_if_not_exists(key, value.to_bytes())
 
-    async def async_set_virtual_ref(
-        self,
-        key: str,
-        location: str,
-        *,
-        offset: int,
-        length: int,
-        checksum: str | datetime | None = None,
-    ) -> None:
-        """Store a virtual reference to a chunk.
-
-        Parameters
-        ----------
-        key : str
-            The chunk to store the reference under. This is the fully qualified zarr key eg: 'array/c/0/0/0'
-        location : str
-            The location of the chunk in storage. This is absolute path to the chunk in storage eg: 's3://bucket/path/to/file.nc'
-        offset : int
-            The offset in bytes from the start of the file location in storage the chunk starts at
-        length : int
-            The length of the chunk in bytes, measured from the given offset
-        checksum : str | datetime | None
-            The etag or last_medified_at field of the object
-        """
-        return await self._store.async_set_virtual_ref(
-            key, location, offset, length, checksum
-        )
-
     def set_virtual_ref(
         self,
         key: str,
@@ -239,6 +211,7 @@ class IcechunkStore(Store, SyncMixin):
         offset: int,
         length: int,
         checksum: str | datetime | None = None,
+        validate_container: bool = False,
     ) -> None:
         """Store a virtual reference to a chunk.
 
@@ -254,8 +227,12 @@ class IcechunkStore(Store, SyncMixin):
             The length of the chunk in bytes, measured from the given offset
         checksum : str | datetime | None
             The etag or last_medified_at field of the object
+        validate_container: bool
+            If set to true, fail for locations that don't match any existing virtual chunk container
         """
-        return self._store.set_virtual_ref(key, location, offset, length, checksum)
+        return self._store.set_virtual_ref(
+            key, location, offset, length, checksum, validate_container
+        )
 
     async def delete(self, key: str) -> None:
         """Remove a key from the store

--- a/icechunk-python/src/store.rs
+++ b/icechunk-python/src/store.rs
@@ -246,7 +246,8 @@ impl PyStore {
         })
     }
 
-    #[pyo3(signature = (key, location, offset, length, checksum = None))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (key, location, offset, length, checksum = None, validate_container = false))]
     fn set_virtual_ref(
         &self,
         py: Python<'_>,
@@ -255,6 +256,7 @@ impl PyStore {
         offset: ChunkOffset,
         length: ChunkLength,
         checksum: Option<ChecksumArgument>,
+        validate_container: bool,
     ) -> PyIcechunkStoreResult<()> {
         // This is blocking function, we need to release the Gil
         py.allow_threads(move || {
@@ -268,7 +270,7 @@ impl PyStore {
                     checksum: checksum.map(|cs| cs.into()),
                 };
                 store
-                    .set_virtual_ref(&key, virtual_ref)
+                    .set_virtual_ref(&key, virtual_ref, validate_container)
                     .await
                     .map_err(PyIcechunkStoreError::from)?;
                 Ok(())

--- a/icechunk-python/tests/test_virtual_ref.py
+++ b/icechunk-python/tests/test_virtual_ref.py
@@ -134,6 +134,16 @@ async def test_write_minio_virtual_refs() -> None:
         "c/0/0/2", f"s3://testbucket/{prefix}/non-existing", offset=1, length=4
     )
 
+    # can validate virtual chunk containers
+    with pytest.raises(IcechunkError, match="invalid chunk location"):
+        store.set_virtual_ref(
+            "c/0/0/2",
+            f"bad://testbucket/{prefix}/non-existing",
+            offset=1,
+            length=4,
+            validate_container=True,
+        )
+
     buffer_prototype = zarr.core.buffer.default_buffer_prototype()
 
     first = await store.get("c/0/0/0", prototype=buffer_prototype)

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -22,7 +22,7 @@ use crate::{
         format_constants,
         manifest::{
             ChunkInfo, ChunkPayload, ChunkRef, Manifest, ManifestExtents, ManifestRef,
-            VirtualChunkRef, VirtualReferenceError,
+            VirtualChunkLocation, VirtualChunkRef, VirtualReferenceError,
         },
         snapshot::{
             ManifestFileInfo, NodeData, NodeSnapshot, NodeType, Snapshot,
@@ -36,7 +36,7 @@ use crate::{
     refs::{fetch_branch_tip, update_branch, RefError},
     repository::RepositoryError,
     storage,
-    virtual_chunks::VirtualChunkResolver,
+    virtual_chunks::{VirtualChunkContainer, VirtualChunkResolver},
     RepositoryConfig, Storage, StorageError,
 };
 
@@ -173,6 +173,13 @@ impl Session {
 
     pub fn config(&self) -> &RepositoryConfig {
         &self.config
+    }
+
+    pub fn matching_container(
+        &self,
+        chunk_location: &VirtualChunkLocation,
+    ) -> Option<&VirtualChunkContainer> {
+        self.virtual_resolver.matching_container(chunk_location.0.as_str())
     }
 
     /// Add a group to the store.

--- a/icechunk/src/virtual_chunks.rs
+++ b/icechunk/src/virtual_chunks.rs
@@ -147,6 +147,13 @@ impl VirtualChunkResolver {
         }
     }
 
+    pub fn matching_container(
+        &self,
+        chunk_location: &str,
+    ) -> Option<&VirtualChunkContainer> {
+        find_container(chunk_location, self.containers.as_ref())
+    }
+
     pub async fn get_fetcher(
         &self,
         chunk_location: &str,


### PR DESCRIPTION
This argument, defaulted to `False` will make sure the location passed matches one of the existing virtual chunk containers.

Closes: #510 