### PR TITLE
fix(lib.rs): Python CLI issues 0 exit code when using --help

### DIFF
--- a/icechunk-python/src/lib.rs
+++ b/icechunk-python/src/lib.rs
@@ -45,14 +45,19 @@ fn cli_entrypoint(py: Python) -> PyResult<()> {
     match IcechunkCLI::try_parse_from(args.to_vec()) {
         Ok(cli_args) => pyo3_async_runtimes::tokio::get_runtime().block_on(async move {
             if let Err(e) = run_cli(cli_args).await {
-                eprintln!("Error: {}", e);
+                eprintln!("{}", e);
                 std::process::exit(1);
             }
             Ok(())
         }),
         Err(e) => {
-            eprintln!("Error: {}", e);
-            std::process::exit(1);
+            if e.use_stderr() {
+                eprintln!("{}", e);
+                std::process::exit(e.exit_code());
+            } else {
+                println!("{}", e);
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for #816 

Using Clap's [use_stderr](https://docs.rs/clap/latest/clap/type.Error.html#method.use_stderr) and [exit_code](https://docs.rs/clap/latest/clap/type.Error.html#method.exit_code) to correctly propagate error + exit code.

Also drops the `Error` printout as it's duplicating the information, the Rust implementation should report errors correctly by itself.