### PR TITLE
Fix reporting of failed upstream tests

### DIFF
--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -128,7 +128,7 @@ jobs:
           && github.repository_owner == 'earth-mover'
         uses: xarray-contrib/issue-from-pytest-log@v1
         with:
-          log-path: output-pytest-log.jsonl
+          log-path: icechunk-python/output-pytest-log.jsonl
 
 
   xarray-backends:


### PR DESCRIPTION
Nightly CI is catching #929 but we don't get notifications