### PR TITLE
Mechanism to deserialize different spec versions

### DIFF
--- a/icechunk/src/format/manifest.rs
+++ b/icechunk/src/format/manifest.rs
@@ -118,11 +118,11 @@ pub struct ChunkInfo {
     pub payload: ChunkPayload,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Default)]
 pub struct Manifest {
     pub icechunk_manifest_format_version: IcechunkFormatVersion,
     pub icechunk_manifest_format_flags: BTreeMap<String, rmpv::Value>,
-    chunks: BTreeMap<NodeId, BTreeMap<ChunkIndices, ChunkPayload>>,
+    pub(crate) chunks: BTreeMap<NodeId, BTreeMap<ChunkIndices, ChunkPayload>>,
 }
 
 impl Manifest {
@@ -147,7 +147,7 @@ impl Manifest {
     pub fn new(chunks: BTreeMap<NodeId, BTreeMap<ChunkIndices, ChunkPayload>>) -> Self {
         Self {
             chunks,
-            icechunk_manifest_format_version: SpecVersionBin::V0_1_0Alpha12 as u8,
+            icechunk_manifest_format_version: SpecVersionBin::current() as u8,
             icechunk_manifest_format_flags: Default::default(),
         }
     }

--- a/icechunk/src/format/serializers/current.rs
+++ b/icechunk/src/format/serializers/current.rs
@@ -1,0 +1,162 @@
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::format::{
+    manifest::{ChunkPayload, Manifest},
+    snapshot::{
+        AttributeFileInfo, ManifestFileInfo, NodeSnapshot, Snapshot, SnapshotMetadata,
+        SnapshotProperties,
+    },
+    transaction_log::TransactionLog,
+    ChunkIndices, IcechunkFormatVersion, NodeId, Path,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct SnapshotDeserializer {
+    manifest_files: Vec<ManifestFileInfo>,
+    attribute_files: Vec<AttributeFileInfo>,
+    total_parents: u32,
+    short_term_parents: u16,
+    short_term_history: VecDeque<SnapshotMetadata>,
+    metadata: SnapshotMetadata,
+    started_at: DateTime<Utc>,
+    properties: SnapshotProperties,
+    nodes: BTreeMap<Path, NodeSnapshot>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SnapshotSerializer<'a> {
+    manifest_files: &'a Vec<ManifestFileInfo>,
+    attribute_files: &'a Vec<AttributeFileInfo>,
+    total_parents: u32,
+    short_term_parents: u16,
+    short_term_history: &'a VecDeque<SnapshotMetadata>,
+    metadata: &'a SnapshotMetadata,
+    started_at: &'a DateTime<Utc>,
+    properties: &'a SnapshotProperties,
+    nodes: &'a BTreeMap<Path, NodeSnapshot>,
+}
+
+impl From<SnapshotDeserializer> for Snapshot {
+    fn from(value: SnapshotDeserializer) -> Self {
+        Self {
+            manifest_files: value.manifest_files,
+            nodes: value.nodes,
+            attribute_files: value.attribute_files,
+            total_parents: value.total_parents,
+            short_term_parents: value.short_term_parents,
+            short_term_history: value.short_term_history,
+            metadata: value.metadata,
+            started_at: value.started_at,
+            properties: value.properties,
+        }
+    }
+}
+
+impl<'a> From<&'a Snapshot> for SnapshotSerializer<'a> {
+    fn from(value: &'a Snapshot) -> Self {
+        Self {
+            manifest_files: &value.manifest_files,
+            attribute_files: &value.attribute_files,
+            nodes: &value.nodes,
+            total_parents: value.total_parents,
+            short_term_parents: value.short_term_parents,
+            short_term_history: &value.short_term_history,
+            metadata: &value.metadata,
+            started_at: &value.started_at,
+            properties: &value.properties,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestDeserializer {
+    icechunk_manifest_format_version: IcechunkFormatVersion,
+    icechunk_manifest_format_flags: BTreeMap<String, rmpv::Value>,
+    chunks: BTreeMap<NodeId, BTreeMap<ChunkIndices, ChunkPayload>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ManifestSerializer<'a> {
+    icechunk_manifest_format_version: &'a IcechunkFormatVersion,
+    icechunk_manifest_format_flags: &'a BTreeMap<String, rmpv::Value>,
+    chunks: &'a BTreeMap<NodeId, BTreeMap<ChunkIndices, ChunkPayload>>,
+}
+
+impl From<ManifestDeserializer> for Manifest {
+    fn from(value: ManifestDeserializer) -> Self {
+        Self {
+            icechunk_manifest_format_version: value.icechunk_manifest_format_version,
+            icechunk_manifest_format_flags: value.icechunk_manifest_format_flags,
+            chunks: value.chunks,
+        }
+    }
+}
+
+impl<'a> From<&'a Manifest> for ManifestSerializer<'a> {
+    fn from(value: &'a Manifest) -> Self {
+        Self {
+            icechunk_manifest_format_version: &value.icechunk_manifest_format_version,
+            icechunk_manifest_format_flags: &value.icechunk_manifest_format_flags,
+            chunks: &value.chunks,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TransactionLogDeserializer {
+    icechunk_transaction_log_format_version: IcechunkFormatVersion,
+    new_groups: HashSet<NodeId>,
+    new_arrays: HashSet<NodeId>,
+    deleted_groups: HashSet<NodeId>,
+    deleted_arrays: HashSet<NodeId>,
+    updated_user_attributes: HashSet<NodeId>,
+    updated_zarr_metadata: HashSet<NodeId>,
+    updated_chunks: HashMap<NodeId, HashSet<ChunkIndices>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TransactionLogSerializer<'a> {
+    icechunk_transaction_log_format_version: &'a IcechunkFormatVersion,
+    new_groups: &'a HashSet<NodeId>,
+    new_arrays: &'a HashSet<NodeId>,
+    deleted_groups: &'a HashSet<NodeId>,
+    deleted_arrays: &'a HashSet<NodeId>,
+    updated_user_attributes: &'a HashSet<NodeId>,
+    updated_zarr_metadata: &'a HashSet<NodeId>,
+    updated_chunks: &'a HashMap<NodeId, HashSet<ChunkIndices>>,
+}
+
+impl From<TransactionLogDeserializer> for TransactionLog {
+    fn from(value: TransactionLogDeserializer) -> Self {
+        Self {
+            icechunk_transaction_log_format_version: value
+                .icechunk_transaction_log_format_version,
+            new_groups: value.new_groups,
+            new_arrays: value.new_arrays,
+            deleted_groups: value.deleted_groups,
+            deleted_arrays: value.deleted_arrays,
+            updated_user_attributes: value.updated_user_attributes,
+            updated_zarr_metadata: value.updated_zarr_metadata,
+            updated_chunks: value.updated_chunks,
+        }
+    }
+}
+
+impl<'a> From<&'a TransactionLog> for TransactionLogSerializer<'a> {
+    fn from(value: &'a TransactionLog) -> Self {
+        Self {
+            icechunk_transaction_log_format_version: &value
+                .icechunk_transaction_log_format_version,
+            new_groups: &value.new_groups,
+            new_arrays: &value.new_arrays,
+            deleted_groups: &value.deleted_groups,
+            deleted_arrays: &value.deleted_arrays,
+            updated_user_attributes: &value.updated_user_attributes,
+            updated_zarr_metadata: &value.updated_zarr_metadata,
+            updated_chunks: &value.updated_chunks,
+        }
+    }
+}

--- a/icechunk/src/format/serializers/mod.rs
+++ b/icechunk/src/format/serializers/mod.rs
@@ -1,0 +1,130 @@
+//! How seralizers work:
+//!
+//! - Main goal is to make sure newer version of Icechunk can read metadata files created using
+//!   older versions. In this way, a repository can evolve during its life. As users upgrade their
+//!   Icechunk versions they don't need to migrate their data.
+//! - Of course we may choose to limit backwards compatibility after certain number of versions or
+//!   a time limit.
+//! - Performance is critical, so we cannot copy much data around during the process of
+//!   serialization/deserialization
+//! - For serialization:
+//!     - We define a new `XSerializer` for each metadata file type `X`. Example: [`SnapshotSerializer`].
+//!     - This type implement [`serde::Serialize`]
+//!     - This type holds only references to the same fields as `X`
+//!     - This type implements `From<&X>` (notice by reference) Example:
+//!       ```ignore
+//!       impl<'a> From<&'a Snapshot> for SnapshotSerializer<'a> {
+//!       ...
+//!       }
+//!       ```
+//!     - Because the serializer only holds references it's essentially free to call
+//!       `snapshot.into()` to get one.
+//!     - Then this object is serialized using serde.
+//! - For deserialization:
+//!     - We define a new `XDeserializer` for each metadata file type `X`. Example: [`SnapshotDeserializer`].
+//!     - This type implement [`serde::Deserialize`]
+//!     - This type holds the same fields as `X` by value
+//!     - `X` implements `From<XDeserializer>` (notice by value). Example:
+//!       ```ignore
+//!        impl From<SnapshotDeserializer> for Snapshot {
+//!        ...
+//!        }
+//!       ```
+//!     - Because the deserializer can be destructed and `X` implements `From`,  it's essentially free to call
+//!       obtain the original type `X`
+//!     - Then this new type `XDeserializer` is deserialized using serde and converted with `into`.
+//!
+//! - `serializers.current.rs` holds all the serializers and deserializers for the current version
+//!    of the spec
+//! - `serializers.version_foo.rs` holds all the serializers and deserializers for version foo of
+//!    the spec
+//! - The `serializers` module root has functions `serialize_X` and `deserialize_X` that take a
+//!   spec version number and use the right (de)-serializer to do the job.
+use std::io::{Read, Write};
+
+use current::{
+    ManifestDeserializer, ManifestSerializer, SnapshotDeserializer, SnapshotSerializer,
+    TransactionLogDeserializer, TransactionLogSerializer,
+};
+
+use super::{
+    format_constants::SpecVersionBin, manifest::Manifest, snapshot::Snapshot,
+    transaction_log::TransactionLog,
+};
+
+pub mod current;
+
+pub fn serialize_snapshot(
+    snapshot: &Snapshot,
+    version: SpecVersionBin,
+    write: &mut impl Write,
+) -> Result<(), rmp_serde::encode::Error> {
+    match version {
+        SpecVersionBin::V0_1_0Alpha12 => {
+            let serializer = SnapshotSerializer::from(snapshot);
+            rmp_serde::encode::write(write, &serializer)
+        }
+    }
+}
+
+pub fn serialize_manifest(
+    manifest: &Manifest,
+    version: SpecVersionBin,
+    write: &mut impl Write,
+) -> Result<(), rmp_serde::encode::Error> {
+    match version {
+        SpecVersionBin::V0_1_0Alpha12 => {
+            let serializer = ManifestSerializer::from(manifest);
+            rmp_serde::encode::write(write, &serializer)
+        }
+    }
+}
+
+pub fn serialize_transaction_log(
+    transaction_log: &TransactionLog,
+    version: SpecVersionBin,
+    write: &mut impl Write,
+) -> Result<(), rmp_serde::encode::Error> {
+    match version {
+        SpecVersionBin::V0_1_0Alpha12 => {
+            let serializer = TransactionLogSerializer::from(transaction_log);
+            rmp_serde::encode::write(write, &serializer)
+        }
+    }
+}
+
+pub fn deserialize_snapshot(
+    version: SpecVersionBin,
+    read: Box<dyn Read>,
+) -> Result<Snapshot, rmp_serde::decode::Error> {
+    match version {
+        SpecVersionBin::V0_1_0Alpha12 => {
+            let deserializer: SnapshotDeserializer = rmp_serde::from_read(read)?;
+            Ok(deserializer.into())
+        }
+    }
+}
+
+pub fn deserialize_manifest(
+    version: SpecVersionBin,
+    read: Box<dyn Read>,
+) -> Result<Manifest, rmp_serde::decode::Error> {
+    match version {
+        SpecVersionBin::V0_1_0Alpha12 => {
+            let deserializer: ManifestDeserializer = rmp_serde::from_read(read)?;
+            Ok(deserializer.into())
+        }
+    }
+}
+
+pub fn deserialize_transaction_log(
+    version: SpecVersionBin,
+    read: Box<dyn Read>,
+) -> Result<TransactionLog, rmp_serde::decode::Error> {
+    match version {
+        SpecVersionBin::V0_1_0Alpha12 => {
+            let deserializer: TransactionLogDeserializer = rmp_serde::from_read(read)?;
+            Ok(deserializer.into())
+        }
+    }
+}

--- a/icechunk/src/format/snapshot.rs
+++ b/icechunk/src/format/snapshot.rs
@@ -142,7 +142,7 @@ pub struct AttributeFileInfo {
     pub format_version: IcechunkFormatVersion,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq)]
 pub struct Snapshot {
     pub manifest_files: Vec<ManifestFileInfo>,
     pub attribute_files: Vec<AttributeFileInfo>,
@@ -155,7 +155,7 @@ pub struct Snapshot {
     pub metadata: SnapshotMetadata,
     pub started_at: DateTime<Utc>,
     pub properties: SnapshotProperties,
-    nodes: BTreeMap<Path, NodeSnapshot>,
+    pub(crate) nodes: BTreeMap<Path, NodeSnapshot>,
 }
 
 impl Default for SnapshotMetadata {
@@ -426,12 +426,12 @@ mod tests {
         let manifests = vec![
             ManifestFileInfo {
                 id: man_ref1.object_id.clone(),
-                format_version: SpecVersionBin::V0_1_0Alpha12 as u8,
+                format_version: SpecVersionBin::current() as u8,
                 size: 1_000_000,
             },
             ManifestFileInfo {
                 id: man_ref2.object_id.clone(),
-                format_version: SpecVersionBin::V0_1_0Alpha12 as u8,
+                format_version: SpecVersionBin::current() as u8,
                 size: 1_000_000,
             },
         ];

--- a/icechunk/src/format/transaction_log.rs
+++ b/icechunk/src/format/transaction_log.rs
@@ -1,7 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use serde::{Deserialize, Serialize};
-
 use crate::change_set::ChangeSet;
 
 use super::{
@@ -10,7 +8,7 @@ use super::{
     ChunkIndices, IcechunkFormatVersion, NodeId,
 };
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct TransactionLog {
     // FIXME: better, more stable on-disk format
     pub icechunk_transaction_log_format_version: IcechunkFormatVersion,
@@ -66,7 +64,7 @@ impl TransactionLog {
             updated_user_attributes,
             updated_zarr_metadata,
             updated_chunks,
-            icechunk_transaction_log_format_version: SpecVersionBin::V0_1_0Alpha12 as u8,
+            icechunk_transaction_log_format_version: SpecVersionBin::current() as u8,
         }
     }
 }

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -1174,7 +1174,7 @@ async fn flush(
             .map(|(mid, msize)| {
                 vec![ManifestFileInfo {
                     id: mid.clone(),
-                    format_version: SpecVersionBin::V0_1_0Alpha12 as u8,
+                    format_version: SpecVersionBin::current() as u8,
                     size: *msize,
                 }]
             })


### PR DESCRIPTION
Also provides a mechanism do separate the serializable datastructure from the in memory one.

To understand the mechanism read the documentation at the top of `serializers/mod.rs`.

After this merges, I'll try to use the mechanism to implement the first backwards-compatible on-disk format change.