### PR TITLE
docs: Add warnings about potential deadlock when opening a repository from processes

### DIFF
--- a/docs/docs/icechunk-python/parallel.md
+++ b/docs/docs/icechunk-python/parallel.md
@@ -81,11 +81,21 @@ xr.testing.assert_identical(ds, ondisk)
 
 ## Distributed writes
 
+There are fundamentally two different modes for distributed writes in Icechunk:
+
+- "Cooperative" distributed writes, in which all of the changes being written are part of the same transaction.
+  The point of this is to allow large scale, massively parallel writing to the store as part of a single coordinated job.
+  In this scenario, it's the user's job to align the writing process with the Zarr chunks.
+- "Uncooperative" writes, in which multiple workers are attempting to write to the same store in an uncoordinated way.
+  This path relies on the optimistic concurrency mechanism to detect and resolve conflicts.
+
 !!! info
 
     This code will not execute with a `ProcessPoolExecutor` without [some changes](https://docs.python.org/3/library/multiprocessing.html#programming-guidelines).
     Specifically it requires wrapping the code in a `if __name__ == "__main__":` block.
     See a full executable example [here](https://github.com/earth-mover/icechunk/blob/main/icechunk-python/examples/mpwrite.py).
+
+### Cooperative distributed writes
 
 Any task execution framework (e.g. `ProcessPoolExecutor`, Joblib, Lithops, Dask Distributed, Ray, etc.)
 can be used instead of the `ThreadPoolExecutor`. However such workloads should account for
@@ -142,4 +152,92 @@ Verify that the writes worked as expected:
 ```python
 ondisk = xr.open_zarr(repo.readonly_session("main").store, consolidated=False)
 xr.testing.assert_identical(ds, ondisk)
+```
+
+### Uncooperative distributed writes
+
+!!! warning
+
+    Using multiprocessing start method 'fork' will result in deadlock when trying to open an existing repository.
+    This happens because the files behind the repository needs to be locked.
+    The 'fork' start method will copying not only the lock, but also the state of the lock.
+    Thus all child processes will copy the file lock in an acquired state, leaving them hanging indefinitely waiting for the file lock to be released, which never happens.
+    Polars has a similar issue, which is descriped in their [documentation about multiprocessing](https://docs.pola.rs/user-guide/misc/multiprocessing/).
+    Putting `mp.set_start_method('forkserver')` at the beginning of the script will solve this issue.
+    Only necessary for POSIX systems except MacOS, because MacOS and Windows do not support the `fork` method.
+
+Here is an example of uncooperative distributed writes using `multiprocessing`, base on [this discussion](https://github.com/earth-mover/icechunk/discussions/802).
+
+```python
+import multiprocessing as mp
+import icechunk as ic
+import zarr
+
+
+def get_storage():
+    return ic.s3_storage(bucket="icechunk-test", prefix="zarr_issue_2868", from_env=True)
+
+
+def worker(i):
+    print(f"Stated worker {i}")
+    storage = get_storage()
+    repo = ic.Repository.open(storage)
+    # keep trying until it succeeds
+    while True:
+        try:
+            session = repo.writable_session("main")
+            z = zarr.open(session.store, mode="r+")
+            print(f"Opened store for {i} | {dict(z.attrs)}")
+            a = z.attrs.get("done", [])
+            a.append(i)
+            z.attrs["done"] = a
+            session.commit(f"wrote from worker {i}")
+            break
+        except ic.ConflictError:
+            print(f"Conflict for {i}, retying")
+            pass
+
+
+def main():
+    mp.set_start_method('forkserver')
+    storage = get_storage()
+    repo = ic.Repository.create(storage)
+    session = repo.writable_session("main")
+
+    zarr.create(
+        shape=(10, 10),
+        chunks=(5, 5),
+        store=session.store,
+        overwrite=True,
+    )
+    session.commit("initialized dataset")
+
+    p1 = mp.Process(target=worker, args=(1,))
+    p2 = mp.Process(target=worker, args=(2,))
+    p1.start()
+    p2.start()
+    p1.join()
+    p2.join()
+
+    session = repo.readonly_session(branch="main")
+    z = zarr.open(session.store, mode="r")
+    print(z.attrs["done"])
+    print(list(repo.ancestry(branch="main")))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+This should output something like, note that the order of the writes is not guaranteed:
+
+```sh
+Stated worker 1
+Stated worker 2
+Opened store for 1 | {}
+Opened store for 2 | {}
+Conflict for 1, retying
+Opened store for 1 | {'done': [2]}
+[2, 1]
+[SnapshotInfo(id="MGPV1YE1SY0799AZFFB0", parent_id=YAN3D2N7ANCNKCFN3JSG, written_at=datetime.datetime(2025,3,4,21,40,57,19985, tzinfo=datetime.timezone.utc), message="wrote from..."), SnapshotInfo(id="YAN3D2N7ANCNKCFN3JSG", parent_id=0M5H3J6SC8MYBQYWACC0, written_at=datetime.datetime(2025,3,4,21,40,56,734126, tzinfo=datetime.timezone.utc), message="wrote from..."), SnapshotInfo(id="0M5H3J6SC8MYBQYWACC0", parent_id=WKKQ9K7ZFXZER26SES5G, written_at=datetime.datetime(2025,3,4,21,40,56,47192, tzinfo=datetime.timezone.utc), message="initialize..."), SnapshotInfo(id="WKKQ9K7ZFXZER26SES5G", parent_id=None, written_at=datetime.datetime(2025,3,4,21,40,55,868277, tzinfo=datetime.timezone.utc), message="Repository...")]
 ```

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -67,6 +67,11 @@ class Repository:
 
         If no repository exists at the given storage location, an error will be raised.
 
+        !!! warning
+            In multiprocessing environments this method can end up in a deadlock, if multiprocessing start method of processes is set to 'fork', which is the default on POSIX systems except MacOS.
+            Change the start method to 'forkserver' is recommended: `mp.set_start_method('forkserver')`.
+            Read more in our [Parallel Write Guide](/icechunk-python/parallel#uncooperative-distributed-writes).
+
         Parameters
         ----------
         storage : Storage
@@ -99,6 +104,11 @@ class Repository:
     ) -> Self:
         """
         Open an existing Icechunk repository or create a new one if it does not exist.
+
+        !!! warning
+            In multiprocessing environments this method can end up in a deadlock, if multiprocessing start method of processes is set to 'fork', which is the default on POSIX systems except MacOS.
+            Change the start method to 'forkserver' is recommended: `mp.set_start_method('forkserver')`.
+            Read more in our [Parallel Write Guide](/icechunk-python/parallel#uncooperative-distributed-writes).
 
         Parameters
         ----------


### PR DESCRIPTION
Based on the discussion #802 