### PR TITLE
Update local_filesystem_storage parameter in docs

### DIFF
--- a/docs/docs/icechunk-python/virtual.md
+++ b/docs/docs/icechunk-python/virtual.md
@@ -88,7 +88,7 @@ We have a virtual dataset with 31 timestamps! One hint that this worked correctl
 import icechunk
 
 storage = icechunk.local_filesystem_storage(
-    prefix='oisst',
+    path='oisst',
 )
 
 config = icechunk.RepositoryConfig.default()


### PR DESCRIPTION
The parameter name changed at some point from `prefix` to `path`.