### PR TITLE
Rust integration tests can run in more object stores.

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # three times a day to run the integration tests that take a long time
+    - cron:  '33 3,10,15 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -88,5 +91,42 @@ jobs:
 
       - name: Check
         if: matrix.os == 'ubuntu-latest' || github.event_name == 'push'
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+          TIGRIS_BUCKET: ${{ secrets.TIGRIS_BUCKET }}
+          TIGRIS_REGION: ${{ secrets.TIGRIS_REGION }}
+          TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}
+          TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}
+
         run: |
           just pre-commit
+
+      - name: Run integration tests against object stores
+        if: github.event_name == 'cron'
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+          TIGRIS_BUCKET: ${{ secrets.TIGRIS_BUCKET }}
+          TIGRIS_REGION: ${{ secrets.TIGRIS_REGION }}
+          TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}
+          TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}
+
+        run: |
+          cargo test --all --all-targets -- --ignored

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@ alias pre := pre-commit
 
 # run all tests
 test *args='':
-  cargo test --all {{args}}
+  cargo test --all --all-targets {{args}}
 
 # compile but don't run all tests
 compile-tests *args='':

--- a/icechunk/tests/common/mod.rs
+++ b/icechunk/tests/common/mod.rs
@@ -1,0 +1,114 @@
+#![allow(dead_code)]
+use std::{env, sync::Arc};
+
+use icechunk::{
+    Storage,
+    config::{S3Credentials, S3Options, S3StaticCredentials},
+    new_s3_storage,
+    storage::{new_r2_storage, new_tigris_storage},
+};
+
+pub(crate) fn make_minio_integration_storage(
+    prefix: String,
+) -> Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error>> {
+    let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
+        S3Options {
+            region: Some("us-east-1".to_string()),
+            endpoint_url: Some("http://localhost:9000".to_string()),
+            allow_http: true,
+            anonymous: false,
+            force_path_style: true,
+        },
+        "testbucket".to_string(),
+        Some(prefix),
+        Some(S3Credentials::Static(S3StaticCredentials {
+            access_key_id: "minio123".into(),
+            secret_access_key: "minio123".into(),
+            session_token: None,
+            expires_after: None,
+        })),
+    )?;
+    Ok(storage)
+}
+
+pub(crate) fn make_tigris_integration_storage(
+    prefix: String,
+) -> Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error>> {
+    let credentials = S3Credentials::Static(S3StaticCredentials {
+        access_key_id: env::var("TIGRIS_ACCESS_KEY_ID")?,
+        secret_access_key: env::var("TIGRIS_SECRET_ACCESS_KEY")?,
+        session_token: None,
+        expires_after: None,
+    });
+    let bucket = env::var("TIGRIS_BUCKET")?;
+    let region = env::var("TIGRIS_REGION")?;
+
+    let storage: Arc<dyn Storage + Send + Sync> = new_tigris_storage(
+        S3Options {
+            region: Some(region),
+            endpoint_url: None,
+            anonymous: false,
+            allow_http: false,
+            force_path_style: false,
+        },
+        bucket,
+        Some(prefix),
+        Some(credentials),
+        false,
+    )?;
+    Ok(storage)
+}
+
+pub(crate) fn make_r2_integration_storage(
+    prefix: String,
+) -> Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error>> {
+    let credentials = S3Credentials::Static(S3StaticCredentials {
+        access_key_id: env::var("R2_ACCESS_KEY_ID")?,
+        secret_access_key: env::var("R2_SECRET_ACCESS_KEY")?,
+        session_token: None,
+        expires_after: None,
+    });
+    let bucket = env::var("R2_BUCKET")?;
+
+    let storage: Arc<dyn Storage + Send + Sync> = new_r2_storage(
+        S3Options {
+            region: None,
+            endpoint_url: None,
+            anonymous: false,
+            allow_http: false,
+            force_path_style: false,
+        },
+        Some(bucket),
+        Some(prefix),
+        Some(env::var("R2_ACCOUNT_ID")?),
+        Some(credentials),
+    )?;
+    Ok(storage)
+}
+
+pub(crate) fn make_aws_integration_storage(
+    prefix: String,
+) -> Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error>> {
+    let credentials = S3Credentials::Static(S3StaticCredentials {
+        access_key_id: env::var("AWS_ACCESS_KEY_ID")?,
+        secret_access_key: env::var("AWS_SECRET_ACCESS_KEY")?,
+        session_token: None,
+        expires_after: None,
+    });
+    let bucket = env::var("AWS_BUCKET")?;
+    let region = env::var("AWS_REGION")?;
+
+    let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
+        S3Options {
+            region: Some(region),
+            endpoint_url: None,
+            anonymous: false,
+            allow_http: false,
+            force_path_style: false,
+        },
+        bucket,
+        Some(prefix),
+        Some(credentials),
+    )?;
+    Ok(storage)
+}

--- a/icechunk/tests/test_distributed_writes.rs
+++ b/icechunk/tests/test_distributed_writes.rs
@@ -1,50 +1,25 @@
 #![allow(clippy::unwrap_used)]
+use chrono::Utc;
 use pretty_assertions::assert_eq;
 use std::{collections::HashMap, ops::Range, sync::Arc};
 
 use bytes::Bytes;
 use icechunk::{
     Repository, Storage,
-    config::{S3Credentials, S3Options, S3StaticCredentials},
-    format::{ByteRange, ChunkIndices, Path, SnapshotId, snapshot::ArrayShape},
+    format::{ByteRange, ChunkIndices, Path, snapshot::ArrayShape},
     repository::VersionInfo,
     session::{Session, get_chunk},
-    storage::new_s3_storage,
 };
 use tokio::task::JoinSet;
 
+mod common;
+
 const SIZE: usize = 10;
