### PR TITLE
Fix `Diff` python typing

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -872,21 +872,21 @@ class Diff:
         """
         ...
     @property
-    def updated_user_attributes(self) -> set[str]:
+    def updated_groups(self) -> set[str]:
         """
-        The nodes that had user attributes updated in the target ref.
-        """
-        ...
-    @property
-    def updated_zarr_metadata(self) -> set[str]:
-        """
-        The nodes that had zarr metadata updated in the target ref.
+        The groups that were updated via zarr metadata in the target ref.
         """
         ...
     @property
-    def updated_chunks(self) -> dict[str, int]:
+    def updated_arrays(self) -> set[str]:
         """
-        The chunks that had data updated in the target ref.
+        The arrays that were updated via zarr metadata in the target ref.
+        """
+        ...
+    @property
+    def updated_chunks(self) -> dict[str, list[list[int]]]:
+        """
+        The chunks indices that had data updated in the target ref, keyed by the path to the array.
         """
         ...
 

--- a/icechunk/src/format/serializers/mod.rs
+++ b/icechunk/src/format/serializers/mod.rs
@@ -35,9 +35,9 @@
 //!     - Then this new type `XDeserializer` is deserialized using serde and converted with `into`.
 //!
 //! - `serializers.current.rs` holds all the serializers and deserializers for the current version
-//!    of the spec
+//!   of the spec
 //! - `serializers.version_foo.rs` holds all the serializers and deserializers for version foo of
-//!    the spec
+//!   the spec
 //! - The `serializers` module root has functions `serialize_X` and `deserialize_X` that take a
 //!   spec version number and use the right (de)-serializer to do the job.
 use std::io::{Read, Write};

--- a/icechunk/src/store.rs
+++ b/icechunk/src/store.rs
@@ -592,7 +592,7 @@ impl Store {
                     ListDirItem::Prefix("c".to_string()),
                 ]
             }
-            Ok(NodeSnapshot { node_data: NodeData::Group { .. }, .. }) => {
+            Ok(NodeSnapshot { node_data: NodeData::Group, .. }) => {
                 // if the prefix is the path to a group we need to discover any nodes with the prefix as node path
                 // listing chunks is unnecessary
                 self.list_metadata_prefix(prefix, true)

--- a/icechunk/src/virtual_chunks.rs
+++ b/icechunk/src/virtual_chunks.rs
@@ -335,7 +335,7 @@ impl VirtualChunkResolver {
             ObjectStoreConfig::Azure { .. } => {
                 unimplemented!("support for virtual chunks on azure")
             }
-            ObjectStoreConfig::InMemory {} => {
+            ObjectStoreConfig::InMemory => {
                 unimplemented!("support for virtual chunks in Memory")
             }
         }


### PR DESCRIPTION
This looks like it was never updated when we treated zarr metadata as blobs