### PR TITLE
Multipart upload for S3 native Storage instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.10"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+checksum = "8c39646d1a6b51240a1a23bb57ea4eebede7e16fbc237fdc876980233dcecb4f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -199,7 +199,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -207,7 +207,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 0.2.12",
+ "http 1.3.0",
  "ring",
  "time",
  "tokio",
@@ -229,10 +229,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.4.4"
+name = "aws-lc-rs"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ac934720fbb46206292d2c75b57e67acfc56fe7dfd34fb9a02334af08409ea"
+checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -256,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.65.0"
+version = "1.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ba2c5c0f2618937ce3d4a5ad574b86775576fa24006bcb3128c6e2cbf3c34e"
+checksum = "e6eab2900764411ab01c8e91a76fd11a63b4e12bc3da97d9e14a0ce1343d86d3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -267,7 +290,7 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -278,6 +301,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
+ "http 1.3.0",
  "http-body 0.4.6",
  "lru",
  "once_cell",
@@ -290,20 +314,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.50.0"
+version = "1.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ca43a4ef210894f93096039ef1d6fa4ad3edfabb3be92b80908b9f2e4b4eab"
+checksum = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -312,20 +337,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.51.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abaf490c2e48eed0bb8e2da2fb08405647bd7f253996e0f93b981958ea0f73b0"
+checksum = "acbbb3ce8da257aedbccdcb1aadafbbb6a5fe9adf445db0e1ea897bdc7e22d08"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -334,21 +360,22 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.51.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68fde0d69c8bfdc1060ea7da21df3e39f6014da316783336deff0a9ec28f4bf"
+checksum = "96a78a8f50a1630db757b60f679c8226a8a70ee2ab5f5e6e51dc67f6c61c7cfd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -357,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -397,15 +424,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.13"
+version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1a71073fca26775c8b5189175ea8863afb1c9ea2cceb02a5de5ad9dfbaa795"
+checksum = "b65d21e1ba6f2cdec92044f904356a19f5ad86961acf015741106cdfafd747c0"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc32c",
  "crc32fast",
+ "crc64fast-nvme",
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -418,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.5"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -429,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -440,6 +468,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
+ "http 1.3.0",
  "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
@@ -449,21 +478,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.60.7"
+name = "aws-smithy-http-client"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.7",
+ "http 0.2.12",
+ "http 1.3.0",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper 1.6.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.19",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.61.1"
+name = "aws-smithy-observability"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+checksum = "445d065e76bc1ef54963db400319f1dd3ebb3e0a74af20f7f7630625b0cc7cc0"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-runtime-api",
+ "once_cell",
 ]
 
 [[package]]
@@ -478,27 +536,25 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.4"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f20685047ca9d6f17b994a07f629c813f08b5bce65523e47124879e60103d45"
+checksum = "0152749e17ce4d1b47c7747bdfec09dac1ccafdcbc741ebf9daa2a373356730f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2 0.3.26",
  "http 0.2.12",
+ "http 1.3.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "httparse",
- "hyper 0.14.30",
- "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -569,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -644,6 +700,29 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -728,6 +807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +834,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -789,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,10 +932,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -837,6 +955,21 @@ checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -854,6 +987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crc64fast-nvme"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
+dependencies = [
+ "crc",
 ]
 
 [[package]]
@@ -1043,6 +1185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1179,6 +1327,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1309,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "globset"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1572,10 +1741,10 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.3.0",
- "hyper 1.5.1",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.19",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -1593,7 +1762,7 @@ dependencies = [
  "futures-util",
  "http 1.3.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1648,7 +1817,7 @@ dependencies = [
  "flatbuffers",
  "futures",
  "icechunk-macros",
- "itertools",
+ "itertools 0.14.0",
  "object_store",
  "pretty_assertions",
  "proptest",