-
-#[allow(clippy::expect_used)]
-async fn mk_storage(
-    prefix: &str,
-) -> Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
-    let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
-        S3Options {
-            region: Some("us-east-1".to_string()),
-            endpoint_url: Some("http://localhost:9000".to_string()),
-            allow_http: true,
-            anonymous: false,
-            force_path_style: true,
-        },
-        "testbucket".to_string(),
-        Some(prefix.to_string()),
-        Some(S3Credentials::Static(S3StaticCredentials {
-            access_key_id: "minio123".into(),
-            secret_access_key: "minio123".into(),
-            session_token: None,
-            expires_after: None,
-        })),
-    )
-    .expect("Creating minio storage failed");
-
-    Ok(storage)
-}
 
 async fn mk_repo(
     storage: Arc<dyn Storage + Send + Sync>,
     init: bool,
-) -> Result<Repository, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Repository, Box<dyn std::error::Error>> {
     if init {
         Ok(Repository::create(None, storage, HashMap::new()).await?)
     } else {
@@ -80,7 +55,7 @@ async fn write_chunks(
     Ok(ds)
 }
 
-async fn verify(ds: Session) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn verify(ds: Session) -> Result<(), Box<dyn std::error::Error>> {
     for x in 0..(SIZE / 2) as u32 {
         for y in 0..(SIZE / 2) as u32 {
             let bytes = get_chunk(
@@ -104,7 +79,40 @@ async fn verify(ds: Session) -> Result<(), Box<dyn std::error::Error + Send + Sy
 }
 
 #[tokio::test]
-#[allow(clippy::unwrap_used)]
+async fn test_distributed_writes_in_minio() -> Result<(), Box<dyn std::error::Error>> {
+    do_test_distributed_writes(|prefix| async {
+        common::make_minio_integration_storage(prefix)
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+async fn test_distributed_writes_in_aws() -> Result<(), Box<dyn std::error::Error>> {
+    do_test_distributed_writes(|prefix| async {
+        common::make_aws_integration_storage(prefix)
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+async fn test_distributed_writes_in_r2() -> Result<(), Box<dyn std::error::Error>> {
+    do_test_distributed_writes(|prefix| async {
+        common::make_r2_integration_storage(prefix)
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+async fn test_distributed_writes_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
+    do_test_distributed_writes(|prefix| async {
+        common::make_tigris_integration_storage(prefix)
+    })
+    .await
+}
+
 /// This test does a distributed write from 4 different [`Repository`] instances, and then commits.
 ///
 /// - We create a repo, and write an empty array to it.
@@ -113,13 +121,20 @@ async fn verify(ds: Session) -> Result<(), Box<dyn std::error::Error + Send + Sy
 /// - We do concurrent writes from the 4 repo instances
 /// - When done, we do a distributed commit using a random repo
 /// - The changes from the other repos are serialized via [`ChangeSet::export_to_bytes`]
-async fn test_distributed_writes() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+async fn do_test_distributed_writes<F, Fut>(
+    mk_storage: F,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: Fn(String) -> Fut,
+    Fut: Future<
+        Output = Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error>>,
+    >,
 {
-    let prefix = format!("test_distributed_writes_{}", SnapshotId::random());
-    let storage1 = mk_storage(prefix.as_str()).await?;
-    let storage2 = mk_storage(prefix.as_str()).await?;
-    let storage3 = mk_storage(prefix.as_str()).await?;
-    let storage4 = mk_storage(prefix.as_str()).await?;
+    let prefix = format!("test_distributed_writes_{}", Utc::now().timestamp_millis());
+    let storage1 = mk_storage(prefix.clone()).await?;
+    let storage2 = mk_storage(prefix.clone()).await?;
+    let storage3 = mk_storage(prefix.clone()).await?;
+    let storage4 = mk_storage(prefix.clone()).await?;
     let repo1 = mk_repo(storage1, true).await?;
 
     let mut ds1 = repo1.writable_session("main").await?;
@@ -182,7 +197,7 @@ async fn test_distributed_writes() -> Result<(), Box<dyn std::error::Error + Sen
     verify(ds1).await?;
 
     // To be safe, we create a new instance of the storage and repo, and verify again
-    let storage = mk_storage(prefix.as_str()).await?;
+    let storage = mk_storage(prefix).await?;
     let repo = mk_repo(storage, false).await?;
     let ds =
         repo.readonly_session(&VersionInfo::BranchTipRef("main".to_string())).await?;

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -8,8 +8,7 @@ use futures::{StreamExt, TryStreamExt};
 use icechunk::{
     Repository, RepositoryConfig, Storage,
     asset_manager::AssetManager,
-    config::{S3Credentials, S3Options, S3StaticCredentials},
-    format::{ByteRange, ChunkId, ChunkIndices, Path, snapshot::ArrayShape},
+    format::{ByteRange, ChunkIndices, Path, snapshot::ArrayShape},
     new_in_memory_storage,
     ops::gc::{
         ExpireRefResult, ExpiredRefAction, GCConfig, GCSummary, expire, expire_ref,
@@ -18,37 +17,48 @@ use icechunk::{
     refs::{Ref, update_branch},
     repository::VersionInfo,
     session::get_chunk,
-    storage::new_s3_storage,
 };
 use pretty_assertions::assert_eq;
 
-fn minio_s3_config() -> (S3Options, S3Credentials) {
-    let config = S3Options {
-        region: Some("us-east-1".to_string()),
-        endpoint_url: Some("http://localhost:9000".to_string()),
-        allow_http: true,
-        anonymous: false,
-        force_path_style: true,
-    };
-    let credentials = S3Credentials::Static(S3StaticCredentials {
-        access_key_id: "minio123".into(),
-        secret_access_key: "minio123".into(),
-        session_token: None,
-        expires_after: None,
-    });
-    (config, credentials)
+mod common;
+
+#[tokio::test]
+pub async fn test_gc_in_minio() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
+    let storage = common::make_minio_integration_storage(prefix)?;
+    do_test_gc(storage).await
 }
 
 #[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_gc_in_aws() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
+    let storage = common::make_aws_integration_storage(prefix)?;
+    do_test_gc(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_gc_in_r2() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
+    let storage = common::make_r2_integration_storage(prefix)?;
+    do_test_gc(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_gc_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
+    let storage = common::make_tigris_integration_storage(prefix)?;
+    do_test_gc(storage).await
+}
+
 /// Create a repo with two commits, reset the branch to "forget" the last commit, run gc
 ///
 /// It runs [`garbage_collect`] to verify it's doing its job.
-pub async fn test_gc() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix = format!("{:?}", ChunkId::random());
-    let (config, credentials) = minio_s3_config();
-    let storage: Arc<dyn Storage + Send + Sync> =
-        new_s3_storage(config, "testbucket".to_string(), Some(prefix), Some(credentials))
-            .expect("Creating minio storage failed");
+pub async fn do_test_gc(
+    storage: Arc<dyn Storage + Send + Sync>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let storage_settings = storage.default_settings();
     let repo = Repository::create(
         Some(RepositoryConfig {
@@ -261,12 +271,45 @@ async fn make_design_doc_repo(
 }
 
 #[tokio::test]
+pub async fn test_expire_ref_in_memory() -> Result<(), Box<dyn std::error::Error>> {
+    let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+    do_test_expire_ref(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_expire_ref_in_aws() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_expire_ref_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_aws_integration_storage(prefix)?;
+    do_test_expire_ref(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_expire_ref_in_r2() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_expire_ref_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_r2_integration_storage(prefix)?;
+    do_test_expire_ref(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_expire_ref_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix = format!("test_expire_ref_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_tigris_integration_storage(prefix)?;
+    do_test_expire_ref(storage).await
+}
+
 /// In this test, we set up a repo as in the design document for expiration.
 ///
 /// We then, expire the branches and tags in the same order as the document
 /// and we verify we get the same results.
-pub async fn test_expire_ref() -> Result<(), Box<dyn std::error::Error>> {
-    let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+pub async fn do_test_expire_ref(
+    storage: Arc<dyn Storage + Send + Sync>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let storage_settings = storage.default_settings();
     let mut repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
 
@@ -475,12 +518,62 @@ pub async fn test_expire_ref_with_odd_timestamps()
 }
 
 #[tokio::test]
+pub async fn test_expire_and_garbage_collect_in_memory()
+-> Result<(), Box<dyn std::error::Error>> {
+    let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+    do_test_expire_and_garbage_collect(storage).await
+}
+
+#[tokio::test]
+pub async fn test_expire_and_garbage_collect_in_minio()
+-> Result<(), Box<dyn std::error::Error>> {
+    let prefix =
+        format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_minio_integration_storage(prefix)?;
+    do_test_expire_and_garbage_collect(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_expire_and_garbage_collect_in_aws()
+-> Result<(), Box<dyn std::error::Error>> {
+    let prefix =
+        format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_aws_integration_storage(prefix)?;
+    do_test_expire_and_garbage_collect(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_expire_and_garbage_collect_in_r2()
+-> Result<(), Box<dyn std::error::Error>> {
+    let prefix =
+        format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_r2_integration_storage(prefix)?;
+    do_test_expire_and_garbage_collect(storage).await
+}
+
+#[tokio::test]
+#[ignore = "needs credentials from env"]
+pub async fn test_expire_and_garbage_collect_in_tigris()
+-> Result<(), Box<dyn std::error::Error>> {
+    let prefix =
+        format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
+    let storage: Arc<dyn Storage + Send + Sync> =
+        common::make_tigris_integration_storage(prefix)?;
+    do_test_expire_and_garbage_collect(storage).await
+}
+
 /// In this test, we set up a repo as in the design document for expiration.
 ///
 /// We then, expire old snapshots and garbage collect. We verify we end up
 /// with what is expected according to the design document.
-pub async fn test_expire_and_garbage_collect() -> Result<(), Box<dyn std::error::Error>> {
-    let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+pub async fn do_test_expire_and_garbage_collect(
+    storage: Arc<dyn Storage + Send + Sync>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let storage_settings = storage.default_settings();
     let mut repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
 

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -130,14 +130,14 @@ where
         f("AWS", s6).await?;
     }
     if env::var("R2_BUCKET").is_ok() {
-        let s6 = common::make_r2_integration_storage(prefix.clone())?;
+        let s7 = common::make_r2_integration_storage(prefix.clone())?;
         println!("Using R2 storage");
-        f("R2", s6).await?;
+        f("R2", s7).await?;
     }
     if env::var("TIGRIS_BUCKET").is_ok() {
-        let s7 = common::make_tigris_integration_storage(prefix.clone())?;
+        let s8 = common::make_tigris_integration_storage(prefix.clone())?;
         println!("Using Tigris storage");
-        f("Tigris", s7).await?;
+        f("Tigris", s8).await?;
     }
 
     Ok(())

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    env,
     future::Future,
     sync::Arc,
 };
@@ -23,6 +24,8 @@ use object_store::azure::AzureConfigKey;
 use pretty_assertions::{assert_eq, assert_ne};
 use tempfile::tempdir;
 use tokio::io::AsyncReadExt;
+
+mod common;
 
 #[allow(clippy::expect_used)]
 async fn mk_s3_storage(prefix: &str) -> StorageResult<Arc<dyn Storage + Send + Sync>> {
@@ -120,6 +123,23 @@ where
     f("s3_object_store", s3).await?;
     println!("Using azure_blob storage");
     f("azure_blob", s4).await?;
+
+    if env::var("AWS_BUCKET").is_ok() {
+        let s6 = common::make_aws_integration_storage(prefix.clone())?;
+        println!("Using AWS storage");
+        f("AWS", s6).await?;
+    }
+    if env::var("R2_BUCKET").is_ok() {
+        let s6 = common::make_r2_integration_storage(prefix.clone())?;
+        println!("Using R2 storage");
+        f("R2", s6).await?;
+    }
+    if env::var("TIGRIS_BUCKET").is_ok() {
+        let s7 = common::make_tigris_integration_storage(prefix.clone())?;
+        println!("Using Tigris storage");
+        f("Tigris", s7).await?;
+    }
+
     Ok(())
 }
 

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -1,149 +1,644 @@
-#[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used, clippy::expect_fun_call)]
-mod tests {
-    use futures::TryStreamExt;
-    use icechunk::{
-        ObjectStoreConfig, Repository, RepositoryConfig, Storage, Store,
-        config::{Credentials, S3Credentials, S3Options, S3StaticCredentials},
-        format::{
-            ByteRange, ChunkId, ChunkIndices, Path,
-            manifest::{
-                Checksum, ChunkPayload, SecondsSinceEpoch, VirtualChunkLocation,
-                VirtualChunkRef, VirtualReferenceErrorKind,
-            },
-            snapshot::ArrayShape,
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::expect_fun_call
+)]
+use futures::TryStreamExt;
+use icechunk::{
+    ObjectStoreConfig, Repository, RepositoryConfig, Storage, Store,
+    config::{Credentials, S3Credentials, S3Options, S3StaticCredentials},
+    format::{
+        ByteRange, ChunkId, ChunkIndices, Path,
+        manifest::{
+            Checksum, ChunkPayload, SecondsSinceEpoch, VirtualChunkLocation,
+            VirtualChunkRef, VirtualReferenceErrorKind,
         },
-        repository::VersionInfo,
-        session::{SessionErrorKind, get_chunk},
-        storage::{
-            self, ConcurrencySettings, ETag, ObjectStorage, new_s3_storage, s3::mk_client,
-        },
-        store::{StoreError, StoreErrorKind},
-        virtual_chunks::VirtualChunkContainer,
-    };
-    use std::{
-        collections::{HashMap, HashSet},
-        error::Error,
-        path::PathBuf,
-        vec,
-    };
-    use std::{path::Path as StdPath, sync::Arc};
-    use tempfile::TempDir;
-    use tokio::sync::RwLock;
+        snapshot::ArrayShape,
+    },
+    repository::VersionInfo,
+    session::{SessionErrorKind, get_chunk},
+    storage::{
+        self, ConcurrencySettings, ETag, ObjectStorage, new_s3_storage, s3::mk_client,
+    },
+    store::{StoreError, StoreErrorKind},
+    virtual_chunks::VirtualChunkContainer,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    path::PathBuf,
+    vec,
+};
+use std::{path::Path as StdPath, sync::Arc};
+use tempfile::TempDir;
+use tokio::sync::RwLock;
 
-    use bytes::Bytes;
-    use object_store::{
-        ObjectStore, PutMode, PutOptions, PutPayload, local::LocalFileSystem,
-    };
-    use pretty_assertions::assert_eq;
+use bytes::Bytes;
+use object_store::{
+    ObjectStore, PutMode, PutOptions, PutPayload, local::LocalFileSystem,
+};
+use pretty_assertions::assert_eq;
 
-    fn minio_s3_config() -> (S3Options, S3Credentials) {
-        let config = S3Options {
-            region: Some("us-east-1".to_string()),
-            endpoint_url: Some("http://localhost:9000".to_string()),
-            allow_http: true,
-            anonymous: false,
-            force_path_style: true,
-        };
-        let credentials = S3Credentials::Static(S3StaticCredentials {
-            access_key_id: "minio123".into(),
-            secret_access_key: "minio123".into(),
-            session_token: None,
-            expires_after: None,
-        });
-        (config, credentials)
+fn minio_s3_config() -> (S3Options, S3Credentials) {
+    let config = S3Options {
+        region: Some("us-east-1".to_string()),
+        endpoint_url: Some("http://localhost:9000".to_string()),
+        allow_http: true,
+        anonymous: false,
+        force_path_style: true,
+    };
+    let credentials = S3Credentials::Static(S3StaticCredentials {
+        access_key_id: "minio123".into(),
+        secret_access_key: "minio123".into(),
+        session_token: None,
+        expires_after: None,
+    });
+    (config, credentials)
+}
+
+async fn create_repository(
+    storage: Arc<dyn Storage + Send + Sync>,
+    virtual_chunk_containers: Vec<VirtualChunkContainer>,
+    s3_credentials: Option<S3Credentials>,
+) -> Repository {
+    let mut creds = HashMap::new();
+    if let Some(s3_credentials) = s3_credentials {
+        creds.insert("s3".to_string(), Credentials::S3(s3_credentials));
     }
 
-    async fn create_repository(
-        storage: Arc<dyn Storage + Send + Sync>,
-        virtual_chunk_containers: Vec<VirtualChunkContainer>,
-        s3_credentials: Option<S3Credentials>,
-    ) -> Repository {
-        let mut creds = HashMap::new();
-        if let Some(s3_credentials) = s3_credentials {
-            creds.insert("s3".to_string(), Credentials::S3(s3_credentials));
-        }
+    let virtual_chunk_containers = virtual_chunk_containers
+        .into_iter()
+        .map(|cont| (cont.name.clone(), cont))
+        .collect();
 
-        let virtual_chunk_containers = virtual_chunk_containers
-            .into_iter()
-            .map(|cont| (cont.name.clone(), cont))
-            .collect();
+    Repository::create(
+        Some(RepositoryConfig {
+            virtual_chunk_containers: Some(virtual_chunk_containers),
+            ..Default::default()
+        }),
+        storage,
+        creds,
+    )
+    .await
+    .expect("Failed to initialize repository")
+}
 
-        Repository::create(
-            Some(RepositoryConfig {
-                virtual_chunk_containers: Some(virtual_chunk_containers),
-                ..Default::default()
+async fn write_chunks_to_store(
+    store: impl ObjectStore,
+    chunks: impl Iterator<Item = (String, Bytes)>,
+) {
+    // TODO: Switch to PutMode::Create when object_store supports that
+    let opts = PutOptions { mode: PutMode::Overwrite, ..PutOptions::default() };
+
+    for (path, bytes) in chunks {
+        store
+            .put_opts(
+                &path.clone().into(),
+                PutPayload::from_bytes(bytes.clone()),
+                opts.clone(),
+            )
+            .await
+            .expect(&format!("putting chunk to {} failed", &path));
+    }
+}
+async fn create_local_repository(path: &StdPath) -> Repository {
+    let storage: Arc<dyn Storage + Send + Sync> = Arc::new(
+        ObjectStorage::new_local_filesystem(path)
+            .await
+            .expect("Creating local storage failed"),
+    );
+
+    let containers = vec![
+        VirtualChunkContainer {
+            name: "file".to_string(),
+            url_prefix: "file://".to_string(),
+            store: ObjectStoreConfig::LocalFileSystem(PathBuf::new()),
+        },
+        VirtualChunkContainer {
+            name: "s3".to_string(),
+            url_prefix: "s3://".to_string(),
+            store: ObjectStoreConfig::S3(S3Options {
+                region: Some("us-east-1".to_string()),
+                endpoint_url: None,
+                anonymous: true,
+                allow_http: false,
+                force_path_style: false,
             }),
-            storage,
-            creds,
+        },
+        VirtualChunkContainer {
+            name: "gcs".to_string(),
+            url_prefix: "gcs://".to_string(),
+            store: ObjectStoreConfig::Gcs(Default::default()),
+        },
+    ];
+    create_repository(storage, containers, None).await
+}
+
+async fn create_minio_repository() -> Repository {
+    let prefix = format!("{:?}", ChunkId::random());
+    let (config, credentials) = minio_s3_config();
+    let storage: Arc<dyn Storage + Send + Sync> =
+        new_s3_storage(config, "testbucket".to_string(), Some(prefix), Some(credentials))
+            .expect("Creating minio storage failed");
+
+    let containers = vec![VirtualChunkContainer {
+        name: "s3".to_string(),
+        url_prefix: "s3://".to_string(),
+        store: ObjectStoreConfig::S3Compatible(S3Options {
+            region: Some(String::from("us-east-1")),
+            endpoint_url: Some("http://localhost:9000".to_string()),
+            anonymous: false,
+            allow_http: true,
+            force_path_style: true,
+        }),
+    }];
+
+    let credentials = S3Credentials::Static(S3StaticCredentials {
+        access_key_id: "minio123".to_string(),
+        secret_access_key: "minio123".to_string(),
+        session_token: None,
+        expires_after: None,
+    });
+
+    create_repository(storage, containers, Some(credentials)).await
+}
+
+async fn write_chunks_to_local_fs(chunks: impl Iterator<Item = (String, Bytes)>) {
+    let store =
+        LocalFileSystem::new_with_prefix("/").expect("Failed to create local store");
+    write_chunks_to_store(store, chunks).await;
+}
+
+async fn write_chunks_to_minio(chunks: impl Iterator<Item = (String, Bytes)>) {
+    let (opts, creds) = minio_s3_config();
+    let client = mk_client(&opts, creds, Vec::new(), Vec::new()).await;
+
+    let bucket_name = "testbucket".to_string();
+    for (key, bytes) in chunks {
+        client
+            .put_object()
+            .bucket(bucket_name.clone())
+            .key(key)
+            .body(bytes.into())
+            .send()
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_repository_with_local_virtual_refs() -> Result<(), Box<dyn Error>> {
+    let chunk_dir = TempDir::new()?;
+    let chunk_1 = chunk_dir.path().join("chunk-1").to_str().unwrap().to_owned();
+    let chunk_2 = chunk_dir.path().join("chunk-2").to_str().unwrap().to_owned();
+
+    let bytes1 = Bytes::copy_from_slice(b"first");
+    let bytes2 = Bytes::copy_from_slice(b"second0000");
+    let chunks = [(chunk_1, bytes1.clone()), (chunk_2, bytes2.clone())];
+    write_chunks_to_local_fs(chunks.iter().cloned()).await;
+
+    let repo_dir = TempDir::new()?;
+    let repo = create_local_repository(repo_dir.path()).await;
+    let mut ds = repo.writable_session("main").await.unwrap();
+
+    let shape = ArrayShape::new(vec![(1, 1), (1, 1), (2, 1)]).unwrap();
+    let user_data = Bytes::new();
+    let payload1 = ChunkPayload::Virtual(VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            // intentional extra '/'
+            "file://{}",
+            chunks[0].0
+        ))?,
+        offset: 0,
+        length: 5,
+        checksum: None,
+    });
+    let payload2 = ChunkPayload::Virtual(VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "file://{}",
+            chunks[1].0,
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: None,
+    });
+
+    let new_array_path: Path = "/array".try_into().unwrap();
+    ds.add_array(new_array_path.clone(), shape, None, user_data).await.unwrap();
+
+    ds.set_chunk_ref(new_array_path.clone(), ChunkIndices(vec![0, 0, 0]), Some(payload1))
+        .await
+        .unwrap();
+    ds.set_chunk_ref(new_array_path.clone(), ChunkIndices(vec![0, 0, 1]), Some(payload2))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        get_chunk(
+            ds.get_chunk_reader(
+                &new_array_path,
+                &ChunkIndices(vec![0, 0, 0]),
+                &ByteRange::ALL
+            )
+            .await
+            .unwrap()
         )
         .await
-        .expect("Failed to initialize repository")
-    }
+        .unwrap(),
+        Some(bytes1.clone()),
+    );
+    assert_eq!(
+        get_chunk(
+            ds.get_chunk_reader(
+                &new_array_path,
+                &ChunkIndices(vec![0, 0, 1]),
+                &ByteRange::ALL
+            )
+            .await
+            .unwrap()
+        )
+        .await
+        .unwrap(),
+        Some(Bytes::copy_from_slice(&bytes2[1..6])),
+    );
 
-    async fn write_chunks_to_store(
-        store: impl ObjectStore,
-        chunks: impl Iterator<Item = (String, Bytes)>,
-    ) {
-        // TODO: Switch to PutMode::Create when object_store supports that
-        let opts = PutOptions { mode: PutMode::Overwrite, ..PutOptions::default() };
-
-        for (path, bytes) in chunks {
-            store
-                .put_opts(
-                    &path.clone().into(),
-                    PutPayload::from_bytes(bytes.clone()),
-                    opts.clone(),
+    for range in [
+        ByteRange::bounded(0u64, 3u64),
+        ByteRange::from_offset(2u64),
+        ByteRange::to_offset(4u64),
+    ] {
+        assert_eq!(
+            get_chunk(
+                ds.get_chunk_reader(
+                    &new_array_path,
+                    &ChunkIndices(vec![0, 0, 0]),
+                    &range
                 )
                 .await
-                .expect(&format!("putting chunk to {} failed", &path));
-        }
-    }
-    async fn create_local_repository(path: &StdPath) -> Repository {
-        let storage: Arc<dyn Storage + Send + Sync> = Arc::new(
-            ObjectStorage::new_local_filesystem(path)
-                .await
-                .expect("Creating local storage failed"),
+                .unwrap()
+            )
+            .await
+            .unwrap(),
+            Some(range.slice(bytes1.clone()))
         );
+    }
+    Ok(())
+}
 
-        let containers = vec![
-            VirtualChunkContainer {
-                name: "file".to_string(),
-                url_prefix: "file://".to_string(),
-                store: ObjectStoreConfig::LocalFileSystem(PathBuf::new()),
-            },
-            VirtualChunkContainer {
-                name: "s3".to_string(),
-                url_prefix: "s3://".to_string(),
-                store: ObjectStoreConfig::S3(S3Options {
-                    region: Some("us-east-1".to_string()),
-                    endpoint_url: None,
-                    anonymous: true,
-                    allow_http: false,
-                    force_path_style: false,
-                }),
-            },
-            VirtualChunkContainer {
-                name: "gcs".to_string(),
-                url_prefix: "gcs://".to_string(),
-                store: ObjectStoreConfig::Gcs(Default::default()),
-            },
-        ];
-        create_repository(storage, containers, None).await
+#[tokio::test(flavor = "multi_thread")]
+async fn test_repository_with_minio_virtual_refs() -> Result<(), Box<dyn Error>> {
+    let bytes1 = Bytes::copy_from_slice(b"first");
+    let bytes2 = Bytes::copy_from_slice(b"second0000");
+    let chunks = [
+        ("/path/to/chunk-1".into(), bytes1.clone()),
+        ("/path/to/chunk-2".into(), bytes2.clone()),
+    ];
+    write_chunks_to_minio(chunks.iter().cloned()).await;
+
+    let repo = create_minio_repository().await;
+    let mut ds = repo.writable_session("main").await.unwrap();
+
+    let shape = ArrayShape::new(vec![(1, 1), (1, 1), (2, 1)]).unwrap();
+    let user_data = Bytes::new();
+    let payload1 = ChunkPayload::Virtual(VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            // intentional extra '/'
+            "s3://testbucket///{}",
+            chunks[0].0
+        ))?,
+        offset: 0,
+        length: 5,
+        checksum: None,
+    });
+    let payload2 = ChunkPayload::Virtual(VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "s3://testbucket/{}",
+            chunks[1].0,
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: None,
+    });
+
+    let new_array_path: Path = "/array".try_into().unwrap();
+    ds.add_array(new_array_path.clone(), shape, None, user_data).await.unwrap();
+
+    ds.set_chunk_ref(new_array_path.clone(), ChunkIndices(vec![0, 0, 0]), Some(payload1))
+        .await
+        .unwrap();
+    ds.set_chunk_ref(new_array_path.clone(), ChunkIndices(vec![0, 0, 1]), Some(payload2))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        get_chunk(
+            ds.get_chunk_reader(
+                &new_array_path,
+                &ChunkIndices(vec![0, 0, 0]),
+                &ByteRange::ALL
+            )
+            .await
+            .unwrap()
+        )
+        .await
+        .unwrap(),
+        Some(bytes1.clone()),
+    );
+    assert_eq!(
+        get_chunk(
+            ds.get_chunk_reader(
+                &new_array_path,
+                &ChunkIndices(vec![0, 0, 1]),
+                &ByteRange::ALL
+            )
+            .await
+            .unwrap()
+        )
+        .await
+        .unwrap(),
+        Some(Bytes::copy_from_slice(&bytes2[1..6])),
+    );
+
+    for range in [
+        ByteRange::bounded(0u64, 3u64),
+        ByteRange::from_offset(2u64),
+        ByteRange::to_offset(4u64),
+    ] {
+        assert_eq!(
+            get_chunk(
+                ds.get_chunk_reader(
+                    &new_array_path,
+                    &ChunkIndices(vec![0, 0, 0]),
+                    &range
+                )
+                .await
+                .unwrap()
+            )
+            .await
+            .unwrap(),
+            Some(range.slice(bytes1.clone()))
+        );
     }
 
-    async fn create_minio_repository() -> Repository {
-        let prefix = format!("{:?}", ChunkId::random());
-        let (config, credentials) = minio_s3_config();
-        let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
-            config,
-            "testbucket".to_string(),
-            Some(prefix),
-            Some(credentials),
-        )
-        .expect("Creating minio storage failed");
+    // check if we can fetch the virtual chunks in multiple small requests
+    ds.commit("done", None).await?;
 
-        let containers = vec![VirtualChunkContainer {
+    let mut config = repo.config().clone();
+    config.storage = Some(storage::Settings {
+        concurrency: Some(ConcurrencySettings {
+            max_concurrent_requests_for_object: Some(100.try_into()?),
+            ideal_concurrent_request_size: Some(1.try_into()?),
+        }),
+        ..repo.storage().default_settings()
+    });
+    let repo = repo.reopen(Some(config), None)?;
+    assert_eq!(
+        repo.config()
+            .storage
+            .as_ref()
+            .unwrap()
+            .concurrency
+            .as_ref()
+            .unwrap()
+            .ideal_concurrent_request_size,
+        Some(1.try_into()?)
+    );
+    let session = repo
+        .readonly_session(&VersionInfo::BranchTipRef("main".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        get_chunk(
+            session
+                .get_chunk_reader(
+                    &new_array_path,
+                    &ChunkIndices(vec![0, 0, 0]),
+                    &ByteRange::ALL
+                )
+                .await
+                .unwrap()
+        )
+        .await
+        .unwrap(),
+        Some(bytes1.clone()),
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zarr_store_virtual_refs_minio_set_and_get()
+-> Result<(), Box<dyn std::error::Error>> {
+    let bytes1 = Bytes::copy_from_slice(b"first");
+    let bytes2 = Bytes::copy_from_slice(b"second0000");
+    let chunks = [
+        ("/path/to/chunk-1".into(), bytes1.clone()),
+        ("/path/to/chunk-2".into(), bytes2.clone()),
+    ];
+    write_chunks_to_minio(chunks.iter().cloned()).await;
+
+    let repo = create_minio_repository().await;
+    let ds = repo.writable_session("main").await.unwrap();
+    let store = Store::from_session(Arc::new(RwLock::new(ds))).await;
+
+    store
+        .set(
+            "zarr.json",
+            Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
+        )
+        .await?;
+    let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[2,2,2],"data_type":"int32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1,1,1]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value":0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[{"name":"mytransformer","configuration":{"bar":43}}],"dimension_names":["x","y","t"]}"#);
+    store.set("array/zarr.json", zarr_meta.clone()).await?;
+    assert_eq!(store.get("array/zarr.json", &ByteRange::ALL).await.unwrap(), zarr_meta);
+
+    let ref1 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            // intentional extra '/'
+            "s3://testbucket///{}",
+            chunks[0].0
+        ))?,
+        offset: 0,
+        length: 5,
+        checksum: None,
+    };
+    let ref2 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "s3://testbucket/{}",
+            chunks[1].0
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: None,
+    };
+    store.set_virtual_ref("array/c/0/0/0", ref1, false).await?;
+    store.set_virtual_ref("array/c/0/0/1", ref2, false).await?;
+
+    assert_eq!(store.get("array/c/0/0/0", &ByteRange::ALL).await?, bytes1,);
+    assert_eq!(
+        store.get("array/c/0/0/1", &ByteRange::ALL).await?,
+        Bytes::copy_from_slice(&bytes2[1..6]),
+    );
+
+    // it shouldn't let us write to an non existing virtual chunk container
+    let bad_location = VirtualChunkLocation::from_absolute_path(&format!(
+        "bad-protocol://testbucket/{}",
+        chunks[1].0
+    ))?;
+
+    let bad_ref = VirtualChunkRef {
+        location: bad_location.clone(),
+        offset: 1,
+        length: 5,
+        checksum: None,
+    };
+    assert!(matches!(
+                store.set_virtual_ref("array/c/0/0/0", bad_ref, true).await,
+                Err(StoreError{kind: StoreErrorKind::InvalidVirtualChunkContainer { chunk_location },..}) if chunk_location == bad_location.0));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zarr_store_virtual_refs_from_public_s3()
+-> Result<(), Box<dyn std::error::Error>> {
+    let repo_dir = TempDir::new()?;
+    let repo = create_local_repository(repo_dir.path()).await;
+    let ds = repo.writable_session("main").await.unwrap();
+
+    let store = Store::from_session(Arc::new(RwLock::new(ds))).await;
+
+    store
+        .set(
+            "zarr.json",
+            Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
+        )
+        .await
+        .unwrap();
+
+    let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[72],"data_type":"float32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[72]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value": 0.0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[],"dimension_names":["year"]}"#);
+    store.set("year/zarr.json", zarr_meta.clone()).await.unwrap();
+
+    let ref2 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc",
+        )?,
+        offset: 22306,
+        length: 288,
+        checksum: None,
+    };
+
+    store.set_virtual_ref("year/c/0", ref2, false).await?;
+
+    let chunk = store.get("year/c/0", &ByteRange::ALL).await.unwrap();
+    assert_eq!(chunk.len(), 288);
+
+    let second_year = f32::from_le_bytes(chunk[4..8].try_into().unwrap());
+    assert!(second_year - 2018.0139 < 0.000001);
+
+    let last_year = f32::from_le_bytes(chunk[(288 - 4)..].try_into().unwrap());
+    assert!(last_year - 2018.9861 < 0.000001);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zarr_store_virtual_refs_from_public_gcs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let repo_dir = TempDir::new()?;
+    let repo = create_local_repository(repo_dir.path()).await;
+    let ds = repo.writable_session("main").await.unwrap();
+
+    let store = Store::from_session(Arc::new(RwLock::new(ds))).await;
+
+    store
+        .set(
+            "zarr.json",
+            Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
+        )
+        .await
+        .unwrap();
+
+    let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[72],"data_type":"float32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value": 0.0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[],"dimension_names":["year"]}"#);
+    store.set("year/zarr.json", zarr_meta.clone()).await.unwrap();
+
+    let ref1 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "gcs://earthmover-sample-data/netcdf/test_echam_spectral.nc",
+        )?,
+        offset: 22306,
+        length: 288,
+        checksum: None,
+    };
+
+    let ref2 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "gcs://gcp-public-data-arco-era5/ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/2m_temperature/0.0.0",
+        )?,
+        offset: 223,
+        length: 400,
+        checksum: None,
+    };
+
+    let ref3 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "gcs://gcp-public-data-arco-era5/ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/2m_temperature/1.0.0",
+        )?,
+        offset: 0,
+        length: 100,
+        checksum: None,
+    };
+
+    let ref_expired = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "gcs://earthmover-sample-data/netcdf/test_echam_spectral.nc",
+        )?,
+        offset: 22306,
+        length: 288,
+        checksum: Some(Checksum::LastModified(SecondsSinceEpoch(3600))),
+    };
+    let ref_bad_tag = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "gcs://earthmover-sample-data/netcdf/test_echam_spectral.nc",
+        )?,
+        offset: 22306,
+        length: 288,
+        checksum: Some(Checksum::ETag(ETag("bad".to_string()))),
+    };
+
+    store.set_virtual_ref("year/c/0", ref1, false).await?;
+    store.set_virtual_ref("year/c/1", ref2, false).await?;
+    store.set_virtual_ref("year/c/2", ref3, false).await?;
+    store.set_virtual_ref("year/c/3", ref_expired, false).await?;
+    store.set_virtual_ref("year/c/4", ref_bad_tag, false).await?;
+
+    // FIXME: enable this once object_store can access public buckets without credentials
+    // otherwise we get an error in GHA
+    if false {
+        let chunk = store.get("year/c/0", &ByteRange::ALL).await.unwrap();
+        assert_eq!(chunk.len(), 288);
+        let chunk = store.get("year/c/1", &ByteRange::ALL).await.unwrap();
+        assert_eq!(chunk.len(), 400);
+        let chunk = store.get("year/c/2", &ByteRange::ALL).await.unwrap();
+        assert_eq!(chunk.len(), 100);
+
+        assert!(store.get("year/c/3", &ByteRange::ALL).await.is_err());
+        assert!(store.get("year/c/4", &ByteRange::ALL).await.is_err());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zarr_store_with_multiple_virtual_chunk_containers()
+-> Result<(), Box<dyn std::error::Error>> {
+    // we create a repository with 3 virtual chunk containers: one for minio chunks, one for
+    // local filesystem chunks and one for chunks in a public S3 bucket.
+
+    let prefix = format!("{:?}", ChunkId::random());
+    let (config, credentials) = minio_s3_config();
+    let storage: Arc<dyn Storage + Send + Sync> =
+        new_s3_storage(config, "testbucket".to_string(), Some(prefix), Some(credentials))
+            .expect("Creating minio storage failed");
+
+    let containers = vec![
+        VirtualChunkContainer {
             name: "s3".to_string(),
             url_prefix: "s3://".to_string(),
             store: ObjectStoreConfig::S3Compatible(S3Options {
@@ -153,758 +648,238 @@ mod tests {
                 allow_http: true,
                 force_path_style: true,
             }),
-        }];
+        },
+        VirtualChunkContainer {
+            name: "file".to_string(),
+            url_prefix: "file://".to_string(),
+            store: ObjectStoreConfig::LocalFileSystem(PathBuf::new()),
+        },
+        VirtualChunkContainer {
+            name: "public".to_string(),
+            url_prefix: "s3://earthmover-sample-data".to_string(),
+            store: ObjectStoreConfig::S3(S3Options {
+                region: Some(String::from("us-east-1")),
+                endpoint_url: None,
+                anonymous: true,
+                allow_http: false,
+                force_path_style: false,
+            }),
+        },
+    ];
 
-        let credentials = S3Credentials::Static(S3StaticCredentials {
+    let virtual_creds = HashMap::from([(
+        "s3".to_string(),
+        Credentials::S3(S3Credentials::Static(S3StaticCredentials {
             access_key_id: "minio123".to_string(),
             secret_access_key: "minio123".to_string(),
             session_token: None,
             expires_after: None,
-        });
+        })),
+    )]);
 
-        create_repository(storage, containers, Some(credentials)).await
+    let mut config = RepositoryConfig::default();
+    for container in containers {
+        config.set_virtual_chunk_container(container);
     }
 
-    async fn write_chunks_to_local_fs(chunks: impl Iterator<Item = (String, Bytes)>) {
-        let store =
-            LocalFileSystem::new_with_prefix("/").expect("Failed to create local store");
-        write_chunks_to_store(store, chunks).await;
-    }
+    let repo = Repository::create(Some(config), storage, virtual_creds).await?;
 
-    async fn write_chunks_to_minio(chunks: impl Iterator<Item = (String, Bytes)>) {
-        let (opts, creds) = minio_s3_config();
-        let client = mk_client(&opts, creds, Vec::new(), Vec::new()).await;
+    let old_timestamp = SecondsSinceEpoch(chrono::Utc::now().timestamp() as u32 - 5);
 
-        let bucket_name = "testbucket".to_string();
-        for (key, bytes) in chunks {
-            client
-                .put_object()
-                .bucket(bucket_name.clone())
-                .key(key)
-                .body(bytes.into())
-                .send()
-                .await
-                .unwrap();
-        }
-    }
+    let minio_bytes1 = Bytes::copy_from_slice(b"first");
+    let minio_bytes2 = Bytes::copy_from_slice(b"second0000");
+    let minio_bytes3 = Bytes::copy_from_slice(b"modified");
+    let chunks = [
+        ("/path/to/chunk-1".into(), minio_bytes1.clone()),
+        ("/path/to/chunk-2".into(), minio_bytes2.clone()),
+        ("/path/to/chunk-3".into(), minio_bytes3.clone()),
+    ];
+    write_chunks_to_minio(chunks.iter().cloned()).await;
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_repository_with_local_virtual_refs() -> Result<(), Box<dyn Error>> {
-        let chunk_dir = TempDir::new()?;
-        let chunk_1 = chunk_dir.path().join("chunk-1").to_str().unwrap().to_owned();
-        let chunk_2 = chunk_dir.path().join("chunk-2").to_str().unwrap().to_owned();
+    let session = repo.writable_session("main").await?;
+    let store = Store::from_session(Arc::new(RwLock::new(session))).await;
 
-        let bytes1 = Bytes::copy_from_slice(b"first");
-        let bytes2 = Bytes::copy_from_slice(b"second0000");
-        let chunks = [(chunk_1, bytes1.clone()), (chunk_2, bytes2.clone())];
-        write_chunks_to_local_fs(chunks.iter().cloned()).await;
-
-        let repo_dir = TempDir::new()?;
-        let repo = create_local_repository(repo_dir.path()).await;
-        let mut ds = repo.writable_session("main").await.unwrap();
-
-        let shape = ArrayShape::new(vec![(1, 1), (1, 1), (2, 1)]).unwrap();
-        let user_data = Bytes::new();
-        let payload1 = ChunkPayload::Virtual(VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                // intentional extra '/'
-                "file://{}",
-                chunks[0].0
-            ))?,
-            offset: 0,
-            length: 5,
-            checksum: None,
-        });
-        let payload2 = ChunkPayload::Virtual(VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "file://{}",
-                chunks[1].0,
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: None,
-        });
-
-        let new_array_path: Path = "/array".try_into().unwrap();
-        ds.add_array(new_array_path.clone(), shape, None, user_data).await.unwrap();
-
-        ds.set_chunk_ref(
-            new_array_path.clone(),
-            ChunkIndices(vec![0, 0, 0]),
-            Some(payload1),
+    store
+        .set(
+            "zarr.json",
+            Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
         )
-        .await
-        .unwrap();
-        ds.set_chunk_ref(
-            new_array_path.clone(),
-            ChunkIndices(vec![0, 0, 1]),
-            Some(payload2),
-        )
-        .await
-        .unwrap();
+        .await?;
+    let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[4,4,4],"data_type":"int32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1,1,1]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value":0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[{"name":"mytransformer","configuration":{"bar":43}}],"dimension_names":["x","y","t"]}"#);
+    store.set("array/zarr.json", zarr_meta.clone()).await?;
 
-        assert_eq!(
-            get_chunk(
-                ds.get_chunk_reader(
-                    &new_array_path,
-                    &ChunkIndices(vec![0, 0, 0]),
-                    &ByteRange::ALL
-                )
-                .await
-                .unwrap()
-            )
-            .await
-            .unwrap(),
-            Some(bytes1.clone()),
-        );
-        assert_eq!(
-            get_chunk(
-                ds.get_chunk_reader(
-                    &new_array_path,
-                    &ChunkIndices(vec![0, 0, 1]),
-                    &ByteRange::ALL
-                )
-                .await
-                .unwrap()
-            )
-            .await
-            .unwrap(),
-            Some(Bytes::copy_from_slice(&bytes2[1..6])),
-        );
-
-        for range in [
-            ByteRange::bounded(0u64, 3u64),
-            ByteRange::from_offset(2u64),
-            ByteRange::to_offset(4u64),
-        ] {
-            assert_eq!(
-                get_chunk(
-                    ds.get_chunk_reader(
-                        &new_array_path,
-                        &ChunkIndices(vec![0, 0, 0]),
-                        &range
-                    )
-                    .await
-                    .unwrap()
-                )
-                .await
-                .unwrap(),
-                Some(range.slice(bytes1.clone()))
-            );
-        }
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_repository_with_minio_virtual_refs() -> Result<(), Box<dyn Error>> {
-        let bytes1 = Bytes::copy_from_slice(b"first");
-        let bytes2 = Bytes::copy_from_slice(b"second0000");
-        let chunks = [
-            ("/path/to/chunk-1".into(), bytes1.clone()),
-            ("/path/to/chunk-2".into(), bytes2.clone()),
-        ];
-        write_chunks_to_minio(chunks.iter().cloned()).await;
-
-        let repo = create_minio_repository().await;
-        let mut ds = repo.writable_session("main").await.unwrap();
-
-        let shape = ArrayShape::new(vec![(1, 1), (1, 1), (2, 1)]).unwrap();
-        let user_data = Bytes::new();
-        let payload1 = ChunkPayload::Virtual(VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                // intentional extra '/'
-                "s3://testbucket///{}",
-                chunks[0].0
-            ))?,
-            offset: 0,
-            length: 5,
-            checksum: None,
-        });
-        let payload2 = ChunkPayload::Virtual(VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "s3://testbucket/{}",
-                chunks[1].0,
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: None,
-        });
-
-        let new_array_path: Path = "/array".try_into().unwrap();
-        ds.add_array(new_array_path.clone(), shape, None, user_data).await.unwrap();
-
-        ds.set_chunk_ref(
-            new_array_path.clone(),
-            ChunkIndices(vec![0, 0, 0]),
-            Some(payload1),
-        )
-        .await
-        .unwrap();
-        ds.set_chunk_ref(
-            new_array_path.clone(),
-            ChunkIndices(vec![0, 0, 1]),
-            Some(payload2),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            get_chunk(
-                ds.get_chunk_reader(
-                    &new_array_path,
-                    &ChunkIndices(vec![0, 0, 0]),
-                    &ByteRange::ALL
-                )
-                .await
-                .unwrap()
-            )
-            .await
-            .unwrap(),
-            Some(bytes1.clone()),
-        );
-        assert_eq!(
-            get_chunk(
-                ds.get_chunk_reader(
-                    &new_array_path,
-                    &ChunkIndices(vec![0, 0, 1]),
-                    &ByteRange::ALL
-                )
-                .await
-                .unwrap()
-            )
-            .await
-            .unwrap(),
-            Some(Bytes::copy_from_slice(&bytes2[1..6])),
-        );
-
-        for range in [
-            ByteRange::bounded(0u64, 3u64),
-            ByteRange::from_offset(2u64),
-            ByteRange::to_offset(4u64),
-        ] {
-            assert_eq!(
-                get_chunk(
-                    ds.get_chunk_reader(
-                        &new_array_path,
-                        &ChunkIndices(vec![0, 0, 0]),
-                        &range
-                    )
-                    .await
-                    .unwrap()
-                )
-                .await
-                .unwrap(),
-                Some(range.slice(bytes1.clone()))
-            );
-        }
-
-        // check if we can fetch the virtual chunks in multiple small requests
-        ds.commit("done", None).await?;
-
-        let mut config = repo.config().clone();
-        config.storage = Some(storage::Settings {
-            concurrency: Some(ConcurrencySettings {
-                max_concurrent_requests_for_object: Some(100.try_into()?),
-                ideal_concurrent_request_size: Some(1.try_into()?),
-            }),
-            ..repo.storage().default_settings()
-        });
-        let repo = repo.reopen(Some(config), None)?;
-        assert_eq!(
-            repo.config()
-                .storage
-                .as_ref()
-                .unwrap()
-                .concurrency
-                .as_ref()
-                .unwrap()
-                .ideal_concurrent_request_size,
-            Some(1.try_into()?)
-        );
-        let session = repo
-            .readonly_session(&VersionInfo::BranchTipRef("main".to_string()))
-            .await
-            .unwrap();
-        assert_eq!(
-            get_chunk(
-                session
-                    .get_chunk_reader(
-                        &new_array_path,
-                        &ChunkIndices(vec![0, 0, 0]),
-                        &ByteRange::ALL
-                    )
-                    .await
-                    .unwrap()
-            )
-            .await
-            .unwrap(),
-            Some(bytes1.clone()),
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_zarr_store_virtual_refs_minio_set_and_get()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let bytes1 = Bytes::copy_from_slice(b"first");
-        let bytes2 = Bytes::copy_from_slice(b"second0000");
-        let chunks = [
-            ("/path/to/chunk-1".into(), bytes1.clone()),
-            ("/path/to/chunk-2".into(), bytes2.clone()),
-        ];
-        write_chunks_to_minio(chunks.iter().cloned()).await;
-
-        let repo = create_minio_repository().await;
-        let ds = repo.writable_session("main").await.unwrap();
-        let store = Store::from_session(Arc::new(RwLock::new(ds))).await;
-
-        store
-            .set(
-                "zarr.json",
-                Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
-            )
-            .await?;
-        let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[2,2,2],"data_type":"int32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1,1,1]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value":0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[{"name":"mytransformer","configuration":{"bar":43}}],"dimension_names":["x","y","t"]}"#);
-        store.set("array/zarr.json", zarr_meta.clone()).await?;
-        assert_eq!(
-            store.get("array/zarr.json", &ByteRange::ALL).await.unwrap(),
-            zarr_meta
-        );
-
-        let ref1 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                // intentional extra '/'
-                "s3://testbucket///{}",
-                chunks[0].0
-            ))?,
-            offset: 0,
-            length: 5,
-            checksum: None,
-        };
-        let ref2 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "s3://testbucket/{}",
-                chunks[1].0
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: None,
-        };
-        store.set_virtual_ref("array/c/0/0/0", ref1, false).await?;
-        store.set_virtual_ref("array/c/0/0/1", ref2, false).await?;
-
-        assert_eq!(store.get("array/c/0/0/0", &ByteRange::ALL).await?, bytes1,);
-        assert_eq!(
-            store.get("array/c/0/0/1", &ByteRange::ALL).await?,
-            Bytes::copy_from_slice(&bytes2[1..6]),
-        );
-
-        // it shouldn't let us write to an non existing virtual chunk container
-        let bad_location = VirtualChunkLocation::from_absolute_path(&format!(
-            "bad-protocol://testbucket/{}",
+    // set virtual refs in minio
+    let ref1 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            // intentional extra '/'
+            "s3://testbucket///{}",
+            chunks[0].0
+        ))?,
+        offset: 0,
+        length: 5,
+        checksum: None,
+    };
+    let ref2 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "s3://testbucket/{}",
             chunks[1].0
-        ))?;
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: None,
+    };
+    let ref3 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "s3://testbucket/{}",
+            chunks[2].0
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: Some(Checksum::LastModified(old_timestamp)),
+    };
+    store.set_virtual_ref("array/c/0/0/0", ref1, false).await?;
+    store.set_virtual_ref("array/c/0/0/1", ref2, false).await?;
+    store.set_virtual_ref("array/c/1/0/0", ref3, false).await?;
 
-        let bad_ref = VirtualChunkRef {
-            location: bad_location.clone(),
-            offset: 1,
-            length: 5,
-            checksum: None,
-        };
-        assert!(matches!(
-                store.set_virtual_ref("array/c/0/0/0", bad_ref, true).await,
-                Err(StoreError{kind: StoreErrorKind::InvalidVirtualChunkContainer { chunk_location },..}) if chunk_location == bad_location.0));
-        Ok(())
-    }
+    // set virtual refs in local filesystem
+    let chunk_dir = TempDir::new()?;
+    let chunk_1 = chunk_dir.path().join("chunk-1").to_str().unwrap().to_owned();
+    let chunk_2 = chunk_dir.path().join("chunk-2").to_str().unwrap().to_owned();
+    let chunk_3 = chunk_dir.path().join("chunk-3").to_str().unwrap().to_owned();
 
-    #[tokio::test]
-    async fn test_zarr_store_virtual_refs_from_public_s3()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let repo_dir = TempDir::new()?;
-        let repo = create_local_repository(repo_dir.path()).await;
-        let ds = repo.writable_session("main").await.unwrap();
+    let local_bytes1 = Bytes::copy_from_slice(b"first");
+    let local_bytes2 = Bytes::copy_from_slice(b"second0000");
+    let local_bytes3 = Bytes::copy_from_slice(b"modified");
+    let local_chunks = [
+        (chunk_1, local_bytes1.clone()),
+        (chunk_2, local_bytes2.clone()),
+        (chunk_3, local_bytes3.clone()),
+    ];
+    write_chunks_to_local_fs(local_chunks.iter().cloned()).await;
 
-        let store = Store::from_session(Arc::new(RwLock::new(ds))).await;
+    let ref1 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            // intentional extra '/'
+            "file://{}",
+            local_chunks[0].0
+        ))?,
+        offset: 0,
+        length: 5,
+        checksum: None,
+    };
+    let ref2 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "file://{}",
+            local_chunks[1].0,
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: None,
+    };
+    let ref3 = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(&format!(
+            "file://{}",
+            local_chunks[2].0,
+        ))?,
+        offset: 1,
+        length: 5,
+        checksum: Some(Checksum::ETag(ETag(String::from("invalid etag")))),
+    };
 
