### PR TITLE
doc: update docstring to include metadata param

### DIFF
--- a/icechunk-python/python/icechunk/session.py
+++ b/icechunk-python/python/icechunk/session.py
@@ -262,6 +262,8 @@ class Session:
         ----------
         message : str
             The message to write with the commit.
+        metadata : dict[str, Any] | None, optional
+            Additional metadata to store with the commit snapshot.
 
         Returns
         -------


### PR DESCRIPTION
I noticed as I was looking through the docs that the `metadata` param in `commit()` isn't documented 