@@ -1697,7 +1866,7 @@ dependencies = [
  "clap",
  "futures",
  "icechunk",
- "itertools",
+ "itertools 0.14.0",
  "miette",
  "pyo3",
  "pyo3-async-runtimes",
@@ -1924,6 +2093,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1962,10 +2140,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "libredox"
@@ -2092,6 +2286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2310,16 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2171,8 +2381,8 @@ dependencies = [
  "http-body-util",
  "httparse",
  "humantime",
- "hyper 1.5.1",
- "itertools",
+ "hyper 1.6.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -2193,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl-probe"
@@ -2360,6 +2570,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,7 +2732,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.19",
  "socket2",
  "thiserror 1.0.69",
@@ -2529,7 +2749,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.19",
  "slab",
  "thiserror 1.0.69",
@@ -2712,7 +2932,7 @@ dependencies = [
  "http 1.3.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -2724,7 +2944,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.19",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -2810,6 +3030,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -2867,6 +3093,7 @@ version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2884,20 +3111,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -2920,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -2940,6 +3166,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3018,7 +3245,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3026,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3574,6 +3814,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,6 +4191,18 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.41",
 ]
 
 [[package]]

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -597,6 +597,7 @@ class StorageSettings:
         storage_class: str | None = None,
         metadata_storage_class: str | None = None,
         chunks_storage_class: str | None = None,
+        minimum_size_for_multipart_upload: int | None = None,
     ) -> None:
         """
         Create a new `StorageSettings` object
@@ -636,6 +637,10 @@ class StorageSettings:
             Store chunk objects using this object store storage class.
             Currently not supported in GCS.
             Defaults to storage_class.
+
+        minimum_size_for_multipart_upload: int | None
+            Use object store's multipart upload for objects larger than this size in bytes.
+            Default: 100 MB if None is passed.
         """
         ...
     @property
@@ -672,6 +677,11 @@ class StorageSettings:
     @property
     def chunks_storage_class(self) -> str | None:
         """Chunk objects in object store will use this storage class or self.storage_class if None"""
+        ...
+
+    @property
+    def minimum_size_for_multipart_upload(self) -> int | None:
+        """Use object store's multipart upload for objects larger than this size in bytes"""
         ...
 
 class RepositoryConfig:

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -759,6 +759,8 @@ pub struct PyStorageSettings {
     pub metadata_storage_class: Option<String>,
     #[pyo3(get, set)]
     pub chunks_storage_class: Option<String>,
+    #[pyo3(get, set)]
+    pub minimum_size_for_multipart_upload: Option<u64>,
 }
 
 impl From<storage::Settings> for PyStorageSettings {
@@ -775,6 +777,7 @@ impl From<storage::Settings> for PyStorageSettings {
             storage_class: value.storage_class,
             metadata_storage_class: value.metadata_storage_class,
             chunks_storage_class: value.chunks_storage_class,
+            minimum_size_for_multipart_upload: value.minimum_size_for_multipart_upload,
         })
     }
 }
@@ -789,6 +792,7 @@ impl From<&PyStorageSettings> for storage::Settings {
             storage_class: value.storage_class.clone(),
             metadata_storage_class: value.metadata_storage_class.clone(),
             chunks_storage_class: value.chunks_storage_class.clone(),
+            minimum_size_for_multipart_upload: value.minimum_size_for_multipart_upload,
         })
     }
 }