-        store
-            .set(
-                "zarr.json",
-                Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
-            )
-            .await
-            .unwrap();
+    store.set_virtual_ref("array/c/0/0/2", ref1, false).await?;
+    store.set_virtual_ref("array/c/0/0/3", ref2, false).await?;
+    store.set_virtual_ref("array/c/1/0/1", ref3, false).await?;
 
-        let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[72],"data_type":"float32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[72]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value": 0.0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[],"dimension_names":["year"]}"#);
-        store.set("year/zarr.json", zarr_meta.clone()).await.unwrap();
+    // set a virtual ref in a public bucket
+    let public_ref = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc",
+        )?,
+        offset: 22306,
+        length: 288,
+        checksum: None,
+    };
+    let public_modified_ref = VirtualChunkRef {
+        location: VirtualChunkLocation::from_absolute_path(
+            "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc",
+        )?,
+        offset: 22306,
+        length: 288,
+        checksum: Some(Checksum::ETag(ETag(String::from("invalid etag")))),
+    };
 
-        let ref2 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc",
-            )?,
-            offset: 22306,
-            length: 288,
-            checksum: None,
-        };
+    store.set_virtual_ref("array/c/1/1/1", public_ref, false).await?;
+    store.set_virtual_ref("array/c/1/1/2", public_modified_ref, false).await?;
 
