### PR TITLE
Fix getsize benchmark

### DIFF
--- a/icechunk-python/benchmarks/test_benchmark_reads.py
+++ b/icechunk-python/benchmarks/test_benchmark_reads.py
@@ -48,7 +48,11 @@ def test_time_getsize_key(synth_dataset: Dataset, benchmark) -> None:
     @benchmark
     def fn():
         for array in synth_dataset.load_variables:
-            key = f"{synth_dataset.group + '/' or ''}{array}/zarr.json"
+            if group := synth_dataset.group is not None:
+                prefix = f"{group}/"
+            else:
+                prefix = ""
+            key = f"{prefix}{array}/zarr.json"
             sync(store.getsize(key))
 
 

--- a/icechunk-python/benchmarks/test_benchmark_reads.py
+++ b/icechunk-python/benchmarks/test_benchmark_reads.py
@@ -48,7 +48,7 @@ def test_time_getsize_key(synth_dataset: Dataset, benchmark) -> None:
     @benchmark
     def fn():
         for array in synth_dataset.load_variables:
-            key = f"{synth_dataset.group or ''}/{array}/zarr.json"
+            key = f"{synth_dataset.group + '/' or ''}{array}/zarr.json"
             sync(store.getsize(key))
 
 


### PR DESCRIPTION
Zarr doesn't support a preceding slash either, so I think icechunk was mistakenly supporting it.

```python
import zarr
store = zarr.storage.MemoryStore()

group = zarr.group(store)

array = group.create_array("array", shape=(1,2,3), dtype="float32")

print(await store.getsize("array/zarr.json")) # works
await store.getsize("/array/zarr.json") #error
```