### PR TITLE
Add `rewrite_manifests` EAR-1667

### DIFF
--- a/docs/docs/icechunk-python/performance.md
+++ b/docs/docs/icechunk-python/performance.md
@@ -242,9 +242,8 @@ or when reading from a Repository object that was just created.
 At that point, you will want to experiment with different manifest split configurations.
 
 To force Icechunk to rewrite all chunk refs to the current splitting configuration use [`rewrite_manifests`](./reference.md#icechunk.Repository.rewrite_manifests)
---- for the current example this will consolidate to two manifests.
 
-To illustrate, we will use a split size of 3.
+To illustrate, we will use a split size of 3 --- for the current example this will consolidate to two manifests.
 ```python exec="on" session="perf" source="material-block"
 split_config = ManifestSplittingConfig.from_dict(
     {ManifestSplitCondition.AnyArray(): {ManifestSplitDimCondition.Any(): 3}}
@@ -310,7 +309,7 @@ First we persist that configuration to disk
 repo.save_config()
 ```
 
-Now point main to the commit with rewritten manifests
+Now point the `main` branch to the commit with rewritten manifests
 ```python exec="on" session="perf" source="material-block"
 repo.reset_branch("main", repo.lookup_branch("split-experiment-1"))
 ```

--- a/docs/docs/icechunk-python/performance.md
+++ b/docs/docs/icechunk-python/performance.md
@@ -262,10 +262,11 @@ repo = ic.Repository.open(storage, config=repo_config)
 
 We will rewrite the manifests on a different branch
 ```python exec="on" session="perf" source="material-block"
-repo.create_branch("split-experiment-1")
+repo.create_branch("split-experiment-1", repo.lookup_branch("main"))
 snap = repo.rewrite_manifests(
     f"rewrite_manifests with new config", branch="split-experiment-1"
 )
+print(repo.lookup_snapshot(snap).manifests)
 ```
 Now benchmark reads on `main` vs `split-experiment-1`
 ```python exec="on" session="perf" source="material-block"

--- a/docs/docs/icechunk-python/performance.md
+++ b/docs/docs/icechunk-python/performance.md
@@ -20,13 +20,17 @@ For very large arrays (millions of chunks), these files can get quite large.
 By default, Icechunk stores all chunk references in a single manifest file per array.
 Requesting even a single chunk requires downloading the entire manifest.
 In some cases, this can result in a slow time-to-first-byte or large memory usage.
+Similarly, appending a small amount of data to a large array requires
+downloading and rewriting the entire manifest.
 
 !!! note
 
     Note that the chunk sizes in the following examples are tiny for demonstration purposes.
 
-To avoid that, Icechunk lets you split the manifest files by specifying a ``ManifestSplittingConfig``.
 
+### Configuring splitting
+
+To solve this issue, Icechunk lets you __split_ the manifest files by specifying a ``ManifestSplittingConfig``.
 ```python exec="on" session="perf" source="material-block"
 import icechunk as ic
 from icechunk import ManifestSplitCondition, ManifestSplittingConfig, ManifestSplitDimCondition
@@ -38,13 +42,19 @@ split_config = ManifestSplittingConfig.from_dict(
         }
     }
 )
