### PR TITLE
Implement new `with_read_only` Zarr `Store` method

### DIFF
--- a/docs/docs/icechunk-python/faq.md
+++ b/docs/docs/icechunk-python/faq.md
@@ -16,3 +16,10 @@ This function also accepts the filter directive. If you prefer not to use enviro
 ```python
 icechunk.set_logs_filter("debug,icechunk=trace")
 ```
+
+**How to get a read-only Icechunk store?**
+
+Zarr has a few mechanisms to define read-only zarr stores. These don't always work perfectly with Icechunk,
+because Icechunk has a more advanced session model. The safest way to make sure you don't write to
+an Icechunk repo is to use `Repository.readonly_session` to create the session. It doesn't matter what
+you do to the Zarr store, a read-only session cannot do writes.

--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -42,6 +42,7 @@ class IcechunkStore(Store, SyncMixin):
         self,
         store: PyStore,
         allow_pickling: bool,
+        read_only: bool | None = None,
         *args: Any,
         **kwargs: Any,
     ):
@@ -49,7 +50,8 @@ class IcechunkStore(Store, SyncMixin):
 
         This should not be called directly, instead use the `create`, `open_existing` or `open_or_create` class methods.
         """
-        super().__init__(read_only=store.read_only)
+        read_only = read_only if read_only is not None else store.read_only
+        super().__init__(read_only=read_only)
         if store is None:
             raise ValueError(
                 "An IcechunkStore should not be created with the default constructor, instead use either the create or open_existing class methods."
@@ -79,6 +81,13 @@ class IcechunkStore(Store, SyncMixin):
         state["_store"] = PyStore.from_bytes(store_repr)
         state["_read_only"] = state["_store"].read_only
         self.__dict__ = state
+
+    def with_read_only(self, read_only: bool = False) -> Store:
+        new_store = IcechunkStore(
+            store=self._store, allow_pickling=self._allow_pickling, read_only=read_only
+        )
+        new_store._is_open = False
+        return new_store
 
     @property
     def session(self) -> "Session":


### PR DESCRIPTION
This new method is not really implementable in Icechunk. If the user created a readonly session there is no real good way to turn it into a writable session, and viceversa.

The implementation we are writing "lies" in this sense. It's pretending to return a new store with the requested readonly-ness, but not really.