### PR TITLE
Fix typo in Virtual Datasets Docs

### DIFF
--- a/docs/docs/icechunk-python/virtual.md
+++ b/docs/docs/icechunk-python/virtual.md
@@ -120,7 +120,7 @@ Now we can read the dataset from the store using xarray to confirm everything we
 
 ```python
 ds = xr.open_zarr(
-    store,
+    session.store,
     zarr_version=3,
     consolidated=False,
     chunks={},


### PR DESCRIPTION
I just went through the example here and I think that no variable called `store` is defined in the steps preceeding this (unless I missed something).