### PR TITLE
Credential refresh can be initialized with the first set of credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ dependencies = [
  "miette",
  "pyo3",
  "pyo3-async-runtimes",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -39,6 +39,7 @@ typetag = "0.2.20"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 miette = { version = "7.5.0", features = ["fancy"] }
 clap = { version = "4.5", features = ["derive"], optional = true }
+rand = "0.9.0"
 
 [features]
 cli = ["clap", "icechunk/cli"]

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1260,8 +1260,13 @@ class S3Credentials:
         ----------
         pickled_function: bytes
             The pickled function to use to provide credentials.
+        current: S3StaticCredentials
+            The initial credentials. They will be returned the first time credentials
+            are requested and then deleted.
         """
-        def __init__(self, pickled_function: bytes) -> None: ...
+        def __init__(
+            self, pickled_function: bytes, current: S3StaticCredentials | None = None
+        ) -> None: ...
 
 AnyS3Credential = (
     S3Credentials.Static
@@ -1359,7 +1364,9 @@ class GcsCredentials:
 
         This is useful for credentials that have an expiration time, or are otherwise not known ahead of time.
         """
-        def __init__(self, pickled_function: bytes) -> None: ...
+        def __init__(
+            self, pickled_function: bytes, current: GcsBearerCredential | None = None
+        ) -> None: ...
 
 AnyGcsCredential = (
     GcsCredentials.FromEnv | GcsCredentials.Static | GcsCredentials.Refreshable

--- a/icechunk-python/python/icechunk/storage.py
+++ b/icechunk-python/python/icechunk/storage.py
@@ -49,6 +49,7 @@ def s3_store(
     force_path_style: bool = False,
 ) -> ObjectStoreConfig.S3Compatible | ObjectStoreConfig.S3:
     """Build an ObjectStoreConfig instance for S3 or S3 compatible object stores."""
+
     options = S3Options(
         region=region,
         endpoint_url=endpoint_url,
@@ -76,6 +77,7 @@ def s3_storage(
     anonymous: bool | None = None,
     from_env: bool | None = None,
     get_credentials: Callable[[], S3StaticCredentials] | None = None,
+    scatter_initial_credentials: bool = False,
     force_path_style: bool = False,
 ) -> Storage:
     """Create a Storage instance that saves data in S3 or S3 compatible object stores.
@@ -106,6 +108,12 @@ def s3_storage(
         Fetch credentials from the operative system environment
     get_credentials: Callable[[], S3StaticCredentials] | None
         Use this function to get and refresh object store credentials
+    scatter_initial_credentials: bool, optional
+        Immediately call and store the value returned by get_credentials. This is useful if the
+        repo or session will be pickled to generate many copies. Passing scatter_initial_credentials=True will
+        ensure all those copies don't need to call get_credentials immediately. After the initial
+        set of credentials has expired, the cached value is no longer used. Notice that credentials
+        obtained are stored, and they can be sent over the network if you pickle the session/repo.
     force_path_style: bool
         Whether to force using path-style addressing for buckets
     """
@@ -118,6 +126,7 @@ def s3_storage(
         anonymous=anonymous,
         from_env=from_env,
         get_credentials=get_credentials,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
     options = S3Options(
         region=region,
@@ -186,6 +195,7 @@ def tigris_storage(
     anonymous: bool | None = None,
     from_env: bool | None = None,
     get_credentials: Callable[[], S3StaticCredentials] | None = None,
+    scatter_initial_credentials: bool = False,
 ) -> Storage:
     """Create a Storage instance that saves data in Tigris object store.
 
@@ -219,6 +229,12 @@ def tigris_storage(
         Fetch credentials from the operative system environment
     get_credentials: Callable[[], S3StaticCredentials] | None
         Use this function to get and refresh object store credentials
+    scatter_initial_credentials: bool, optional
+        Immediately call and store the value returned by get_credentials. This is useful if the
+        repo or session will be pickled to generate many copies. Passing scatter_initial_credentials=True will
+        ensure all those copies don't need to call get_credentials immediately. After the initial
+        set of credentials has expired, the cached value is no longer used. Notice that credentials
+        obtained are stored, and they can be sent over the network if you pickle the session/repo.
     """
     credentials = s3_credentials(
         access_key_id=access_key_id,
@@ -228,6 +244,7 @@ def tigris_storage(
         anonymous=anonymous,
         from_env=from_env,
         get_credentials=get_credentials,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
     options = S3Options(region=region, endpoint_url=endpoint_url, allow_http=allow_http)
     return Storage.new_tigris(
@@ -254,6 +271,7 @@ def r2_storage(
     anonymous: bool | None = None,
     from_env: bool | None = None,
     get_credentials: Callable[[], S3StaticCredentials] | None = None,
+    scatter_initial_credentials: bool = False,
 ) -> Storage:
     """Create a Storage instance that saves data in Tigris object store.
 
@@ -287,6 +305,12 @@ def r2_storage(
         Fetch credentials from the operative system environment
     get_credentials: Callable[[], S3StaticCredentials] | None
         Use this function to get and refresh object store credentials
+    scatter_initial_credentials: bool, optional
+        Immediately call and store the value returned by get_credentials. This is useful if the
+        repo or session will be pickled to generate many copies. Passing scatter_initial_credentials=True will
+        ensure all those copies don't need to call get_credentials immediately. After the initial
+        set of credentials has expired, the cached value is no longer used. Notice that credentials
+        obtained are stored, and they can be sent over the network if you pickle the session/repo.
     """
     credentials = s3_credentials(
         access_key_id=access_key_id,
@@ -296,6 +320,7 @@ def r2_storage(
         anonymous=anonymous,
         from_env=from_env,
         get_credentials=get_credentials,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
     options = S3Options(region=region, endpoint_url=endpoint_url, allow_http=allow_http)
     return Storage.new_r2(
@@ -318,6 +343,7 @@ def gcs_storage(
     from_env: bool | None = None,
     config: dict[str, str] | None = None,
     get_credentials: Callable[[], GcsBearerCredential] | None = None,
+    scatter_initial_credentials: bool = False,
 ) -> Storage:
     """Create a Storage instance that saves data in Google Cloud Storage object store.
 
@@ -333,6 +359,12 @@ def gcs_storage(
         The bearer token to use for the object store
     get_credentials: Callable[[], GcsBearerCredential] | None
         Use this function to get and refresh object store credentials
+    scatter_initial_credentials: bool, optional
+        Immediately call and store the value returned by get_credentials. This is useful if the
+        repo or session will be pickled to generate many copies. Passing scatter_initial_credentials=True will
+        ensure all those copies don't need to call get_credentials immediately. After the initial
+        set of credentials has expired, the cached value is no longer used. Notice that credentials
+        obtained are stored, and they can be sent over the network if you pickle the session/repo.
     """
     credentials = gcs_credentials(
         service_account_file=service_account_file,
@@ -341,6 +373,7 @@ def gcs_storage(
         bearer_token=bearer_token,
         from_env=from_env,
         get_credentials=get_credentials,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
     return Storage.new_gcs(
         bucket=bucket,

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use chrono::{DateTime, Datelike, Timelike, Utc};
+use chrono::{DateTime, Datelike, TimeDelta, Timelike, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -22,7 +22,7 @@ use icechunk::{
     virtual_chunks::VirtualChunkContainer,
 };
 use pyo3::{
-    Bound, Py, PyErr, PyResult, Python, pyclass, pymethods,
+    Bound, FromPyObject, Py, PyErr, PyResult, Python, pyclass, pymethods,
     types::{PyAnyMethods, PyModule, PyType},
 };
 
@@ -131,36 +131,57 @@ pub(crate) fn datetime_repr(d: &DateTime<Utc>) -> String {
     )
 }
 
-#[pyclass(eq)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PythonCredentialsFetcher {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct PythonCredentialsFetcher<CredType> {
     pub pickled_function: Vec<u8>,
+    pub current: Option<CredType>,
 }
 
-#[pymethods]
-impl PythonCredentialsFetcher {
-    #[new]
-    pub fn new(pickled_function: Vec<u8>) -> Self {
-        PythonCredentialsFetcher { pickled_function }
+impl<CredType> PythonCredentialsFetcher<CredType> {
+    fn new(pickled_function: Vec<u8>) -> Self {
+        PythonCredentialsFetcher { pickled_function, current: None }
     }
 
-    pub fn __repr__(&self) -> String {
-        format!(
-            r#"PythonCredentialsFetcher(pickled_function=bytes.fromhex("{:02X?}"))"#,
-            self.pickled_function
-        )
+    fn new_with_current<C>(pickled_function: Vec<u8>, current: C) -> Self
+    where
+        C: Into<CredType>,
+    {
+        PythonCredentialsFetcher { pickled_function, current: Some(current.into()) }
     }
 }
+
+fn call_pickled<PyCred>(
+    py: Python<'_>,
+    pickled_function: Vec<u8>,
+) -> Result<PyCred, PyErr>
+where
+    PyCred: for<'a> FromPyObject<'a>,
+{
+    let pickle_module = PyModule::import(py, "pickle")?;
+    let loads_function = pickle_module.getattr("loads")?;
+    let fetcher = loads_function.call1((pickled_function,))?;
+    let creds: PyCred = fetcher.call0()?.extract()?;
+    Ok(creds)
+}
+
 #[async_trait]
 #[typetag::serde]
-impl S3CredentialsFetcher for PythonCredentialsFetcher {
+impl S3CredentialsFetcher for PythonCredentialsFetcher<S3StaticCredentials> {
     async fn get(&self) -> Result<S3StaticCredentials, String> {
         Python::with_gil(|py| {
-            let pickle_module = PyModule::import(py, "pickle")?;
-            let loads_function = pickle_module.getattr("loads")?;
-            let fetcher = loads_function.call1((self.pickled_function.clone(),))?;
-            let creds: PyS3StaticCredentials = fetcher.call0()?.extract()?;
-            Ok(creds.into())
+            if let Some(static_creds) = self.current.as_ref() {
+                // avoid herding by adding some randomness
+                let delta = TimeDelta::seconds(rand::random_range(5..180));
+                let expiration = static_creds
+                    .expires_after
+                    .map(|exp| exp - delta)
+                    .unwrap_or(chrono::DateTime::<Utc>::MAX_UTC);
+                if Utc::now() < expiration {
+                    return Ok(static_creds.clone());
+                }
+            }
+            call_pickled::<PyS3StaticCredentials>(py, self.pickled_function.clone())
+                .map(|c| c.into())
         })
         .map_err(|e: PyErr| e.to_string())
     }
@@ -168,14 +189,22 @@ impl S3CredentialsFetcher for PythonCredentialsFetcher {
 
 #[async_trait]
 #[typetag::serde]
-impl GcsCredentialsFetcher for PythonCredentialsFetcher {
+impl GcsCredentialsFetcher for PythonCredentialsFetcher<GcsBearerCredential> {
     async fn get(&self) -> Result<GcsBearerCredential, String> {
         Python::with_gil(|py| {
-            let pickle_module = PyModule::import(py, "pickle")?;
-            let loads_function = pickle_module.getattr("loads")?;
-            let fetcher = loads_function.call1((self.pickled_function.clone(),))?;
-            let creds: PyGcsBearerCredential = fetcher.call0()?.extract()?;
-            Ok(creds.into())
+            if let Some(static_creds) = self.current.as_ref() {
+                // avoid herding by adding some randomness
+                let delta = TimeDelta::seconds(rand::random_range(5..180));
+                let expiration = static_creds
+                    .expires_after
+                    .map(|exp| exp - delta)
+                    .unwrap_or(chrono::DateTime::<Utc>::MAX_UTC);
+                if Utc::now() < expiration {
+                    return Ok(static_creds.clone());
+                }
+            }
+            call_pickled::<PyGcsBearerCredential>(py, self.pickled_function.clone())
+                .map(|c| c.into())
         })
         .map_err(|e: PyErr| e.to_string())
     }
@@ -187,7 +216,7 @@ pub enum PyS3Credentials {
     FromEnv(),
     Anonymous(),
     Static(PyS3StaticCredentials),
-    Refreshable(Vec<u8>),
+    Refreshable { pickled_function: Vec<u8>, current: Option<PyS3StaticCredentials> },
 }
 
 impl From<PyS3Credentials> for S3Credentials {
@@ -196,10 +225,14 @@ impl From<PyS3Credentials> for S3Credentials {
             PyS3Credentials::FromEnv() => S3Credentials::FromEnv,
             PyS3Credentials::Anonymous() => S3Credentials::Anonymous,
             PyS3Credentials::Static(creds) => S3Credentials::Static(creds.into()),
-            PyS3Credentials::Refreshable(pickled_function) => {
-                S3Credentials::Refreshable(Arc::new(PythonCredentialsFetcher {
-                    pickled_function,
-                }))
+            PyS3Credentials::Refreshable { pickled_function, current } => {
+                let fetcher = if let Some(current) = current {
+                    PythonCredentialsFetcher::new_with_current(pickled_function, current)
+                } else {
+                    PythonCredentialsFetcher::new(pickled_function)
+                };
+
+                S3Credentials::Refreshable(Arc::new(fetcher))
             }
         }
     }
@@ -269,7 +302,7 @@ impl From<GcsBearerCredential> for PyGcsBearerCredential {
 pub enum PyGcsCredentials {
     FromEnv(),
     Static(PyGcsStaticCredentials),
-    Refreshable(Vec<u8>),
+    Refreshable { pickled_function: Vec<u8>, current: Option<PyGcsBearerCredential> },
 }
 
 impl From<PyGcsCredentials> for GcsCredentials {
@@ -277,10 +310,14 @@ impl From<PyGcsCredentials> for GcsCredentials {
         match value {
             PyGcsCredentials::FromEnv() => GcsCredentials::FromEnv,
             PyGcsCredentials::Static(creds) => GcsCredentials::Static(creds.into()),
-            PyGcsCredentials::Refreshable(pickled_function) => {
-                GcsCredentials::Refreshable(Arc::new(PythonCredentialsFetcher {
-                    pickled_function,
-                }))
+            PyGcsCredentials::Refreshable { pickled_function, current } => {
+                let fetcher = if let Some(current) = current {
+                    PythonCredentialsFetcher::new_with_current(pickled_function, current)
+                } else {
+                    PythonCredentialsFetcher::new(pickled_function)
+                };
+
+                GcsCredentials::Refreshable(Arc::new(fetcher))
             }
         }
     }

--- a/icechunk-python/src/lib.rs
+++ b/icechunk-python/src/lib.rs
@@ -15,7 +15,6 @@ use config::{
     PyManifestPreloadCondition, PyManifestPreloadConfig, PyObjectStoreConfig,
     PyRepositoryConfig, PyS3Credentials, PyS3Options, PyS3StaticCredentials, PyStorage,
     PyStorageConcurrencySettings, PyStorageSettings, PyVirtualChunkContainer,
-    PythonCredentialsFetcher,
 };
 use conflicts::{
     PyBasicConflictSolver, PyConflict, PyConflictDetector, PyConflictSolver,
@@ -99,7 +98,6 @@ fn _icechunk_python(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyConflictDetector>()?;
     m.add_class::<PyVersionSelection>()?;
     m.add_class::<PyS3StaticCredentials>()?;
-    m.add_class::<PythonCredentialsFetcher>()?;
     m.add_class::<PyS3Credentials>()?;
     m.add_class::<PyGcsCredentials>()?;
     m.add_class::<PyGcsBearerCredential>()?;

--- a/icechunk-python/tests/test_credentials.py
+++ b/icechunk-python/tests/test_credentials.py
@@ -1,3 +1,5 @@
+import pickle
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -21,7 +23,11 @@ def get_bad_credentials() -> S3StaticCredentials:
     return S3StaticCredentials(access_key_id="xyz", secret_access_key="abc")
 
 
-def test_refreshable_credentials_grant_access() -> None:
+@pytest.mark.parametrize(
+    "scatter_initial_credentials",
+    [False, True],
+)
+def test_refreshable_credentials_grant_access(scatter_initial_credentials: bool) -> None:
     good_storage = s3_storage(
         region="us-east-1",
         endpoint_url="http://localhost:9000",
@@ -30,6 +36,7 @@ def test_refreshable_credentials_grant_access() -> None:
         bucket="testbucket",
         prefix="this-repo-does-not-exist",
         get_credentials=get_good_credentials,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
     bad_storage = s3_storage(
         region="us-east-1",
@@ -39,6 +46,7 @@ def test_refreshable_credentials_grant_access() -> None:
         bucket="testbucket",
         prefix="this-repo-does-not-exist",
         get_credentials=get_bad_credentials,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
 
     assert not Repository.exists(good_storage)
@@ -55,18 +63,35 @@ def returns_something_else() -> int:
     return 42
 
 
-def test_refreshable_credentials_errors() -> None:
-    st = s3_storage(
-        region="us-east-1",
-        endpoint_url="http://localhost:9000",
-        allow_http=True,
-        bucket="testbucket",
-        prefix="this-repo-does-not-exist",
-        get_credentials=throws,
-    )
+@pytest.mark.parametrize(
+    "scatter_initial_credentials",
+    [False, True],
+)
+def test_refreshable_credentials_errors(scatter_initial_credentials: bool) -> None:
+    if scatter_initial_credentials:
+        with pytest.raises(ValueError, match="bad creds"):
+            st = s3_storage(
+                region="us-east-1",
+                endpoint_url="http://localhost:9000",
+                allow_http=True,
+                bucket="testbucket",
+                prefix="this-repo-does-not-exist",
+                get_credentials=throws,
+                scatter_initial_credentials=scatter_initial_credentials,
+            )
+    else:
+        st = s3_storage(
+            region="us-east-1",
+            endpoint_url="http://localhost:9000",
+            allow_http=True,
+            bucket="testbucket",
+            prefix="this-repo-does-not-exist",
+            get_credentials=throws,
+            scatter_initial_credentials=scatter_initial_credentials,
+        )
 
-    with pytest.raises(ValueError, match="bad creds"):
-        assert not Repository.exists(st)
+        with pytest.raises(ValueError, match="bad creds"):
+            assert not Repository.exists(st)
 
     st = Storage.new_s3(
         config=S3Options(
@@ -102,8 +127,9 @@ def test_refreshable_credentials_errors() -> None:
 class ExpirableCredentials:
     """We use a file to keep track of how many times credentials are refreshed"""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, expired_times: int) -> None:
         self.path = path
+        self.expired_times = expired_times
 
     def __call__(self) -> S3StaticCredentials:
         try:
@@ -115,15 +141,21 @@ class ExpirableCredentials:
         self.path.write_text(s)
 
         # The return an expired credential for 3 times, then we return credentials with no expiration
-        expires = None if s == "..." else datetime.now(UTC)
+        expires = None if len(s) >= self.expired_times else datetime.now(UTC)
         return S3StaticCredentials(
             access_key_id="minio123", secret_access_key="minio123", expires_after=expires
         )
 
 
-def test_s3_refreshable_credentials_refresh(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "scatter_initial_credentials",
+    [False, True],
+)
+def test_s3_refreshable_credentials_refresh(
+    tmp_path: Path, scatter_initial_credentials: bool
+) -> None:
     path = tmp_path / "calls.txt"
-    creds_obj = ExpirableCredentials(path)
+    creds_obj = ExpirableCredentials(path, 3)
 
     st = s3_storage(
         region="us-east-1",
@@ -133,7 +165,11 @@ def test_s3_refreshable_credentials_refresh(tmp_path: Path) -> None:
         bucket="testbucket",
         prefix="this-repo-does-not-exist",
         get_credentials=creds_obj,
+        scatter_initial_credentials=scatter_initial_credentials,
     )
+
+    if scatter_initial_credentials:
+        assert path.read_text() == "."
 
     # credentials expire immediately so refresh function keeps getting called
     assert not Repository.exists(st)
@@ -145,3 +181,39 @@ def test_s3_refreshable_credentials_refresh(tmp_path: Path) -> None:
     assert not Repository.exists(st)
     assert not Repository.exists(st)
     assert path.read_text() == "..."
+
+
+@pytest.mark.parametrize(
+    "scatter_initial_credentials",
+    [False, True],
+)
+def test_s3_refreshable_credentials_pickle_with_optimization(
+    tmp_path: Path,
+    scatter_initial_credentials: bool,
+) -> None:
+    """Verifies pickled repos don't need to call get_credentials again if scatter_initial_credentials=True"""
+    path = tmp_path / "calls.txt"
+    creds_obj = ExpirableCredentials(path, 0)
+
+    st = s3_storage(
+        region="us-east-1",
+        endpoint_url="http://localhost:9000",
+        allow_http=True,
+        force_path_style=True,
+        bucket="testbucket",
+        prefix="test_refreshable_credentials_pickle_optimization-"
+        + str(int(time.time() * 1000)),
+        get_credentials=creds_obj,
+        scatter_initial_credentials=scatter_initial_credentials,
+    )
+    # let's create and use a repo
+    repo = Repository.create(storage=st)
+    assert Repository.exists(st)
+    assert Repository.exists(st)
+
+    # now we pickle it, use the copy, and check get_credentials is not called again
+    repo = pickle.loads(pickle.dumps(repo))
+    repo.ancestry(branch="main")
+
+    called_only_once = path.read_text() == "."
+    assert called_only_once == scatter_initial_credentials


### PR DESCRIPTION
`s3_storage` style functions got a new argument:

```
resolve_get_credentials: bool = False
```

If True is passed, pickled repos and sessions will use the result returned the first time `get_credentials` was called, instead of having to run it again.

This speeds up short distributed tasks, since they no longer need to spend time fetching credentials. Tasks will reuse the credentials gathered by the "coordinator"