-        store.set_virtual_ref("year/c/0", ref2, false).await?;
+    // assert we can find all the virtual chunks
 
-        let chunk = store.get("year/c/0", &ByteRange::ALL).await.unwrap();
-        assert_eq!(chunk.len(), 288);
+    // these are the minio chunks
+    assert_eq!(store.get("array/c/0/0/0", &ByteRange::ALL).await?, minio_bytes1,);
+    assert_eq!(
+        store.get("array/c/0/0/1", &ByteRange::ALL).await?,
+        Bytes::copy_from_slice(&minio_bytes2[1..6]),
+    );
+    // try to fetch the modified chunk
+    assert!(matches!(
+        store.get("array/c/1/0/0", &ByteRange::ALL).await,
+        Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::VirtualReferenceError(
+            VirtualReferenceErrorKind::ObjectModified(location)
+        )),..}) if location == "s3://testbucket/path/to/chunk-3"
+    ));
 
-        let second_year = f32::from_le_bytes(chunk[4..8].try_into().unwrap());
-        assert!(second_year - 2018.0139 < 0.000001);
+    // these are the local file chunks
+    assert_eq!(store.get("array/c/0/0/2", &ByteRange::ALL).await?, local_bytes1,);
+    assert_eq!(
+        store.get("array/c/0/0/3", &ByteRange::ALL).await?,
+        Bytes::copy_from_slice(&local_bytes2[1..6]),
+    );
+    // try to fetch the modified chunk
+    assert!(matches!(
+        store.get("array/c/1/0/1", &ByteRange::ALL).await,
+        Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::VirtualReferenceError(
+            VirtualReferenceErrorKind::ObjectModified(location)
+        )),..}) if location.contains("chunk-3")
+    ));
 
