### PR TITLE
Support changing log levels and setting them in Python

### DIFF
--- a/docs/docs/icechunk-python/faq.md
+++ b/docs/docs/icechunk-python/faq.md
@@ -7,3 +7,12 @@ Icechunk is different from normal Zarr stores because it is stateful. In a distr
 **Does `icechunk-python` include logging?**
 
 Yes! Set the environment variable `ICECHUNK_LOG=icechunk=debug` to print debug logs to stdout. Available "levels" in order of increasing verbosity are `error`, `warn`, `info`, `debug`, `trace`. The default level is `error`. The Rust library uses `tracing-subscriber` crate. The `ICECHUNK_LOG` variable can be used to filter logging following that crate's [documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives). For example, `ICECHUNK_LOG=trace` will set both icechunk and it's dependencies' log levels to `trace` while `ICECHUNK_LOG=icechunk=trace` will enable the `trace` level for icechunk only. For more complex control `ICECHUNK_LOG=debug,icechunk=trace,rustls=info,h2=info,hyper=info` will set `trace` for `icechunk`, `info` for `rustls`,`hyper`, and `h2` crates, and `debug` for every other crate.
+
+You can also use Python's `os.environ` to set or change the value of the variable. If you change the environment variable after `icechunk` was
+imported, you will need to call `icechunk.set_logs_filter(None)` for changes to take effect.
+
+This function also accepts the filter directive. If you prefer not to use environment variables, you can do:
+
+```python
+icechunk.set_logs_filter("debug,icechunk=trace")
+```

--- a/icechunk-python/python/icechunk/__init__.py
+++ b/icechunk-python/python/icechunk/__init__.py
@@ -43,6 +43,7 @@ from icechunk._icechunk_python import (
     VirtualChunkSpec,
     __version__,
     initialize_logs,
+    set_logs_filter,
     spec_version,
 )
 from icechunk.credentials import (
@@ -153,6 +154,7 @@ __all__ = [
     "s3_static_credentials",
     "s3_storage",
     "s3_store",
+    "set_logs_filter",
     "spec_version",
     "tigris_storage",
 ]

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1845,7 +1845,29 @@ def initialize_logs() -> None:
     """
     Initialize the logging system for the library.
 
-    This should be called before any other Icechunk functions are called.
+    Reads the value of the environment variable ICECHUNK_LOG to obtain the filters.
+    This is autamtically called on `import icechunk`.
+    """
+    ...
+
+def set_logs_filter(log_filter_directive: str | None) -> None:
+    """
+    Set filters and log levels for the different modules.
+
+    Examples:
+      - set_logs_filter("trace")  # trace level for all modules
+      - set_logs_filter("error")  # error level for all modules
+      - set_logs_filter("icechunk=debug,info")  # debug level for icechunk, info for everything else
+
+    Full spec for the log_filter_directive syntax is documented in
+    https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+
+    Parameters
+    ----------
+    log_filter_directive: str | None
+        The comma separated list of directives for modules and log levels.
+        If None, the directive will be read from the environment variable
+        ICECHUNK_LOG
     """
     ...
 

--- a/icechunk-python/tests/test_logs.py
+++ b/icechunk-python/tests/test_logs.py
@@ -1,0 +1,57 @@
+import os
+from unittest import mock
+
+import icechunk as ic
+
+
+@mock.patch.dict(os.environ, {"ICECHUNK_LOG": "debug"}, clear=True)
+def test_debug_logs_from_environment(capfd):
+    ic.set_logs_filter(None)
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert "Creating Repository" in capfd.readouterr().out
+
+
+@mock.patch.dict(os.environ, clear=True)
+def test_no_logs_from_environment(capfd):
+    ic.set_logs_filter(None)
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert capfd.readouterr().out == ""
+
+
+@mock.patch.dict(os.environ, clear=True)
+def test_change_log_levels_from_env(capfd):
+    # first with logs disabled
+    ic.set_logs_filter(None)
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert capfd.readouterr().out == ""
+
+    # now with logs enabled
+    with mock.patch.dict(os.environ, {"ICECHUNK_LOG": "debug"}, clear=True):
+        ic.set_logs_filter(None)
+        ic.Repository.create(storage=ic.in_memory_storage())
+        assert "Creating Repository" in capfd.readouterr().out
+
+
+def test_debug_logs_from_argument(capfd):
+    ic.set_logs_filter("debug")
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert "Creating Repository" in capfd.readouterr().out
+
+
+@mock.patch.dict(os.environ, {"ICECHUNK_LOG": "debug"}, clear=True)
+def test_no_logs_from_argument(capfd):
+    ic.set_logs_filter("false")
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert capfd.readouterr().out == ""
+
+
+def test_change_log_levels_from_argument(capfd):
+    # first with logs disabled
+    ic.set_logs_filter("")
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert capfd.readouterr().out == ""
+
+    # now with logs enabled
+    ic.set_logs_filter("debug")
+    ic.Repository.create(storage=ic.in_memory_storage())
+    assert "Creating Repository" in capfd.readouterr().out


### PR DESCRIPTION
This introduces a new function `icechunk.set_logs_filter(str)` that allows setting and changing the logs Icechunk will produce.

On module import, we still initialize logs to the value of ICECHUNK_LOG environment variable (or error level if not present).