### PR TITLE
Manifest preload magic methods

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -421,6 +421,12 @@ class ManifestPreloadCondition:
     def false() -> ManifestPreloadCondition:
         """Create a preload condition that never matches any manifests"""
         ...
+    def __and__(other: ManifestPreloadCondition) -> ManifestPreloadCondition:
+        """Create a preload condition that matches if both this condition and `other` match."""
+        ...
+    def __or__(other: ManifestPreloadCondition) -> ManifestPreloadCondition:
+        """Create a preload condition that matches if either this condition or `other` match."""
+        ...
 
 class ManifestPreloadConfig:
     """Configuration for how Icechunk manifest preload on session creation"""

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -992,6 +992,13 @@ impl PyManifestPreloadCondition {
     pub fn r#false() -> Self {
         Self::False()
     }
+
+    pub fn __and__(&self, other: &Self) -> Self {
+        Self::And(vec![self.clone(), other.clone()])
+    }
+    pub fn __or__(&self, other: &Self) -> Self {
+        Self::Or(vec![self.clone(), other.clone()])
+    }
 }
 
 impl From<&PyManifestPreloadCondition> for ManifestPreloadCondition {

--- a/icechunk-python/tests/test_config.py
+++ b/icechunk-python/tests/test_config.py
@@ -219,5 +219,28 @@ def test_can_change_deep_config_values() -> None:
     )
 
 
+def test_manifest_preload_magic_methods() -> None:
+    assert (
+        icechunk.ManifestPreloadCondition.and_conditions(
+            [
+                icechunk.ManifestPreloadCondition.true(),
+                icechunk.ManifestPreloadCondition.name_matches("foo"),
+            ]
+        )
+        == icechunk.ManifestPreloadCondition.true()
+        & icechunk.ManifestPreloadCondition.name_matches("foo")
+    )
+    assert (
+        icechunk.ManifestPreloadCondition.or_conditions(
+            [
+                icechunk.ManifestPreloadCondition.true(),
+                icechunk.ManifestPreloadCondition.name_matches("foo"),
+            ]
+        )
+        == icechunk.ManifestPreloadCondition.true()
+        | icechunk.ManifestPreloadCondition.name_matches("foo")
+    )
+
+
 def test_spec_version():
     assert icechunk.spec_version() >= 1


### PR DESCRIPTION
Adds magic methods to the `ManifestPreloadCondition` Python class, so that rather than require users to remember the class method for comparison, then can use the `&` and `|` operators.

```py
icechunk.ManifestPreloadCondition.and_conditions(
    [
        icechunk.ManifestPreloadCondition.true(),
        icechunk.ManifestPreloadCondition.name_matches("foo"),
    ]
) ==
icechunk.ManifestPreloadCondition.true() & icechunk.ManifestPreloadCondition.name_matches("foo")
```