-        let last_year = f32::from_le_bytes(chunk[(288 - 4)..].try_into().unwrap());
-        assert!(last_year - 2018.9861 < 0.000001);
-        Ok(())
-    }
+    // these are the public bucket chunks
+    let chunk = store.get("array/c/1/1/1", &ByteRange::ALL).await.unwrap();
+    assert_eq!(chunk.len(), 288);
 
-    #[tokio::test]
-    async fn test_zarr_store_virtual_refs_from_public_gcs()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let repo_dir = TempDir::new()?;
-        let repo = create_local_repository(repo_dir.path()).await;
-        let ds = repo.writable_session("main").await.unwrap();
+    let second_year = f32::from_le_bytes(chunk[4..8].try_into().unwrap());
+    assert!(second_year - 2018.0139 < 0.000001);
 
-        let store = Store::from_session(Arc::new(RwLock::new(ds))).await;
+    let last_year = f32::from_le_bytes(chunk[(288 - 4)..].try_into().unwrap());
+    assert!(last_year - 2018.9861 < 0.000001);
 
-        store
-            .set(
-                "zarr.json",
-                Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
-            )
-            .await
-            .unwrap();
+    // try to fetch the modified chunk
+    assert!(matches!(
+        store.get("array/c/1/1/2", &ByteRange::ALL).await,
+        Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::VirtualReferenceError(
+            VirtualReferenceErrorKind::ObjectModified(location)
+        )),..}) if location == "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc"
+    ));
 