@@ -805,8 +809,9 @@ impl Eq for PyStorageSettings {}
 
 #[pymethods]
 impl PyStorageSettings {
-    #[pyo3(signature = ( concurrency=None, unsafe_use_conditional_create=None, unsafe_use_conditional_update=None, unsafe_use_metadata=None, storage_class=None, metadata_storage_class=None, chunks_storage_class=None))]
+    #[pyo3(signature = ( concurrency=None, unsafe_use_conditional_create=None, unsafe_use_conditional_update=None, unsafe_use_metadata=None, storage_class=None, metadata_storage_class=None, chunks_storage_class=None, minimum_size_for_multipart_upload=None))]
     #[new]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         concurrency: Option<Py<PyStorageConcurrencySettings>>,
         unsafe_use_conditional_create: Option<bool>,
@@ -815,6 +820,7 @@ impl PyStorageSettings {
         storage_class: Option<String>,
         metadata_storage_class: Option<String>,
         chunks_storage_class: Option<String>,
+        minimum_size_for_multipart_upload: Option<u64>,
     ) -> Self {
         Self {
             concurrency,
@@ -824,6 +830,7 @@ impl PyStorageSettings {
             storage_class,
             metadata_storage_class,
             chunks_storage_class,
+            minimum_size_for_multipart_upload,
         }
     }
 

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -35,8 +35,8 @@ rmp-serde = "1.3.0"
 url = "2.5.4"
 async-stream = "0.3.6"
 rmpv = { version = "1.3.0", features = ["serde", "with-serde"] }
-aws-sdk-s3 = "1.65.0"
-aws-config = "1.5.10"
+aws-sdk-s3 = "1.82.0"
+aws-config = "1.6.1"
 aws-credential-types = "1.2.2"
 typed-path = "0.10.0"
 aws-smithy-types-convert = { version = "0.60.9", features = [

--- a/icechunk/proptest-regressions/storage/mod.txt
+++ b/icechunk/proptest-regressions/storage/mod.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 3a74daab07603c4d5c3124cf9ad1dca500ecc16a2f9409ef4acde9eea5901314 # shrinks to offset = 1, size = 16440244, min_part_size = 0, max_parts = 1
+cc 4ebde7bdc214b3005bb1c480f35dcc45fe730b73c0e90d8d0f2c149738464adb # shrinks to offset = 0, size = 1, part_size = 1, max_parts = 1

--- a/icechunk/src/storage/mod.rs
+++ b/icechunk/src/storage/mod.rs
@@ -3,9 +3,11 @@ use aws_sdk_s3::{
     config::http::HttpResponse,
     error::SdkError,
     operation::{
+        complete_multipart_upload::CompleteMultipartUploadError,
+        create_multipart_upload::CreateMultipartUploadError,
         delete_objects::DeleteObjectsError, get_object::GetObjectError,
         head_object::HeadObjectError, list_objects_v2::ListObjectsV2Error,
-        put_object::PutObjectError,
+        put_object::PutObjectError, upload_part::UploadPartError,
     },
     primitives::ByteStreamError,
 };
@@ -62,6 +64,16 @@ pub enum StorageErrorKind {
     S3GetObjectError(#[from] SdkError<GetObjectError, HttpResponse>),
     #[error("error writing object to object store {0}")]
     S3PutObjectError(#[from] SdkError<PutObjectError, HttpResponse>),
+    #[error("error creating multipart upload {0}")]
+    S3CreateMultipartUploadError(
+        #[from] SdkError<CreateMultipartUploadError, HttpResponse>,
+    ),
+    #[error("error uploading multipart part {0}")]
+    S3UploadPartError(#[from] SdkError<UploadPartError, HttpResponse>),
+    #[error("error completing multipart upload {0}")]
+    S3CompleteMultipartUploadError(
+        #[from] SdkError<CompleteMultipartUploadError, HttpResponse>,
+    ),
     #[error("error getting object metadata from object store {0}")]
     S3HeadObjectError(#[from] SdkError<HeadObjectError, HttpResponse>),
     #[error("error listing objects in object store {0}")]
@@ -186,6 +198,8 @@ pub struct Settings {
     pub metadata_storage_class: Option<String>,
     #[serde(default)]
     pub chunks_storage_class: Option<String>,
+    #[serde(default)]
+    pub minimum_size_for_multipart_upload: Option<u64>,
 }
 
 static DEFAULT_CONCURRENCY: OnceLock<ConcurrencySettings> = OnceLock::new();
@@ -215,6 +229,11 @@ impl Settings {
 
     pub fn chunks_storage_class(&self) -> Option<&String> {
         self.chunks_storage_class.as_ref().or(self.storage_class.as_ref())
+    }
+
+    pub fn minimum_size_for_multipart_upload(&self) -> u64 {
+        // per AWS  recommendation: 100 MB
+        self.minimum_size_for_multipart_upload.unwrap_or(100 * 1024 * 1024)
     }
 
     pub fn merge(&self, other: Self) -> Self {
@@ -274,6 +293,15 @@ impl Settings {
                 (None, None) => None,
                 (None, Some(c)) => Some(c),
                 (Some(c), None) => Some(c.clone()),
+                (Some(_), Some(theirs)) => Some(theirs),
+            },
+            minimum_size_for_multipart_upload: match (
+                &self.minimum_size_for_multipart_upload,
+                other.minimum_size_for_multipart_upload,
+            ) {
+                (None, None) => None,
+                (None, Some(c)) => Some(c),
+                (Some(c), None) => Some(*c),
                 (Some(_), Some(theirs)) => Some(theirs),
             },
         }
@@ -703,6 +731,38 @@ pub fn split_in_multiple_requests(
     .map(|(_, range)| range)
 }
 
+/// Split an object request into multiple byte range requests ensuring only the last request is
+/// smaller
+///
+/// Returns tuples of Range for each request.
+///
+/// It tries to generate ceil(size/ideal_req_size) requests, but never exceeds max_requests.
+///
+/// ideal_req_size and max_requests must be > 0
+pub fn split_in_multiple_equal_requests(
+    range: &Range<u64>,
+    ideal_req_size: u64,
+    max_requests: u16,
+) -> impl Iterator<Item = Range<u64>> + use<> {
+    let size = max(0, range.end - range.start);
+    // we do a ceiling division, rounding always up
+    let num_parts = size.div_ceil(ideal_req_size);
+    // no more than max_parts, so we limit
+    let num_parts = max(1, min(num_parts, max_requests as u64));
+
+    let big_parts = num_parts - 1;
+    let big_parts_size = size / max(1, big_parts);
+    let small_part_size = size - big_parts_size * big_parts;
+
+    iter::successors(Some((1, range.start..range.start)), move |(index, prev_range)| {
+        let size = if *index <= big_parts { big_parts_size } else { small_part_size };
+        Some((index + 1, prev_range.end..prev_range.end + size))
+    })
+    .dropping(1)
+    .take(num_parts as usize)
+    .map(|(_, range)| range)
+}
+
 pub fn new_s3_storage(
     config: S3Options,
     bucket: String,
@@ -906,6 +966,45 @@ mod tests {
             PathBuf::from_iter([repo_dir.path().as_os_str().to_str().unwrap(), "foo"]);
         let s = new_local_filesystem_storage(&inside_existing).await.unwrap();
         assert!(s.root_is_clean().await.unwrap());
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 999, .. ProptestConfig::default()
+        })]
+
+        #[icechunk_macros::test]
+        fn test_split_equal_requests(offset in 0..1_000_000u64, size in 1..3_000_000_000u64, part_size in 1..16_000_000u64, max_parts in 1..100u16 ) {
+            let res: Vec<_> = split_in_multiple_equal_requests(&(offset..offset+size), part_size, max_parts).collect();
+            // there is always at least 1 request
+            prop_assert!(!res.is_empty());
+
+            // it does as many requests as possible
+            prop_assert!(res.len() as u64 >= min(max_parts as u64, size / part_size));
+
+            // there are never more than max_parts requests
+            prop_assert!(res.len() <= max_parts as usize);
+
+            // the request sizes add up to total size
+            prop_assert_eq!(res.iter().map(|range| range.end - range.start).sum::<u64>(), size);
+
+            let sizes: Vec<_> = res.iter().map(|range| (range.end - range.start)).collect();
+            if sizes.len() > 1 {
+                // all but last request have the same size
+                assert_eq!(sizes.iter().rev().skip(1).unique().count(), 1);
+
+                // last element is smaller or equal
+                assert!(sizes.last().unwrap() <= sizes.first().unwrap());
+            }
+
+            // we split as much as possible
+            assert!(res.len() >= min((size / part_size) as usize, max_parts as usize) );
+
+            // there are no holes in the requests, nor bytes that are requested more than once
+            let mut iter = res.iter();
+            iter.next();
+            prop_assert!(res.iter().zip(iter).all(|(r1,r2)| r1.end == r2.start));
+        }
     }
 
     proptest! {

--- a/icechunk/src/storage/s3.rs
+++ b/icechunk/src/storage/s3.rs
@@ -27,14 +27,14 @@ use aws_sdk_s3::{
     error::{BoxError, SdkError},
     operation::put_object::PutObjectError,
     primitives::ByteStream,
-    types::{Delete, Object, ObjectIdentifier},
+    types::{CompletedMultipartUpload, CompletedPart, Delete, Object, ObjectIdentifier},
 };
 use aws_smithy_types_convert::{date_time::DateTimeExt, stream::PaginationStreamExt};
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, Utc};
 use futures::{
     StreamExt, TryStreamExt,
-    stream::{self, BoxStream},
+    stream::{self, BoxStream, FuturesOrdered},
 };
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncRead, sync::OnceCell};
@@ -44,7 +44,7 @@ use super::{
     CHUNK_PREFIX, CONFIG_PATH, DeleteObjectsResult, FetchConfigResult, GetRefResult,
     ListInfo, MANIFEST_PREFIX, REF_PREFIX, Reader, SNAPSHOT_PREFIX, Settings,
     StorageErrorKind, StorageResult, TRANSACTION_PREFIX, UpdateConfigResult, VersionInfo,
-    WriteRefResult,
+    WriteRefResult, split_in_multiple_equal_requests,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -273,7 +273,7 @@ impl S3Storage {
         Ok(Box::new(b.send().await?.body.into_async_read()))
     }
 
-    async fn put_object<
+    async fn put_object_single<
         I: IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     >(
         &self,
@@ -306,6 +306,135 @@ impl S3Storage {
 
         b.body(bytes.into()).send().await?;
         Ok(())
+    }
+
+    async fn put_object_multipart<
+        I: IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    >(
+        &self,
+        settings: &Settings,
+        key: &str,
+        content_type: Option<impl Into<String>>,
+        metadata: I,
+        storage_class: Option<&String>,
+        bytes: &Bytes,
+    ) -> StorageResult<()> {
+        let mut multi = self
+            .get_client()
+            .await
+            .create_multipart_upload()
+            // We would like this, but it fails in MinIO
+            //.checksum_type(aws_sdk_s3::types::ChecksumType::FullObject)
+            //.checksum_algorithm(aws_sdk_s3::types::ChecksumAlgorithm::Crc64Nvme)
+            .bucket(self.bucket.clone())
+            .key(key);
+
+        if settings.unsafe_use_metadata() {
+            if let Some(ct) = content_type {
+                multi = multi.content_type(ct)
+            };
+            for (k, v) in metadata {
+                multi = multi.metadata(k, v);
+            }
+        }
+
+        if let Some(klass) = storage_class {
+            let klass = klass.as_str().into();
+            multi = multi.storage_class(klass);
+        }
+
+        let create_res = multi.send().await?;
+        let upload_id =
+            create_res.upload_id().ok_or(StorageError::from(StorageErrorKind::Other(
+                "No upload_id in create multipart upload result".to_string(),
+            )))?;
+
+        // We need to ensure all requests are the same size except for the last one, which can be
+        // smaller. This is a requirement for R2 compatibility
+        let parts = split_in_multiple_equal_requests(
+            &(0..bytes.len() as u64),
+            settings.concurrency().ideal_concurrent_request_size().get(),
+            settings.concurrency().max_concurrent_requests_for_object().get(),
+        )
+        .collect::<Vec<_>>();
+
+        let results = parts
+            .into_iter()
+            .enumerate()
+            .map(|(part_idx, range)| async move {
+                let body = bytes.slice(range.start as usize..range.end as usize).into();
+                let idx = part_idx as i32 + 1;
+                self.get_client()
+                    .await
+                    .upload_part()
+                    .upload_id(upload_id)
+                    .bucket(self.bucket.clone())
+                    .key(key)
+                    .part_number(idx)
+                    .body(body)
+                    .send()
+                    .await
+                    .map(|res| (idx, res))
+            })
+            .collect::<FuturesOrdered<_>>();
+
+        let completed_parts = results
+            .map_ok(|(idx, res)| {
+                let etag = res.e_tag().unwrap_or("");
+                CompletedPart::builder().e_tag(etag).part_number(idx).build()
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let completed_parts =
+            CompletedMultipartUpload::builder().set_parts(Some(completed_parts)).build();
+
+        self.get_client()
+            .await
+            .complete_multipart_upload()
+            .bucket(self.bucket.clone())
+            .key(key)
+            .upload_id(upload_id)
+            //.checksum_type(aws_sdk_s3::types::ChecksumType::FullObject)
+            .multipart_upload(completed_parts)
+            .send()
+            .await?;
+
+        Ok(())
+    }
+
+    async fn put_object<
+        I: IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    >(
+        &self,
+        settings: &Settings,
+        key: &str,
+        content_type: Option<impl Into<String>>,
+        metadata: I,
+        storage_class: Option<&String>,
+        bytes: &Bytes,
+    ) -> StorageResult<()> {
+        if bytes.len() >= settings.minimum_size_for_multipart_upload() as usize {
+            self.put_object_multipart(
+                settings,
+                key,
+                content_type,
+                metadata,
+                storage_class,
+                bytes,
+            )
+            .await
+        } else {
+            self.put_object_single(
+                settings,
+                key,
+                content_type,
+                metadata,
+                storage_class,
+                bytes.clone(),
+            )
+            .await
+        }
     }
 
     fn get_ref_name<'a>(&self, key: Option<&'a str>) -> Option<&'a str> {
@@ -512,7 +641,7 @@ impl Storage for S3Storage {
             None::<String>,
             metadata,
             settings.metadata_storage_class(),
-            bytes,
+            &bytes,
         )
         .await
     }
@@ -532,7 +661,7 @@ impl Storage for S3Storage {
             None::<String>,
             metadata.into_iter(),
             settings.metadata_storage_class(),
-            bytes,
+            &bytes,
         )
         .await
     }
@@ -552,7 +681,7 @@ impl Storage for S3Storage {
             None::<String>,
             metadata.into_iter(),
             settings.metadata_storage_class(),
-            bytes,
+            &bytes,
         )
         .await
     }
@@ -565,7 +694,6 @@ impl Storage for S3Storage {
         bytes: bytes::Bytes,
     ) -> Result<(), StorageError> {
         let key = self.get_chunk_path(&id)?;
-        //FIXME: use multipart upload
         let metadata: [(String, String); 0] = [];
         self.put_object(
             settings,
@@ -573,7 +701,7 @@ impl Storage for S3Storage {
             None::<String>,
             metadata,
             settings.chunks_storage_class(),
-            bytes,
+            &bytes,
         )
         .await
     }
@@ -787,7 +915,7 @@ impl Storage for S3Storage {
             .get_client()
             .await
             .head_object()
-            .bucket(self.bucket.as_str())
+            .bucket(self.bucket.clone())
             .key(key)
             .send()
             .await?;
@@ -812,7 +940,7 @@ impl Storage for S3Storage {
             .get_client()
             .await
             .get_object()
-            .bucket(self.bucket.as_str())
+            .bucket(self.bucket.clone())
             .key(key)
             .range(range_to_header(range));
         Ok(Box::new(b.send().await?.body.collect().await?))


### PR DESCRIPTION
Implements multipart upload for objects (by default) larger than 100MB. All object types are supported.

object_store instances not implemented yet.