### PR TITLE
Skip bytes logging in object_store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 push = false
+
+
+[profile.perf]
+inherits = "release"
+debug = 1

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -46,3 +46,7 @@ default = ["cli"]
 
 [lints]
 workspace = true
+
+[profile.perf]
+inherits = "release"
+debug = 1

--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -448,12 +448,12 @@ impl Storage for ObjectStorage {
             .await
     }
 
-    #[instrument(skip(self, _settings))]
+    #[instrument(skip(self, _settings, bytes))]
     async fn write_chunk(
         &self,
         _settings: &Settings,
         id: ChunkId,
-        bytes: bytes::Bytes,
+        bytes: Bytes,
     ) -> Result<(), StorageError> {
         let path = self.get_chunk_path(&id);
         self.get_client().await.put(&path, bytes.into()).await?;

--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -134,7 +134,7 @@ impl ObjectStorage {
     /// Get the client, initializing it if it hasn't been initialized yet. This is necessary because the
     /// client is not serializeable and must be initialized after deserialization. Under normal construction
     /// the original client is returned immediately.
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_client(&self) -> &Arc<dyn ObjectStore> {
         self.client
             .get_or_init(|| async {
@@ -283,12 +283,12 @@ impl Storage for ObjectStorage {
         true
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     fn default_settings(&self) -> Settings {
         self.backend.default_settings()
     }
 
-    #[instrument(skip(self, _settings))]
+    #[instrument(skip_all)]
     async fn fetch_config(
         &self,
         _settings: &Settings,
@@ -550,6 +550,7 @@ impl Storage for ObjectStorage {
         Ok(stream.boxed())
     }
 
+    #[instrument(skip(self, batch))]
     async fn delete_batch(
         &self,
         prefix: &str,

--- a/icechunk/src/storage/s3.rs
+++ b/icechunk/src/storage/s3.rs
@@ -201,7 +201,7 @@ impl S3Storage {
     /// Get the client, initializing it if it hasn't been initialized yet. This is necessary because the
     /// client is not serializeable and must be initialized after deserialization. Under normal construction
     /// the original client is returned immediately.
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_client(&self) -> &Arc<Client> {
         self.client
             .get_or_init(|| async {
@@ -323,7 +323,7 @@ impl Storage for S3Storage {
         self.can_write
     }
 
-    #[instrument(skip(self, _settings))]
+    #[instrument(skip_all)]
     async fn fetch_config(
         &self,
         _settings: &Settings,
@@ -586,7 +586,7 @@ impl Storage for S3Storage {
         }
     }
 
-    #[instrument(skip(self, _settings))]
+    #[instrument(skip_all)]
     async fn ref_names(&self, _settings: &Settings) -> StorageResult<Vec<String>> {
         let prefix = self.ref_key("")?;
         let mut paginator = self

--- a/icechunk/src/store.rs
+++ b/icechunk/src/store.rs
@@ -158,14 +158,14 @@ impl Store {
         Self { session, get_partial_values_concurrency }
     }
 
-    #[instrument(skip(bytes))]
+    #[instrument(skip_all)]
     pub fn from_bytes(bytes: Bytes) -> StoreResult<Self> {
         let session: Session = rmp_serde::from_slice(&bytes).map_err(StoreError::from)?;
         let conc = session.config().get_partial_values_concurrency();
         Ok(Self::from_session_and_config(Arc::new(RwLock::new(session)), conc))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub async fn as_bytes(&self) -> StoreResult<Bytes> {
         let session = self.session.write().await;
         let bytes = rmp_serde::to_vec(session.deref()).map_err(StoreError::from)?;
@@ -176,7 +176,7 @@ impl Store {
         Arc::clone(&self.session)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub async fn read_only(&self) -> bool {
         self.session.read().await.read_only()
     }
@@ -186,7 +186,7 @@ impl Store {
         Ok(self.list_dir(prefix).await?.next().await.is_none())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub async fn clear(&self) -> StoreResult<()> {
         let mut repo = self.session.write().await;
         Ok(repo.clear().await?)
@@ -207,7 +207,7 @@ impl Store {
     ///
     /// Currently this function is using concurrency but not parallelism. To limit the number of
     /// concurrent tasks use the Store config value `get_partial_values_concurrency`.
-    #[instrument(skip(self, key_ranges))]
+    #[instrument(skip_all)]
     pub async fn get_partial_values(
         &self,
         key_ranges: impl IntoIterator<Item = (String, ByteRange)>,
@@ -266,12 +266,12 @@ impl Store {
         exists(key, guard.deref()).await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub fn supports_writes(&self) -> StoreResult<bool> {
         Ok(true)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub fn supports_deletes(&self) -> StoreResult<bool> {
         Ok(true)
     }


### PR DESCRIPTION
I used

```
samply record -- python script.py
```

I also grepped for `write_`
```
-> % grep -B 2 "fn write_" icechunk/src/**/**.rs
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs-    #[instrument(skip(self, manifest))]
icechunk/src/asset_manager.rs:    pub async fn write_manifest(&self, manifest: Arc<Manifest>) -> RepositoryResult<u64> {
--
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs-    #[instrument(skip(self, snapshot))]
icechunk/src/asset_manager.rs:    pub async fn write_snapshot(&self, snapshot: Arc<Snapshot>) -> RepositoryResult<()> {
--
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs-    #[instrument(skip(self, log))]
icechunk/src/asset_manager.rs:    pub async fn write_transaction_log(
--
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs-    #[instrument(skip(self, bytes))]
icechunk/src/asset_manager.rs:    pub async fn write_chunk(
--
icechunk/src/asset_manager.rs-}
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs:async fn write_new_manifest(
--
icechunk/src/asset_manager.rs-}
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs:async fn write_new_snapshot(
--
icechunk/src/asset_manager.rs-}
icechunk/src/asset_manager.rs-
icechunk/src/asset_manager.rs:async fn write_new_tx_log(
--
icechunk/src/cli/interface.rs-}
icechunk/src/cli/interface.rs-
icechunk/src/cli/interface.rs:fn write_config(config: &CliConfig) -> Result<(), anyhow::Error> {
--
icechunk/src/session.rs-    /// Write a manifest for a node that was created in this session
icechunk/src/session.rs-    /// It doesn't need to look at previous manifests because the node is new
icechunk/src/session.rs:    async fn write_manifest_for_new_node(
--
icechunk/src/session.rs-    /// It needs to update the chunks according to the change set
icechunk/src/session.rs-    /// and record the new manifest
icechunk/src/session.rs:    async fn write_manifest_for_existing_node(
--
icechunk/src/storage/logging.rs-    }
icechunk/src/storage/logging.rs-
icechunk/src/storage/logging.rs:    async fn write_snapshot(
--
icechunk/src/storage/logging.rs-    }
icechunk/src/storage/logging.rs-
icechunk/src/storage/logging.rs:    async fn write_transaction_log(
--
icechunk/src/storage/logging.rs-    }
icechunk/src/storage/logging.rs-
icechunk/src/storage/logging.rs:    async fn write_manifest(
--
icechunk/src/storage/logging.rs-    }
icechunk/src/storage/logging.rs-
icechunk/src/storage/logging.rs:    async fn write_chunk(
--
icechunk/src/storage/logging.rs-    }
icechunk/src/storage/logging.rs-
icechunk/src/storage/logging.rs:    async fn write_ref(
--
icechunk/src/storage/mod.rs-    ) -> StorageResult<Box<dyn AsyncRead + Unpin + Send>>;
icechunk/src/storage/mod.rs-
icechunk/src/storage/mod.rs:    async fn write_snapshot(
--
icechunk/src/storage/mod.rs-        bytes: Bytes,
icechunk/src/storage/mod.rs-    ) -> StorageResult<()>;
icechunk/src/storage/mod.rs:    async fn write_manifest(
--
icechunk/src/storage/mod.rs-        bytes: Bytes,
icechunk/src/storage/mod.rs-    ) -> StorageResult<()>;
icechunk/src/storage/mod.rs:    async fn write_chunk(
--
icechunk/src/storage/mod.rs-        bytes: Bytes,
icechunk/src/storage/mod.rs-    ) -> StorageResult<()>;
icechunk/src/storage/mod.rs:    async fn write_transaction_log(
--
icechunk/src/storage/mod.rs-    ) -> StorageResult<GetRefResult>;
icechunk/src/storage/mod.rs-    async fn ref_names(&self, settings: &Settings) -> StorageResult<Vec<String>>;
icechunk/src/storage/mod.rs:    async fn write_ref(
--
icechunk/src/storage/object_store.rs-
icechunk/src/storage/object_store.rs-    #[instrument(skip(self, settings, metadata, bytes))]
icechunk/src/storage/object_store.rs:    async fn write_snapshot(
--
icechunk/src/storage/object_store.rs-
icechunk/src/storage/object_store.rs-    #[instrument(skip(self, settings, metadata, bytes))]
icechunk/src/storage/object_store.rs:    async fn write_manifest(
--
icechunk/src/storage/object_store.rs-
icechunk/src/storage/object_store.rs-    #[instrument(skip(self, settings, metadata, bytes))]
icechunk/src/storage/object_store.rs:    async fn write_transaction_log(
--
icechunk/src/storage/object_store.rs-
icechunk/src/storage/object_store.rs-    #[instrument(skip(self, _settings, bytes))]
icechunk/src/storage/object_store.rs:    async fn write_chunk(
--
icechunk/src/storage/object_store.rs-
icechunk/src/storage/object_store.rs-    #[instrument(skip(self, settings, bytes))]
icechunk/src/storage/object_store.rs:    async fn write_ref(
--
icechunk/src/storage/s3.rs-
icechunk/src/storage/s3.rs-    #[instrument(skip(self, settings, metadata, bytes))]
icechunk/src/storage/s3.rs:    async fn write_snapshot(
--
icechunk/src/storage/s3.rs-
icechunk/src/storage/s3.rs-    #[instrument(skip(self, settings, metadata, bytes))]
icechunk/src/storage/s3.rs:    async fn write_manifest(
--
icechunk/src/storage/s3.rs-
icechunk/src/storage/s3.rs-    #[instrument(skip(self, settings, metadata, bytes))]
icechunk/src/storage/s3.rs:    async fn write_transaction_log(
--
icechunk/src/storage/s3.rs-
icechunk/src/storage/s3.rs-    #[instrument(skip(self, settings, bytes))]
icechunk/src/storage/s3.rs:    async fn write_chunk(
--
icechunk/src/storage/s3.rs-
icechunk/src/storage/s3.rs-    #[instrument(skip(self, settings, bytes))]
icechunk/src/storage/s3.rs:    async fn write_ref(
```