### PR TITLE
Support for read-only Storage

### DIFF
--- a/icechunk/src/storage/logging.rs
+++ b/icechunk/src/storage/logging.rs
@@ -53,6 +53,11 @@ impl Storage for LoggingStorage {
     fn default_settings(&self) -> Settings {
         self.backend.default_settings()
     }
+
+    fn can_write(&self) -> bool {
+        self.backend.can_write()
+    }
+
     async fn fetch_config(
         &self,
         settings: &Settings,

--- a/icechunk/src/storage/mod.rs
+++ b/icechunk/src/storage/mod.rs
@@ -302,6 +302,9 @@ pub trait Storage: fmt::Debug + fmt::Display + private::Sealed + Sync + Send {
     fn default_settings(&self) -> Settings {
         Default::default()
     }
+
+    fn can_write(&self) -> bool;
+
     async fn fetch_config(&self, settings: &Settings)
         -> StorageResult<FetchConfigResult>;
     async fn update_config(
@@ -624,6 +627,7 @@ pub fn new_s3_storage(
         bucket,
         prefix,
         credentials.unwrap_or(S3Credentials::FromEnv),
+        true,
     )?;
     Ok(Arc::new(st))
 }
@@ -645,6 +649,7 @@ pub fn new_tigris_storage(
         bucket,
         prefix,
         credentials.unwrap_or(S3Credentials::FromEnv),
+        true,
     )?;
     Ok(Arc::new(st))
 }

--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -296,6 +296,10 @@ impl private::Sealed for ObjectStorage {}
 #[async_trait]
 #[typetag::serde]
 impl Storage for ObjectStorage {
+    fn can_write(&self) -> bool {
+        true
+    }
+
     #[instrument(skip(self))]
     fn default_settings(&self) -> Settings {
         self.backend.default_settings()


### PR DESCRIPTION
Why:

* We may implement `Storage` for certain read-only s3-like, such as HTTP
* We'll need this for [Tigris support](https://github.com/earth-mover/icechunk/blob/main/design-docs/009-tigris-support.md)