### PR TITLE
Manifest splitting magic methods

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -530,6 +530,14 @@ class ManifestSplitCondition:
         """Create a splitting condition that matches any array."""
         ...
 
+    def __or__(self, other: ManifestSplitCondition) -> ManifestSplitCondition:
+        """Create a splitting condition that matches if either this condition or `other` matches"""
+        ...
+
+    def __and__(self, other: ManifestSplitCondition) -> ManifestSplitCondition:
+        """Create a splitting condition that matches if both this condition and `other` match"""
+        ...
+
 class ManifestSplitDimCondition:
     """Conditions for specifying dimensions along which to shard manifests."""
     class Axis:

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1168,6 +1168,14 @@ impl PyManifestSplitCondition {
         self.hash(&mut hasher);
         hasher.finish() as usize
     }
+
+    fn __or__(&self, other: &Self) -> Self {
+        Self::Or(vec![self.clone(), other.clone()])
+    }
+
+    fn __and__(&self, other: &Self) -> Self {
+        Self::And(vec![self.clone(), other.clone()])
+    }
 }
 
 impl From<&PyManifestSplitCondition> for ManifestSplitCondition {

--- a/icechunk-python/tests/test_manifest_splitting.py
+++ b/icechunk-python/tests/test_manifest_splitting.py
@@ -294,3 +294,22 @@ def test_manifest_splitting_complex_config(config, expected_split_sizes):
             for nchunks, splitsize in zip(SHAPE, expected_split_sizes, strict=False)
         )
         assert len(os.listdir(f"{tmpdir}/manifests")) == nmanifests
+
+
+def test_manifest_splitting_magic_methods():
+    assert ManifestSplitCondition.and_conditions(
+        [
+            ManifestSplitCondition.name_matches("temperature"),
+            ManifestSplitCondition.name_matches("salinity"),
+        ]
+    ) == ManifestSplitCondition.name_matches(
+        "temperature"
+    ) & ManifestSplitCondition.name_matches("salinity")
+    assert ManifestSplitCondition.or_conditions(
+        [
+            ManifestSplitCondition.name_matches("temperature"),
+            ManifestSplitCondition.name_matches("salinity"),
+        ]
+    ) == ManifestSplitCondition.name_matches(
+        "temperature"
+    ) | ManifestSplitCondition.name_matches("salinity")


### PR DESCRIPTION
Builds on #1038 with magic methods for `&` and `|` operators for manifest splitting as well.

```py
ManifestSplitCondition.and_conditions(
    [
        ManifestSplitCondition.name_matches("temperature"),
        ManifestSplitCondition.name_matches("salinity"),
    ]
) == ManifestSplitCondition.name_matches("temperature") & ManifestSplitCondition.name_matches("salinity")
```
