### PR TITLE
Experimental support for Tigris

### DIFF
--- a/icechunk-python/python/icechunk/__init__.py
+++ b/icechunk-python/python/icechunk/__init__.py
@@ -60,6 +60,7 @@ from icechunk.storage import (
     local_filesystem_storage,
     s3_storage,
     s3_store,
+    tigris_storage,
 )
 from icechunk.store import IcechunkStore
 
@@ -123,4 +124,5 @@ __all__ = [
     "s3_static_credentials",
     "s3_storage",
     "s3_store",
+    "tigris_storage",
 ]

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -456,6 +456,14 @@ class Storage:
         credentials: AnyS3Credential | None = None,
     ) -> Storage: ...
     @classmethod
+    def new_tigris(
+        cls,
+        config: S3Options,
+        bucket: str,
+        prefix: str | None,
+        credentials: AnyS3Credential | None = None,
+    ) -> Storage: ...
+    @classmethod
     def new_in_memory(cls) -> Storage: ...
     @classmethod
     def new_local_filesystem(cls, path: str) -> Storage: ...

--- a/icechunk-python/python/icechunk/storage.py
+++ b/icechunk-python/python/icechunk/storage.py
@@ -117,6 +117,68 @@ def s3_storage(
     )
 
 
+def tigris_storage(
+    *,
+    bucket: str,
+    prefix: str | None,
+    region: str | None = None,
+    endpoint_url: str | None = None,
+    allow_http: bool = False,
+    access_key_id: str | None = None,
+    secret_access_key: str | None = None,
+    session_token: str | None = None,
+    expires_after: datetime | None = None,
+    anonymous: bool | None = None,
+    from_env: bool | None = None,
+    get_credentials: Callable[[], S3StaticCredentials] | None = None,
+) -> Storage:
+    """Create a Storage instance that saves data in Tigris object store.
+
+    Parameters
+    ----------
+    bucket: str
+        The bucket where the repository will store its data
+    prefix: str | None
+        The prefix within the bucket that is the root directory of the repository
+    region: str | None
+        The region to use in the object store, if `None` a default region will be used
+    endpoint_url: str | None
+        Optional endpoint where the object store serves data, example: http://localhost:9000
+    allow_http: bool
+        If the object store can be accessed using http protocol instead of https
+    access_key_id: str | None
+        S3 credential access key
+    secret_access_key: str | None
+        S3 credential secret access key
+    session_token: str | None
+        Optional S3 credential session token
+    expires_after: datetime | None
+        Optional expiration for the object store credentials
+    anonymous: bool | None
+        If set to True requests to the object store will not be signed
+    from_env: bool | None
+        Fetch credentials from the operative system environment
+    get_credentials: Callable[[], S3StaticCredentials] | None
+        Use this function to get and refresh object store credentials
+    """
+    credentials = s3_credentials(
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        session_token=session_token,
+        expires_after=expires_after,
+        anonymous=anonymous,
+        from_env=from_env,
+        get_credentials=get_credentials,
+    )
+    options = S3Options(region=region, endpoint_url=endpoint_url, allow_http=allow_http)
+    return Storage.new_tigris(
+        config=options,
+        bucket=bucket,
+        prefix=prefix,
+        credentials=credentials,
+    )
+
+
 def gcs_storage(
     *,
     bucket: str,

--- a/icechunk-python/tests/data/test-repo/config.yaml
+++ b/icechunk-python/tests/data/test-repo/config.yaml
@@ -1,21 +1,26 @@
 inline_chunk_threshold_bytes: 12
-unsafe_overwrite_refs: false
-get_partial_values_concurrency: 10
-compression:
-  algorithm: Zstd
-  level: 1
-caching:
-  num_snapshot_nodes: 10000
-  num_chunk_refs: 5000000
-  num_transaction_changes: 0
-  num_bytes_attributes: 0
-  num_bytes_chunks: 0
+unsafe_overwrite_refs: null
+get_partial_values_concurrency: null
+compression: null
+caching: null
 storage: null
 virtual_chunk_containers:
   gcs:
     name: gcs
     url_prefix: gcs
     store: !Gcs {}
+  az:
+    name: az
+    url_prefix: az
+    store: !Azure {}
+  tigris:
+    name: tigris
+    url_prefix: tigris
+    store: !Tigris
+      region: null
+      endpoint_url: https://fly.storage.tigris.dev
+      anonymous: false
+      allow_http: false
   s3:
     name: s3
     url_prefix: s3://
@@ -24,14 +29,6 @@ virtual_chunk_containers:
       endpoint_url: http://localhost:9000
       anonymous: false
       allow_http: true
-  az:
-    name: az
-    url_prefix: az
-    store: !Azure {}
-  tigris:
-    name: tigris
-    url_prefix: tigris
-    store: !Tigris {}
   file:
     name: file
     url_prefix: file

--- a/icechunk/src/config.rs
+++ b/icechunk/src/config.rs
@@ -30,9 +30,7 @@ pub enum ObjectStoreConfig {
     S3(S3Options),
     Gcs(HashMap<String, String>),
     Azure(HashMap<String, String>),
-    Tigris {
-        // TODO:
-    },
+    Tigris(S3Options),
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, Clone, Copy)]

--- a/icechunk/src/storage/mod.rs
+++ b/icechunk/src/storage/mod.rs
@@ -494,6 +494,27 @@ pub fn new_s3_storage(
     Ok(Arc::new(st))
 }
 
+pub fn new_tigris_storage(
+    config: S3Options,
+    bucket: String,
+    prefix: Option<String>,
+    credentials: Option<S3Credentials>,
+) -> StorageResult<Arc<dyn Storage>> {
+    let config = S3Options {
+        endpoint_url: Some(
+            config.endpoint_url.unwrap_or("https://fly.storage.tigris.dev".to_string()),
+        ),
+        ..config
+    };
+    let st = S3Storage::new(
+        config,
+        bucket,
+        prefix,
+        credentials.unwrap_or(S3Credentials::FromEnv),
+    )?;
+    Ok(Arc::new(st))
+}
+
 pub fn new_in_memory_storage() -> StorageResult<Arc<dyn Storage>> {
     let st = ObjectStorage::new_in_memory()?;
     Ok(Arc::new(st))


### PR DESCRIPTION
Tigris can now be used for Icechunk repositories and for virtual chunk containers.

Warning: Currently, if using Tigris for the repo storage, there are two behaviors that are broken:

* When creating a repository an assertions can sometimes trigger if the request is done from a region geographically far from where the data is. The repository is created successfully.
* There will be a delay between when commit is done and when it's visible in a branch. This breaks our consistency guarantees.

We are exploring ways to deal with the issues above.