-repo_config = ic.RepositoryConfig(manifest=ic.ManifestConfig(splitting=split_config))
+repo_config = ic.RepositoryConfig(
+    manifest=ic.ManifestConfig(splitting=split_config),
+)
 ```
 
 Then pass the config to `Repository.open` or `Repository.create`
 ```python
 repo = ic.Repository.open(..., config=repo_config)
 ```
+
+!!! important
+
+    Once you find a splitting configuration you like, remember to persist it on-disk using `repo.save_config`.
 
 This particular example splits manifests so that each manifest contains `365 * 24` chunks along the time dimension, and every chunk along every other dimension in a single file.
 
@@ -92,3 +102,132 @@ will result in splitting manifests so that each manifest contains (3 longitude c
 !!! note
 
     Python dictionaries preserve insertion order, so the first condition encountered takes priority.
+
+
+
+### Splitting behaviour
+
+By default, Icechunk minimizes the number of chunk refs that are written in a single commit.
+
+Consider this simple example: a 1D array with split size 1 along axis 0.
+```python exec="on" session="perf" source="material-block"
+import random
+
+import icechunk as ic
+from icechunk import (
+    ManifestSplitCondition,
+    ManifestSplitDimCondition,
+    ManifestSplittingConfig,
+)
+
+split_config = ManifestSplittingConfig.from_dict(
+    {ManifestSplitCondition.AnyArray(): {ManifestSplitDimCondition.Any(): 1}}
+)
+repo_config = ic.RepositoryConfig(manifest=ic.ManifestConfig(splitting=split_config))
+
+storage = ic.local_filesystem_storage(
+    f"/tmp/splitting-test/{random.randint(100, 20000)}"
+)
+# Note any config passed to Repository.create is persisted to disk.
+repo = ic.Repository.create(storage, config=repo_config)
+```
+
+Create an array
+```python exec="on" session="perf" source="material-block"
+import zarr
+
+session = repo.writable_session("main")
+root = zarr.group(session.store)
+name = "array"
+array = root.create_array(name=name, shape=(10,), dtype=int, chunks=(1,))
+```
+
+Now lets write 5 chunk references
+```python exec="on" session="perf" source="material-block"
+import numpy as np
+
+array[:5] = np.arange(10, 15)
+print(session.status())
+```
+
+And commit
+```python exec="on" session="perf" source="material-block"
+snap = session.commit("Add 5 chunks")
+```
+
+Use [`repo.lookup_snapshot`](./reference.md#icechunk.Repository.lookup_snapshot) to examine the manifests associated with a Snapshot
+```python exec="on" session="perf" source="material-block"
+print(repo.lookup_snapshot(snap).manifests)
+```
+
+Let's open the Repository again with a different splitting config --- where 5 chunk references are in a single manifest.
+```python exec="on" session="perf" source="material-block"
+split_config = ManifestSplittingConfig.from_dict(
+    {ManifestSplitCondition.AnyArray(): {ManifestSplitDimCondition.Any(): 5}}
+)
+repo_config = ic.RepositoryConfig(manifest=ic.ManifestConfig(splitting=split_config))
+new_repo = ic.Repository.open(storage, config=repo_config)
+print(new_repo.config.manifest)
+```
+
+Now let's append data.
+```python exec="on" session="perf" source="material-block"
+session = new_repo.writable_session("main")
+array = zarr.open_array(session.store, path=name, mode="a")
+array[6:9] = [1, 2, 3]
+print(session.status())
+```
+
+```python  exec="on" session="perf" source="material-block"
+snap2 = session.commit("appended data")
+repo.lookup_snapshot(snap2).manifests
+```
+
+Look carefully, only one new manifest with the 3 new chunk refs has been written.
+
+Why?
+
+Icechunk minimizes how many chunk references are rewritten at each commit (to save time and memory). The previous splitting configuration (split size of 1) results in manifests that are _compatible_ with the current configuration (split size of 5) because the bounding box of every existing manifest `slice(0, 1)`, `slice(1, 2)`, etc. is fully contained in the bounding boxes implied by the new configuration `[slice(0, 5), slice(5, 10)]`.
+
+Now for a more complex example: let's rewrite the references in `slice(3,7)` i.e. spanning the break in manifests
+
+```python  exec="on" session="perf" source="material-block"
+session = new_repo.writable_session("main")
+array = zarr.open_array(session.store, path=name, mode="a")
+array[3:7] = [1, 2, 3, 4]
+print(session.status())
+```
+
+```python  exec="on" session="perf" source="material-block"
+snap3 = session.commit("rewrite [3,7)")
+print(repo.lookup_snapshot(snap3).manifests)
+```
+This ends up rewriting all refs to two new manifests.
+
+### Rewriting manifests
+
+To force Icechunk to rewrite all chunk refs to the current splitting configuration use [`rewrite_manifests`](./reference.md#icechunk.Repository.rewrite_manifests) --- for the current example this will consolidate to two manifests.
+
+To illustrate, we will use a split size of 3.
+```python exec="on" session="perf" source="material-block"
+split_config = ManifestSplittingConfig.from_dict(
+    {ManifestSplitCondition.AnyArray(): {ManifestSplitDimCondition.Any(): 3}}
+)
+repo_config = ic.RepositoryConfig(
+    manifest=ic.ManifestConfig(splitting=split_config),
+)
+new_repo = ic.Repository.open(storage, config=repo_config)
+
+snap4 = new_repo.rewrite_manifests(
+    f"rewrite_manifests with new config {str(split_config.to_dict())!r}", branch="main"
+)
+```
+
+`rewrite_snapshots` will create a new commit on `branch` with the provided `message`.
+```python exec="on" session="perf" source="material-block"
+print(repo.lookup_snapshot(snap4).manifests)
+```
+
+!!! important
+
+    Once you find a splitting configuration you like, remember to persist it on-disk using `repo.save_config`.

--- a/icechunk-python/python/icechunk/__init__.py
+++ b/icechunk-python/python/icechunk/__init__.py
@@ -195,6 +195,14 @@ def from_dict(split_sizes: SplitSizesDict) -> ManifestSplittingConfig:
     return ManifestSplittingConfig(unwrapped)
 
 
+def to_dict(config: ManifestSplittingConfig) -> SplitSizesDict:
+    return {
+        split_condition: dict(dim_conditions)
+        for split_condition, dim_conditions in config.split_sizes
+    }
+
+
 ManifestSplittingConfig.from_dict = from_dict  # type: ignore[attr-defined]
+ManifestSplittingConfig.to_dict = to_dict  # type: ignore[attr-defined]
 
 initialize_logs()

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1298,6 +1298,9 @@ class PyRepository:
     def garbage_collect(
         self, delete_object_older_than: datetime.datetime
     ) -> GCSummary: ...
+    def rewrite_manifests(
+        self, message: str, *, branch: str, metadata: dict[str, Any] | None = None
+    ) -> str: ...
     def total_chunks_storage(self) -> int: ...
 
 class PySession:

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -634,6 +634,31 @@ class Repository:
 
         return self._repository.garbage_collect(delete_object_older_than)
 
+    def rewrite_manifests(
+        self, message: str, *, branch: str, metadata: dict[str, Any] | None = None
+    ) -> str:
+        """
+        Rewrite manifests for all arrays and commit to the specified branch.
+
+        Parameters
+        ----------
+        message : str
+            The message to write with the commit.
+        branch: str
+            The branch to commit to.
+        metadata : dict[str, Any] | None, optional
+            Additional metadata to store with the commit snapshot.
+
+        Returns
+        -------
+        str
+            The snapshot ID of the new commit.
+
+        """
+        return self._repository.rewrite_manifests(
+            message, branch=branch, metadata=metadata
+        )
+
     def total_chunks_storage(self) -> int:
         """Calculate the total storage used for chunks, in bytes .
 

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -638,7 +638,14 @@ class Repository:
         self, message: str, *, branch: str, metadata: dict[str, Any] | None = None
     ) -> str:
         """
-        Rewrite manifests for all arrays and commit to the specified branch.
+        Rewrite manifests for all arrays.
+
+        This method will start a new writable session on the specified branch,
+        rewrite manifests for all arrays, and then commits with the specifeid ``message``
+        and ``metadata``.
+
+        A JSON representation of the currently active splitting configuration will be
+        stored in the commit's metadata under the key `"splitting_config"`.
 
         Parameters
         ----------

--- a/icechunk-python/python/icechunk/testing/strategies.py
+++ b/icechunk-python/python/icechunk/testing/strategies.py
@@ -1,0 +1,43 @@
+from collections.abc import Iterable
+from typing import cast
+
+import hypothesis.strategies as st
+
+import icechunk as ic
+import zarr
+from zarr.core.metadata import ArrayV3Metadata
+
+
+@st.composite
+def splitting_configs(
+    draw: st.DrawFn, *, arrays: Iterable[zarr.Array]
+) -> ic.ManifestSplittingConfig:
+    config_dict = {}
+    for array in arrays:
+        if draw(st.booleans()):
+            array_condition = ic.ManifestSplitCondition.name_matches(
+                array.path.split("/")[-1]
+            )
+        else:
+            array_condition = ic.ManifestSplitCondition.path_matches(array.path)
+        dimnames = (
+            cast(ArrayV3Metadata, array.metadata).dimension_names or (None,) * array.ndim
+        )
+        dimsize_axis_names = draw(
+            st.lists(
+                st.sampled_from(
+                    tuple(zip(array.shape, range(array.ndim), dimnames, strict=False))
+                ),
+                min_size=1,
+                unique=True,
+            )
+        )
+        for size, axis, dimname in dimsize_axis_names:
+            if dimname is None or draw(st.booleans()):
+                key = ic.ManifestSplitDimCondition.Axis(axis)
+            else:
+                key = ic.ManifestSplitDimCondition.DimensionName(dimname)  # type: ignore[assignment]
+            config_dict[array_condition] = {
+                key: draw(st.integers(min_value=1, max_value=size + 10))
+            }
+    return ic.ManifestSplittingConfig.from_dict(config_dict)  # type: ignore[attr-defined, no-any-return]

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1204,7 +1204,7 @@ impl PyManifestSplitDimCondition {
         match self {
             Axis(axis) => format!("Axis({})", axis),
             DimensionName(name) => format!(r#"DimensionName("{}")"#, name),
-            Any() => "Rest".to_string(),
+            Any() => "Any".to_string(),
         }
     }
 

--- a/icechunk-python/src/errors.rs
+++ b/icechunk-python/src/errors.rs
@@ -1,7 +1,7 @@
 use icechunk::{
     StorageError,
     format::IcechunkFormatError,
-    ops::gc::GCError,
+    ops::{gc::GCError, manifests::ManifestOpsError},
     repository::RepositoryError,
     session::{SessionError, SessionErrorKind},
     store::{StoreError, StoreErrorKind},
@@ -38,6 +38,8 @@ pub(crate) enum PyIcechunkStoreError {
     IcechunkFormatError(#[from] IcechunkFormatError),
     #[error(transparent)]
     GCError(#[from] GCError),
+    #[error(transparent)]
+    ManifestOpsError(#[from] ManifestOpsError),
     #[error("{0}")]
     PyKeyError(String),
     #[error("{0}")]

--- a/icechunk-python/src/repository.rs
+++ b/icechunk-python/src/repository.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -18,6 +19,7 @@ use icechunk::{
     },
     ops::{
         gc::{ExpiredRefAction, GCConfig, GCSummary, expire, garbage_collect},
+        manifests::rewrite_manifests,
         stats::repo_chunks_storage,
     },
     repository::{RepositoryErrorKind, VersionInfo},
@@ -922,6 +924,28 @@ impl PyRepository {
                 })?;
 
             Ok(PySession(Arc::new(RwLock::new(session))))
+        })
+    }
+
+    #[pyo3(signature = (message, branch, metadata=None))]
+    pub fn rewrite_manifests(
+        &self,
+        py: Python<'_>,
+        message: &str,
+        branch: &str,
+        metadata: Option<PySnapshotProperties>,
+    ) -> PyResult<String> {
+        // This function calls block_on, so we need to allow other thread python to make progress
+        py.allow_threads(move || {
+            let metadata = metadata.map(|m| m.into());
+            let result =
+                pyo3_async_runtimes::tokio::get_runtime().block_on(async move {
+                    let lock = self.0.read().await;
+                    rewrite_manifests(lock.deref(), branch, message, metadata)
+                        .await
+                        .map_err(PyIcechunkStoreError::ManifestOpsError)
+                })?;
+            Ok(result.to_string())
         })
     }
 

--- a/icechunk-python/src/repository.rs
+++ b/icechunk-python/src/repository.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    ops::Deref,
     sync::Arc,
 };
 
@@ -941,7 +940,7 @@ impl PyRepository {
             let result =
                 pyo3_async_runtimes::tokio::get_runtime().block_on(async move {
                     let lock = self.0.read().await;
-                    rewrite_manifests(lock.deref(), branch, message, metadata)
+                    rewrite_manifests(&lock, branch, message, metadata)
                         .await
                         .map_err(PyIcechunkStoreError::ManifestOpsError)
                 })?;

--- a/icechunk-python/tests/test_manifest_splitting.py
+++ b/icechunk-python/tests/test_manifest_splitting.py
@@ -6,16 +6,31 @@ import tempfile
 
 import numpy as np
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 import icechunk as ic
 import xarray as xr
 import zarr
 from icechunk import ManifestSplitCondition, ManifestSplitDimCondition
+from icechunk.testing.strategies import splitting_configs
 from icechunk.xarray import to_icechunk
+from zarr.testing.strategies import arrays as zarr_arrays
 
 SHAPE = (3, 4, 17)
 CHUNKS = (1, 1, 1)
 DIMS = ("time", "latitude", "longitude")
+
+
+@given(data=st.data())
+def test_splitting_config_dict_roundtrip(data):
+    arrays = data.draw(
+        st.lists(
+            zarr_arrays(compressors=st.none(), attrs=st.none(), zarr_formats=st.just(3))
+        )
+    )
+    config = data.draw(splitting_configs(arrays=arrays))
+    assert ic.ManifestSplittingConfig.from_dict(config.to_dict()) == config
 
 
 def test_manifest_splitting_appends():

--- a/icechunk/src/ops/manifests.rs
+++ b/icechunk/src/ops/manifests.rs
@@ -1,0 +1,30 @@
+use crate::{
+    Repository,
+    format::{SnapshotId, snapshot::SnapshotProperties},
+    session::SessionError,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestOpsError {
+    #[error("error rewriting manifests")]
+    ManifestRewriteError(#[from] Box<SessionError>),
+}
+
+pub type ManifestOpsResult<A> = Result<A, ManifestOpsError>;
+
+pub async fn rewrite_manifests(
+    repository: &Repository,
+    branch: &str,
+    message: &str,
+    properties: Option<SnapshotProperties>,
+) -> ManifestOpsResult<SnapshotId> {
+    let mut session = repository
+        .writable_session(branch)
+        .await
+        .map_err(|e| ManifestOpsError::ManifestRewriteError(Box::new(e.into())))?;
+
+    session
+        .rewrite_manifests(message, properties)
+        .await
+        .map_err(|e| ManifestOpsError::ManifestRewriteError(Box::new(e)))
+}

--- a/icechunk/src/ops/mod.rs
+++ b/icechunk/src/ops/mod.rs
@@ -11,8 +11,8 @@ use crate::{
     repository::{RepositoryError, RepositoryResult},
     storage,
 };
-
 pub mod gc;
+pub mod manifests;
 pub mod stats;
 
 pub async fn all_roots<'a>(

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -954,6 +954,7 @@ mod tests {
             snapshot::{ArrayShape, DimensionName},
         },
         new_local_filesystem_storage,
+        ops::manifests::rewrite_manifests,
         session::{SessionError, get_chunk},
         storage::new_in_memory_storage,
     };
@@ -1414,6 +1415,86 @@ mod tests {
                 .await?
         }
         verify_data(&session, 10).await;
+
+        Ok(())
+    }
+
+    #[tokio_test]
+    async fn tests_manifest_rewriting_simple() -> Result<(), Box<dyn Error>> {
+        let split_size = 3u32;
+        let dim_size = 10u32;
+
+        let shape = ArrayShape::new(vec![(dim_size as u64, 1)]).unwrap();
+        let dimension_names = Some(vec!["t".into()]);
+        let temp_path: Path = "/temperature".try_into().unwrap();
+        let split_config = ManifestSplittingConfig::with_size(split_size);
+
+        let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+        let repository = create_repo_with_split_manifest_config(
+            &temp_path,
+            &shape,
+            &dimension_names,
+            &split_config,
+            Some(Arc::clone(&storage)),
+        )
+        .await?;
+
+        let mut total_manifests = 0;
+        assert_manifest_count(&storage, total_manifests).await;
+
+        // only add refs that will be packed in the first split.
+        let mut session = repository.writable_session("main").await?;
+        for i in 0..dim_size {
+            session
+                .set_chunk_ref(
+                    temp_path.clone(),
+                    ChunkIndices(vec![i]),
+                    Some(ChunkPayload::Inline(format!("{0}", i).into())),
+                )
+                .await?
+        }
+        session.commit("first split", None).await?;
+        total_manifests += 4;
+        assert_manifest_count(&storage, total_manifests).await;
+
+        let split_sizes = vec![(
+            ManifestSplitCondition::PathMatches { regex: r".*".to_string() },
+            vec![ManifestSplitDim {
+                condition: ManifestSplitDimCondition::Any,
+                num_chunks: 12,
+            }],
+        )];
+
+        let new_repo =
+            reopen_repo_with_new_splitting_config(&repository, Some(split_sizes));
+
+        rewrite_manifests(
+            &new_repo,
+            "main",
+            "rewrite_manifests with split-size=12",
+            None,
+        )
+        .await?;
+        total_manifests += 1;
+        assert_manifest_count(&storage, total_manifests).await;
+
+        // make sure data is correct
+        let new_repo = reopen_repo_with_new_splitting_config(&repository, None);
+        let session = new_repo
+            .readonly_session(&VersionInfo::BranchTipRef("main".to_string()))
+            .await?;
+        for i in 0..dim_size {
+            let val = get_chunk(
+                session
+                    .get_chunk_reader(&temp_path, &ChunkIndices(vec![i]), &ByteRange::ALL)
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(val, Bytes::copy_from_slice(format!("{0}", i).as_bytes()));
+        }
 
         Ok(())
     }

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -1495,7 +1495,7 @@ mod tests {
         let new_repo =
             reopen_repo_with_new_splitting_config(&repository, Some(split_sizes));
 
-        rewrite_manifests(
+        let snap = rewrite_manifests(
             &new_repo,
             "main",
             "rewrite_manifests with split-size=12",
@@ -1505,6 +1505,13 @@ mod tests {
         total_manifests += 1;
         assert_manifest_count(&storage, total_manifests).await;
         validate_data().await;
+        assert!(
+            repository
+                .lookup_snapshot(&snap)
+                .await?
+                .metadata
+                .contains_key("splitting_config")
+        );
 
         // split manifests to smaller sizes
         let split_sizes = vec![(
@@ -1518,11 +1525,23 @@ mod tests {
         let new_repo =
             reopen_repo_with_new_splitting_config(&repository, Some(split_sizes));
 
-        rewrite_manifests(&new_repo, "main", "rewrite_manifests with split-size=4", None)
-            .await?;
+        let snap = rewrite_manifests(
+            &new_repo,
+            "main",
+            "rewrite_manifests with split-size=4",
+            None,
+        )
+        .await?;
         total_manifests += 3;
         assert_manifest_count(&storage, total_manifests).await;
         validate_data().await;
+        assert!(
+            repository
+                .lookup_snapshot(&snap)
+                .await?
+                .metadata
+                .contains_key("splitting_config")
+        );
 
         Ok(())
     }

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -972,8 +972,7 @@ impl Session {
 
         let splitting_config_serialized =
             serde_json::to_value(self.config.manifest().splitting())?;
-        let mut properties =
-            properties.unwrap_or_else(|| BTreeMap::<String, Value>::new());
+        let mut properties = properties.unwrap_or_else(BTreeMap::<String, Value>::new);
         properties.insert("splitting_config".to_string(), splitting_config_serialized);
         self._commit(message, Some(properties), true).await
     }

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -6,10 +6,9 @@ use futures::{FutureExt, Stream, StreamExt, TryStreamExt, future::Either, stream
 use itertools::{Itertools as _, enumerate, repeat_n};
 use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::{
     cmp::min,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     convert::Infallible,
     future::{Future, ready},
     ops::Range,
@@ -972,7 +971,7 @@ impl Session {
 
         let splitting_config_serialized =
             serde_json::to_value(self.config.manifest().splitting())?;
-        let mut properties = properties.unwrap_or_else(BTreeMap::<String, Value>::new);
+        let mut properties = properties.unwrap_or_default();
         properties.insert("splitting_config".to_string(), splitting_config_serialized);
         self._commit(message, Some(properties), true).await
     }


### PR DESCRIPTION
Closes #986

Updated docs here: https://icechunk--1002.org.readthedocs.build/en/1002/icechunk-python/performance/#splitting-manifests 

Questions:
1. Should we allow filtering by a prefix?
2. Shall we automatically add the splitting config to the commit's `metadata`? and make sure it's easy to use for creating a new repo?

Decisions:
1. I punted on (1)
2. I've done (2) just to record the config, but didn't add the ability to easily create a ManifestSplittingConfig from the info in metadata.