### PR TITLE
Correctly support anonymous gcp credentials

### DIFF
--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -932,7 +932,8 @@ impl ObjectStoreBackend for GcsObjectStoreBackend {
                     GcsRefreshableCredentialProvider::new(Arc::clone(fetcher));
                 builder.with_credentials(Arc::new(credential_provider))
             }
-            None | Some(GcsCredentials::FromEnv) | Some(GcsCredentials::Anonymous) => {
+            Some(GcsCredentials::Anonymous) => builder.with_skip_signature(true),
+            None | Some(GcsCredentials::FromEnv) => {
                 GoogleCloudStorageBuilder::from_env()
             }
         };

--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -933,9 +933,7 @@ impl ObjectStoreBackend for GcsObjectStoreBackend {
                 builder.with_credentials(Arc::new(credential_provider))
             }
             Some(GcsCredentials::Anonymous) => builder.with_skip_signature(true),
-            None | Some(GcsCredentials::FromEnv) => {
-                GoogleCloudStorageBuilder::from_env()
-            }
+            None | Some(GcsCredentials::FromEnv) => GoogleCloudStorageBuilder::from_env(),
         };
 
         let builder = builder.with_bucket_name(&self.bucket);


### PR DESCRIPTION
Fix GCP anonymous credentials now that object_store `0.12.1` is out