### PR TITLE
Update value error from ancestry to match interface arguments

### DIFF
--- a/icechunk-python/src/repository.rs
+++ b/icechunk-python/src/repository.rs
@@ -1060,7 +1060,7 @@ fn args_to_version_info(
     let n = [&branch, &tag, &snapshot].iter().filter(|r| !r.is_none()).count();
     if n > 1 {
         return Err(PyValueError::new_err(
-            "Must provide one of branch_name, tag_name, or snapshot_id",
+            "Must provide one of branch, tag, or snapshot_id",
         ));
     }
 
@@ -1088,7 +1088,7 @@ fn args_to_version_info(
         Ok(VersionInfo::SnapshotId(snapshot_id))
     } else {
         return Err(PyValueError::new_err(
-            "Must provide either branch_name, tag_name, or snapshot_id",
+            "Must provide one of branch, tag, or snapshot_id",
         ));
     }
 }


### PR DESCRIPTION
- ancestry takes args `branch`, `tag` and `snapshot_id`
- error suggests to use `branch_name` and `tag_name`
- using these as keyword arguments resulted in 
```
Repository.ancestry() got an unexpected keyword argument 'branch_name'
```