### PR TITLE
doc: fix wrong name in docstrings

### DIFF
--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -340,7 +340,7 @@ class Repository:
         """
         self._repository.delete_branch(branch)
 
-    def delete_tag(self, branch: str) -> None:
+    def delete_tag(self, tag: str) -> None:
         """
         Delete a tag.
 
@@ -353,7 +353,7 @@ class Repository:
         -------
         None
         """
-        self._repository.delete_tag(branch)
+        self._repository.delete_tag(tag)
 
     def create_tag(self, tag: str, snapshot_id: str) -> None:
         """

--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -289,7 +289,7 @@ class IcechunkStore(Store, SyncMixin):
 
         Parameters
         ----------
-        key : str
+        prefix : str
         """
         return await self._store.delete_dir(prefix)
 


### PR DESCRIPTION
Caught these when using `--strict` in the docs build in preparation for executable docs