### PR TITLE
Don't do multipart uploads for chunks

### DIFF
--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -459,11 +459,7 @@ impl Storage for ObjectStorage {
         bytes: bytes::Bytes,
     ) -> Result<(), StorageError> {
         let path = self.get_chunk_path(&id);
-        let upload = self.get_client().await.put_multipart(&path).await?;
-        // TODO: new_with_chunk_size?
-        let mut write = object_store::WriteMultipart::new(upload);
-        write.write(&bytes);
-        write.finish().await?;
+        self.get_client().await.put(&path, bytes.into()).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Some leftover code was doing unconditional multipart uploads of chunks, in the object store that use `object_store` (gcs, local, etc).

This was producing for usual chunk sizes ~ 3x performance penalty.

We should add multipart back, but only for large objects.

Closes: #723 