### PR TITLE
Remote benchmark tweaks

### DIFF
--- a/icechunk-python/benchmarks/conftest.py
+++ b/icechunk-python/benchmarks/conftest.py
@@ -38,6 +38,13 @@ def synth_dataset(request) -> Store:
     ds.storage_config = ds.storage_config.with_overwrite(
         **TEST_BUCKETS[where]
     ).with_extra(prefix=extra_prefix, force_idempotent=True)
+    if ds.setupfn is None:
+        # these datasets aren't automatically set up
+        # so skip if the data haven't been written yet.
+        try:
+            ds.store()
+        except ValueError as e:
+            pytest.skip(reason=str(e))
     return ds
 
 

--- a/icechunk-python/benchmarks/helpers.py
+++ b/icechunk-python/benchmarks/helpers.py
@@ -52,10 +52,10 @@ def assert_cwd_is_icechunk_python():
         )
 
 
-def get_commit(ref: str) -> str:
+def get_full_commit(ref: str) -> str:
     return subprocess.run(
         ["git", "rev-parse", ref], capture_output=True, text=True, check=True
-    ).stdout.strip()[:8]
+    ).stdout.strip()
 
 
 def rdms() -> str:

--- a/icechunk-python/benchmarks/most_recent.sh
+++ b/icechunk-python/benchmarks/most_recent.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+echo $(ls -t ./.benchmarks/**/* | head -n 1)
+pytest-benchmark compare --group=group,func,param --sort=fullname --columns=median --name=normal `ls -t ./.benchmarks/**/* | head -n 1`

--- a/icechunk-python/benchmarks/runner.py
+++ b/icechunk-python/benchmarks/runner.py
@@ -151,6 +151,24 @@ class LocalRunner(Runner):
 
     def run(self, *, pytest_extra: str = "") -> None:
         super().run(pytest_extra=pytest_extra)
+        if len(refs) > 1:
+            files = sorted(
+                glob.glob("./.benchmarks/**/*.json", recursive=True),
+                key=os.path.getmtime,
+                reverse=True,
+            )[-len(refs) :]
+            # TODO: Use `just` here when we figure that out.
+            subprocess.run(
+                [
+                    "pytest-benchmark",
+                    "compare",
+                    "--group=group,func,param",
+                    "--sort=fullname",
+                    "--columns=median",
+                    "--name=normal",
+                    *files,
+                ]
+            )
 
 
 class CoiledRunner(Runner):
@@ -261,25 +279,6 @@ if __name__ == "__main__":
 
     for runner in tqdm.tqdm(runners):
         runner.run(pytest_extra=args.pytest)
-
-    if len(refs) > 1:
-        files = sorted(
-            glob.glob("./.benchmarks/**/*.json", recursive=True),
-            key=os.path.getmtime,
-            reverse=True,
-        )[-len(refs) :]
-        # TODO: Use `just` here when we figure that out.
-        subprocess.run(
-            [
-                "pytest-benchmark",
-                "compare",
-                "--group=group,func,param",
-                "--sort=fullname",
-                "--columns=median",
-                "--name=normal",
-                *files,
-            ]
-        )
 
 
 # Compare wish-list:


### PR DESCRIPTION
@paraseba 

```
python benchmarks/runner.py --pytest="-k open" --where s3 main
```

works for me. It will *print* results to screen for now. The pytest kwarg simply runs a set of short test. Delete to run the whole thing