-        let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[72],"data_type":"float32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value": 0.0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[],"dimension_names":["year"]}"#);
-        store.set("year/zarr.json", zarr_meta.clone()).await.unwrap();
+    let session = store.session();
+    let locations = session
+        .read()
+        .await
+        .all_virtual_chunk_locations()
+        .await?
+        .try_collect::<HashSet<_>>()
+        .await?;
+    assert_eq!(
+        locations,
+        [
+            "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc".to_string(),
+            "s3://testbucket/path/to/chunk-1".to_string(),
+            "s3://testbucket/path/to/chunk-2".to_string(),
+            "s3://testbucket/path/to/chunk-3".to_string(),
+            format!("file://{}", local_chunks[0].0),
+            format!("file://{}", local_chunks[1].0),
+            format!("file://{}", local_chunks[2].0),
+        ]
+        .into()
+    );
 
-        let ref1 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "gcs://earthmover-sample-data/netcdf/test_echam_spectral.nc",
-            )?,
-            offset: 22306,
-            length: 288,
-            checksum: None,
-        };
-
-        let ref2 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "gcs://gcp-public-data-arco-era5/ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/2m_temperature/0.0.0",
-            )?,
-            offset: 223,
-            length: 400,
-            checksum: None,
-        };
-
-        let ref3 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "gcs://gcp-public-data-arco-era5/ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/2m_temperature/1.0.0",
-            )?,
-            offset: 0,
-            length: 100,
-            checksum: None,
-        };
-
-        let ref_expired = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "gcs://earthmover-sample-data/netcdf/test_echam_spectral.nc",
-            )?,
-            offset: 22306,
-            length: 288,
-            checksum: Some(Checksum::LastModified(SecondsSinceEpoch(3600))),
-        };
-        let ref_bad_tag = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "gcs://earthmover-sample-data/netcdf/test_echam_spectral.nc",
-            )?,
-            offset: 22306,
-            length: 288,
-            checksum: Some(Checksum::ETag(ETag("bad".to_string()))),
-        };
-
-        store.set_virtual_ref("year/c/0", ref1, false).await?;
-        store.set_virtual_ref("year/c/1", ref2, false).await?;
-        store.set_virtual_ref("year/c/2", ref3, false).await?;
-        store.set_virtual_ref("year/c/3", ref_expired, false).await?;
-        store.set_virtual_ref("year/c/4", ref_bad_tag, false).await?;
-
-        // FIXME: enable this once object_store can access public buckets without credentials
-        // otherwise we get an error in GHA
-        if false {
-            let chunk = store.get("year/c/0", &ByteRange::ALL).await.unwrap();
-            assert_eq!(chunk.len(), 288);
-            let chunk = store.get("year/c/1", &ByteRange::ALL).await.unwrap();
-            assert_eq!(chunk.len(), 400);
-            let chunk = store.get("year/c/2", &ByteRange::ALL).await.unwrap();
-            assert_eq!(chunk.len(), 100);
-
-            assert!(store.get("year/c/3", &ByteRange::ALL).await.is_err());
-            assert!(store.get("year/c/4", &ByteRange::ALL).await.is_err());
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_zarr_store_with_multiple_virtual_chunk_containers()
-    -> Result<(), Box<dyn std::error::Error>> {
-        // we create a repository with 3 virtual chunk containers: one for minio chunks, one for
-        // local filesystem chunks and one for chunks in a public S3 bucket.
-
-        let prefix = format!("{:?}", ChunkId::random());
-        let (config, credentials) = minio_s3_config();
-        let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
-            config,
-            "testbucket".to_string(),
-            Some(prefix),
-            Some(credentials),
-        )
-        .expect("Creating minio storage failed");
-
-        let containers = vec![
-            VirtualChunkContainer {
-                name: "s3".to_string(),
-                url_prefix: "s3://".to_string(),
-                store: ObjectStoreConfig::S3Compatible(S3Options {
-                    region: Some(String::from("us-east-1")),
-                    endpoint_url: Some("http://localhost:9000".to_string()),
-                    anonymous: false,
-                    allow_http: true,
-                    force_path_style: true,
-                }),
-            },
-            VirtualChunkContainer {
-                name: "file".to_string(),
-                url_prefix: "file://".to_string(),
-                store: ObjectStoreConfig::LocalFileSystem(PathBuf::new()),
-            },
-            VirtualChunkContainer {
-                name: "public".to_string(),
-                url_prefix: "s3://earthmover-sample-data".to_string(),
-                store: ObjectStoreConfig::S3(S3Options {
-                    region: Some(String::from("us-east-1")),
-                    endpoint_url: None,
-                    anonymous: true,
-                    allow_http: false,
-                    force_path_style: false,
-                }),
-            },
-        ];
-
-        let virtual_creds = HashMap::from([(
-            "s3".to_string(),
-            Credentials::S3(S3Credentials::Static(S3StaticCredentials {
-                access_key_id: "minio123".to_string(),
-                secret_access_key: "minio123".to_string(),
-                session_token: None,
-                expires_after: None,
-            })),
-        )]);
-
-        let mut config = RepositoryConfig::default();
-        for container in containers {
-            config.set_virtual_chunk_container(container);
-        }
-
-        let repo = Repository::create(Some(config), storage, virtual_creds).await?;
-
-        let old_timestamp = SecondsSinceEpoch(chrono::Utc::now().timestamp() as u32 - 5);
-
-        let minio_bytes1 = Bytes::copy_from_slice(b"first");
-        let minio_bytes2 = Bytes::copy_from_slice(b"second0000");
-        let minio_bytes3 = Bytes::copy_from_slice(b"modified");
-        let chunks = [
-            ("/path/to/chunk-1".into(), minio_bytes1.clone()),
-            ("/path/to/chunk-2".into(), minio_bytes2.clone()),
-            ("/path/to/chunk-3".into(), minio_bytes3.clone()),
-        ];
-        write_chunks_to_minio(chunks.iter().cloned()).await;
-
-        let session = repo.writable_session("main").await?;
-        let store = Store::from_session(Arc::new(RwLock::new(session))).await;
-
-        store
-            .set(
-                "zarr.json",
-                Bytes::copy_from_slice(br#"{"zarr_format":3, "node_type":"group"}"#),
-            )
-            .await?;
-        let zarr_meta = Bytes::copy_from_slice(br#"{"zarr_format":3,"node_type":"array","attributes":{"foo":42},"shape":[4,4,4],"data_type":"int32","chunk_grid":{"name":"regular","configuration":{"chunk_shape":[1,1,1]}},"chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},"fill_value":0,"codecs":[{"name":"mycodec","configuration":{"foo":42}}],"storage_transformers":[{"name":"mytransformer","configuration":{"bar":43}}],"dimension_names":["x","y","t"]}"#);
-        store.set("array/zarr.json", zarr_meta.clone()).await?;
-
-        // set virtual refs in minio
-        let ref1 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                // intentional extra '/'
-                "s3://testbucket///{}",
-                chunks[0].0
-            ))?,
-            offset: 0,
-            length: 5,
-            checksum: None,
-        };
-        let ref2 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "s3://testbucket/{}",
-                chunks[1].0
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: None,
-        };
-        let ref3 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "s3://testbucket/{}",
-                chunks[2].0
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: Some(Checksum::LastModified(old_timestamp)),
-        };
-        store.set_virtual_ref("array/c/0/0/0", ref1, false).await?;
-        store.set_virtual_ref("array/c/0/0/1", ref2, false).await?;
-        store.set_virtual_ref("array/c/1/0/0", ref3, false).await?;
-
-        // set virtual refs in local filesystem
-        let chunk_dir = TempDir::new()?;
-        let chunk_1 = chunk_dir.path().join("chunk-1").to_str().unwrap().to_owned();
-        let chunk_2 = chunk_dir.path().join("chunk-2").to_str().unwrap().to_owned();
-        let chunk_3 = chunk_dir.path().join("chunk-3").to_str().unwrap().to_owned();
-
-        let local_bytes1 = Bytes::copy_from_slice(b"first");
-        let local_bytes2 = Bytes::copy_from_slice(b"second0000");
-        let local_bytes3 = Bytes::copy_from_slice(b"modified");
-        let local_chunks = [
-            (chunk_1, local_bytes1.clone()),
-            (chunk_2, local_bytes2.clone()),
-            (chunk_3, local_bytes3.clone()),
-        ];
-        write_chunks_to_local_fs(local_chunks.iter().cloned()).await;
-
-        let ref1 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                // intentional extra '/'
-                "file://{}",
-                local_chunks[0].0
-            ))?,
-            offset: 0,
-            length: 5,
-            checksum: None,
-        };
-        let ref2 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "file://{}",
-                local_chunks[1].0,
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: None,
-        };
-        let ref3 = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(&format!(
-                "file://{}",
-                local_chunks[2].0,
-            ))?,
-            offset: 1,
-            length: 5,
-            checksum: Some(Checksum::ETag(ETag(String::from("invalid etag")))),
-        };
-
-        store.set_virtual_ref("array/c/0/0/2", ref1, false).await?;
-        store.set_virtual_ref("array/c/0/0/3", ref2, false).await?;
-        store.set_virtual_ref("array/c/1/0/1", ref3, false).await?;
-
-        // set a virtual ref in a public bucket
-        let public_ref = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc",
-            )?,
-            offset: 22306,
-            length: 288,
-            checksum: None,
-        };
-        let public_modified_ref = VirtualChunkRef {
-            location: VirtualChunkLocation::from_absolute_path(
-                "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc",
-            )?,
-            offset: 22306,
-            length: 288,
-            checksum: Some(Checksum::ETag(ETag(String::from("invalid etag")))),
-        };
-
-        store.set_virtual_ref("array/c/1/1/1", public_ref, false).await?;
-        store.set_virtual_ref("array/c/1/1/2", public_modified_ref, false).await?;
-
-        // assert we can find all the virtual chunks
-
-        // these are the minio chunks
-        assert_eq!(store.get("array/c/0/0/0", &ByteRange::ALL).await?, minio_bytes1,);
-        assert_eq!(
-            store.get("array/c/0/0/1", &ByteRange::ALL).await?,
-            Bytes::copy_from_slice(&minio_bytes2[1..6]),
-        );
-        // try to fetch the modified chunk
-        assert!(matches!(
-            store.get("array/c/1/0/0", &ByteRange::ALL).await,
-            Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::VirtualReferenceError(
-                VirtualReferenceErrorKind::ObjectModified(location)
-            )),..}) if location == "s3://testbucket/path/to/chunk-3"
-        ));
-
-        // these are the local file chunks
-        assert_eq!(store.get("array/c/0/0/2", &ByteRange::ALL).await?, local_bytes1,);
-        assert_eq!(
-            store.get("array/c/0/0/3", &ByteRange::ALL).await?,
-            Bytes::copy_from_slice(&local_bytes2[1..6]),
-        );
-        // try to fetch the modified chunk
-        assert!(matches!(
-            store.get("array/c/1/0/1", &ByteRange::ALL).await,
-            Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::VirtualReferenceError(
-                VirtualReferenceErrorKind::ObjectModified(location)
-            )),..}) if location.contains("chunk-3")
-        ));
-
-        // these are the public bucket chunks
-        let chunk = store.get("array/c/1/1/1", &ByteRange::ALL).await.unwrap();
-        assert_eq!(chunk.len(), 288);
-
-        let second_year = f32::from_le_bytes(chunk[4..8].try_into().unwrap());
-        assert!(second_year - 2018.0139 < 0.000001);
-
-        let last_year = f32::from_le_bytes(chunk[(288 - 4)..].try_into().unwrap());
-        assert!(last_year - 2018.9861 < 0.000001);
-
-        // try to fetch the modified chunk
-        assert!(matches!(
-            store.get("array/c/1/1/2", &ByteRange::ALL).await,
-            Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::VirtualReferenceError(
-                VirtualReferenceErrorKind::ObjectModified(location)
-            )),..}) if location == "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc"
-        ));
-
-        let session = store.session();
-        let locations = session
-            .read()
-            .await
-            .all_virtual_chunk_locations()
-            .await?
-            .try_collect::<HashSet<_>>()
-            .await?;
-        assert_eq!(
-            locations,
-            [
-                "s3://earthmover-sample-data/netcdf/oscar_vel2018.nc".to_string(),
-                "s3://testbucket/path/to/chunk-1".to_string(),
-                "s3://testbucket/path/to/chunk-2".to_string(),
-                "s3://testbucket/path/to/chunk-3".to_string(),
-                format!("file://{}", local_chunks[0].0),
-                format!("file://{}", local_chunks[1].0),
-                format!("file://{}", local_chunks[2].0),
-            ]
-            .into()
-        );
-
-        Ok(())
-    }
+    Ok(())
 }


### PR DESCRIPTION
We add a set of `ignored` tests that contact the real object stores: S3, R2, Tigris. These tests are the same Rust integration tests we were previously running against in memory or minio storages only.

To enable these tests, run `cargo test --ignored` with the following environment variables set:

- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_BUCKET
- AWS_REGION
- R2_ACCESS_KEY_ID
- R2_SECRET_ACCESS_KEY
- R2_BUCKET
- R2_ACCOUNT_ID
- TIGRIS_ACCESS_KEY_ID
- TIGRIS_SECRET_ACCESS_KEY
- TIGRIS_BUCKET
- TIGRIS_REGION