### PR TITLE
Configure mkdocs site_url so 404s look better on deployed site

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Icechunk
 site_description: >-
   Open-source, cloud-native transactional tensor storage engine
 site_author: Earthmover PBC
-site_url: https://icechunk.io
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://icechunk.io']
 repo_url: https://github.com/earth-mover/icechunk
 repo_name: earth-mover/icechunk
 copyright: Earthmover PBC # @see overrides/partials/footer.html


### PR DESCRIPTION
Similar to Icechunk, VirtualiZarr was having issues with 404 pages being rendered poorly on readthedocs. For an Icechunk example, see https://icechunk.io/en/latest/icechunk-python/unknown-page. @chuckwondo pointed me to this elegant solution so I thought I'd propose it for your library as well.