### PR TITLE
Parallelize size statistics gathering

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1356,7 +1356,9 @@ class PyRepository:
     def rewrite_manifests(
         self, message: str, *, branch: str, metadata: dict[str, Any] | None = None
     ) -> str: ...
-    def total_chunks_storage(self) -> int: ...
+    def total_chunks_storage(
+        self, process_manifests_concurrently: int | None = None
+    ) -> int: ...
 
 class PySession:
     @classmethod

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -728,7 +728,9 @@ class Repository:
             message, branch=branch, metadata=metadata
         )
 
-    def total_chunks_storage(self) -> int:
+    def total_chunks_storage(
+        self, process_manifests_concurrently: int | None = None
+    ) -> int:
         """Calculate the total storage used for chunks, in bytes .
 
         It reports the storage needed to store all snapshots in the repository that
@@ -738,6 +740,11 @@ class Repository:
         `garbage_collection`.
 
         The result includes only native chunks, not adding virtual or inline chunks.
+
+        Parameters
+        ----------
+        process_manifests_concurrently : int | None
+            Process this many manifests concurrently. Defaults to 10.
         """
 
-        return self._repository.total_chunks_storage()
+        return self._repository.total_chunks_storage(process_manifests_concurrently)

--- a/icechunk-python/src/repository.rs
+++ b/icechunk-python/src/repository.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    num::NonZeroU16,
     sync::Arc,
 };
 
@@ -222,6 +223,7 @@ impl PySnapshotInfo {
             id = self.id,
             parent = format_option_to_string(self.parent_id.as_ref()),
             at = datetime_repr(&self.written_at),
+            // TODO: what would be a better default here?
             message = self.message.chars().take(10).collect::<String>() + "...",
         )
     }
@@ -650,7 +652,7 @@ impl PyRepository {
                             Arc::clone(lock.asset_manager()),
                         )
                     };
-                    asset_manager.snapshot_ancestry(&snapshot_id).await
+                    asset_manager.snapshot_info_ancestry(&snapshot_id).await
                 })
                 .map_err(PyIcechunkStoreError::RepositoryError)?
                 .map_err(PyIcechunkStoreError::RepositoryError);
@@ -1048,7 +1050,11 @@ impl PyRepository {
         })
     }
 
-    pub fn total_chunks_storage(&self, py: Python<'_>) -> PyResult<u64> {
+    pub fn total_chunks_storage(
+        &self,
+        py: Python<'_>,
+        process_manifests_concurrently: Option<NonZeroU16>,
+    ) -> PyResult<u64> {
         // This function calls block_on, so we need to allow other thread python to make progress
         py.allow_threads(move || {
             let result =
@@ -1065,6 +1071,9 @@ impl PyRepository {
                         storage.as_ref(),
                         &storage_settings,
                         asset_manager,
+                        process_manifests_concurrently.unwrap_or(
+                            NonZeroU16::try_from(10).unwrap_or(NonZeroU16::MIN),
+                        ),
                     )
                     .await
                     .map_err(PyIcechunkStoreError::RepositoryError)?;

--- a/icechunk/src/asset_manager.rs
+++ b/icechunk/src/asset_manager.rs
@@ -1,7 +1,7 @@
 use async_stream::try_stream;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use futures::Stream;
+use futures::{Stream, TryStreamExt};
 use quick_cache::{Weighter, sync::Cache};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -309,19 +309,33 @@ impl AssetManager {
     /// Returns the sequence of parents of the current session, in order of latest first.
     /// Output stream includes snapshot_id argument
     #[instrument(skip(self))]
-    pub async fn snapshot_ancestry(
+    pub async fn snapshot_info_ancestry(
         self: Arc<Self>,
         snapshot_id: &SnapshotId,
     ) -> RepositoryResult<impl Stream<Item = RepositoryResult<SnapshotInfo>> + use<>>
     {
+        let res =
+            self.snapshot_ancestry(snapshot_id).await?.and_then(|snap| async move {
+                let info = snap.as_ref().try_into()?;
+                Ok(info)
+            });
+        Ok(res)
+    }
+
+    /// Returns the sequence of parents of the current session, in order of latest first.
+    /// Output stream includes snapshot_id argument
+    #[instrument(skip(self))]
+    pub async fn snapshot_ancestry(
+        self: Arc<Self>,
+        snapshot_id: &SnapshotId,
+    ) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + use<>>
+    {
         let mut this = self.fetch_snapshot(snapshot_id).await?;
         let stream = try_stream! {
-            let info: SnapshotInfo = this.as_ref().try_into()?;
-            yield info;
+            yield Arc::clone(&this);
             while let Some(parent) = this.parent_id() {
                 let snap = self.fetch_snapshot(&parent).await?;
-                let info: SnapshotInfo = snap.as_ref().try_into()?;
-                yield info;
+                yield Arc::clone(&snap);
                 this = snap;
             }
         };

--- a/icechunk/src/ops/gc.rs
+++ b/icechunk/src/ops/gc.rs
@@ -12,7 +12,7 @@ use crate::{
         ChunkId, IcechunkFormatError, IcechunkFormatErrorKind, ManifestId, SnapshotId,
         manifest::ChunkPayload,
     },
-    ops::pointed_snapshots,
+    ops::pointed_snapshot_ids,
     refs::{Ref, RefError, delete_branch, delete_tag, list_refs},
     repository::{RepositoryError, RepositoryErrorKind},
     storage::{self, DeleteObjectsResult, ListInfo},
@@ -174,7 +174,7 @@ pub async fn garbage_collect(
     }
 
     tracing::info!("Finding GC roots");
-    let all_snaps = pointed_snapshots(
+    let all_snaps = pointed_snapshot_ids(
         storage,
         storage_settings,
         Arc::clone(&asset_manager),
@@ -448,7 +448,7 @@ pub async fn expire_ref(
     // here we'll populate the results of every expired snapshot
     let mut released = HashSet::new();
     let ancestry =
-        Arc::clone(&asset_manager).snapshot_ancestry(&snap_id).await?.peekable();
+        Arc::clone(&asset_manager).snapshot_info_ancestry(&snap_id).await?.peekable();
 
     pin!(ancestry);
 

--- a/icechunk/src/ops/stats.rs
+++ b/icechunk/src/ops/stats.rs
@@ -1,16 +1,74 @@
-use futures::TryStreamExt as _;
-use std::{collections::HashSet, sync::Arc};
-use tokio::pin;
+use futures::{TryStream, TryStreamExt as _, future::ready, stream};
+use std::{
+    collections::HashSet,
+    num::NonZeroU16,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
     Storage,
     asset_manager::AssetManager,
-    format::{IcechunkFormatError, IcechunkFormatErrorKind, manifest::ChunkPayload},
-    repository::RepositoryResult,
+    format::{ChunkId, ManifestId, manifest::ChunkPayload},
+    ops::pointed_snapshots,
+    repository::{RepositoryErrorKind, RepositoryResult},
     storage,
 };
 
-use super::pointed_snapshots;
+async fn manifest_chunks_storage(
+    manifest_id: ManifestId,
+    manifest_size: u64,
+    asset_manager: Arc<AssetManager>,
+    seen_chunks: Arc<Mutex<HashSet<ChunkId>>>,
+) -> RepositoryResult<u64> {
+    let manifest = asset_manager.fetch_manifest(&manifest_id, manifest_size).await?;
+    let mut size = 0;
+    for payload in manifest.chunk_payloads() {
+        match payload {
+            Ok(ChunkPayload::Ref(chunk_ref)) => {
+                if seen_chunks
+                    .lock()
+                    .map_err(|e| {
+                        RepositoryErrorKind::Other(format!(
+                            "Thread panic during manifest_chunk_storage: {e}"
+                        ))
+                    })?
+                    .insert(chunk_ref.id)
+                {
+                    size += chunk_ref.length;
+                }
+            }
+            Ok(_) => {}
+            // TODO: don't skip errors
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    "Error in chunk payload iterator"
+                );
+            }
+        }
+    }
+    Ok(size)
+}
+
+pub fn try_unique_stream<S, T, E, F, V>(
+    f: F,
+    stream: S,
+) -> impl TryStream<Ok = T, Error = E>
+where
+    F: Fn(&S::Ok) -> V,
+    S: TryStream<Ok = T, Error = E>,
+    V: Eq + std::hash::Hash,
+{
+    let mut seen = HashSet::new();
+    stream.try_filter(move |item| {
+        let v = f(item);
+        if seen.insert(v) {
+            futures::future::ready(true)
+        } else {
+            futures::future::ready(false)
+        }
+    })
+}
 
 /// Compute the total size in bytes of all committed repo chunks.
 /// It doesn't include inline or virtual chunks.
@@ -18,6 +76,7 @@ pub async fn repo_chunks_storage(
     storage: &(dyn Storage + Send + Sync),
     storage_settings: &storage::Settings,
     asset_manager: Arc<AssetManager>,
+    process_manifests_concurrently: NonZeroU16,
 ) -> RepositoryResult<u64> {
     let extra_roots = Default::default();
     let all_snaps = pointed_snapshots(
@@ -28,48 +87,30 @@ pub async fn repo_chunks_storage(
     )
     .await?;
 
-    let mut seen_manifests = HashSet::new();
-    let mut seen_chunks = HashSet::new();
-    let mut size = 0;
+    let all_manifest_infos = all_snaps
+        // this could be slightly optimized by not collecting all manifest info records into a vec
+        // but we don't expect too many, and they are small anyway
+        .map_ok(|snap| stream::iter(snap.manifest_files().map(Ok).collect::<Vec<_>>()))
+        .try_flatten();
+    let unique_manifest_infos = try_unique_stream(|mi| mi.id.clone(), all_manifest_infos);
 
-    pin!(all_snaps);
-    while let Some(snap_id) = all_snaps.try_next().await? {
-        let snap = asset_manager.fetch_snapshot(&snap_id).await?;
+    let seen_chunks = &Arc::new(Mutex::new(HashSet::new()));
+    let asset_manager = &asset_manager;
 
-        for manifest_id in snap.manifest_files().map(|mf| mf.id) {
-            if !seen_manifests.contains(&manifest_id) {
-                let manifest_info =
-                    snap.manifest_info(&manifest_id).ok_or_else(|| {
-                        IcechunkFormatError::from(
-                            IcechunkFormatErrorKind::ManifestInfoNotFound {
-                                manifest_id: manifest_id.clone(),
-                            },
-                        )
-                    })?;
-                let manifest = asset_manager
-                    .fetch_manifest(&manifest_id, manifest_info.size_bytes)
-                    .await?;
-                for payload in manifest.chunk_payloads() {
-                    match payload {
-                        Ok(ChunkPayload::Ref(chunk_ref)) => {
-                            if seen_chunks.insert(chunk_ref.id) {
-                                size += chunk_ref.length;
-                            }
-                        }
-                        Ok(_) => {}
-                        // TODO: don't skip errors
-                        Err(err) => {
-                            tracing::error!(
-                                error = %err,
-                                "Error in chunk payload iterator"
-                            );
-                        }
-                    }
-                }
+    let res = unique_manifest_infos
+        .map_ok(|manifest_info| async move {
+            let manifest_size = manifest_info.size_bytes;
+            manifest_chunks_storage(
+                manifest_info.id,
+                manifest_size,
+                Arc::clone(asset_manager),
+                Arc::clone(seen_chunks),
+            )
+            .await
+        })
+        .try_buffered(process_manifests_concurrently.get() as usize)
+        .try_fold(0, |total, partial| ready(Ok(total + partial)))
+        .await?;
 
-                seen_manifests.insert(manifest_id);
-            }
-        }
-    }
-    Ok(size)
+    Ok(res)
 }

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -93,6 +93,8 @@ pub enum RepositoryErrorKind {
     CannotDeleteMain,
     #[error("the storage used by this Icechunk repository is read-only: {0}")]
     ReadonlyStorage(String),
+    #[error("unexpected error: {0}")]
+    Other(String),
 }
 
 pub type RepositoryError = ICError<RepositoryErrorKind>;
@@ -437,7 +439,7 @@ impl Repository {
         snapshot_id: &SnapshotId,
     ) -> RepositoryResult<impl Stream<Item = RepositoryResult<SnapshotInfo>> + '_ + use<'_>>
     {
-        Arc::clone(&self.asset_manager).snapshot_ancestry(snapshot_id).await
+        Arc::clone(&self.asset_manager).snapshot_info_ancestry(snapshot_id).await
     }
 
     #[instrument(skip(self))]
@@ -446,7 +448,7 @@ impl Repository {
         snapshot_id: &SnapshotId,
     ) -> RepositoryResult<impl Stream<Item = RepositoryResult<SnapshotInfo>> + use<>>
     {
-        Arc::clone(&self.asset_manager).snapshot_ancestry(snapshot_id).await
+        Arc::clone(&self.asset_manager).snapshot_info_ancestry(snapshot_id).await
     }
 
     /// Returns the sequence of parents of the snapshot pointed by the given version

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -1177,7 +1177,7 @@ impl Session {
             let current_snapshot =
                 self.asset_manager.fetch_snapshot(&ref_data.snapshot).await?;
             let ancestry = Arc::clone(&self.asset_manager)
-                .snapshot_ancestry(&current_snapshot.id())
+                .snapshot_info_ancestry(&current_snapshot.id())
                 .await?
                 .map_ok(|meta| meta.id);
             let new_commits =

--- a/icechunk/tests/test_stats.rs
+++ b/icechunk/tests/test_stats.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
-use std::sync::Arc;
+use std::{num::NonZeroU16, sync::Arc};
 
 use bytes::Bytes;
 use chrono::Utc;
@@ -124,6 +124,7 @@ pub async fn do_test_repo_chunks_storage(
         storage.as_ref(),
         &storage_settings,
         Arc::clone(&asset_manager),
+        NonZeroU16::try_from(10).unwrap(),
     )
     .await
     .unwrap();
@@ -135,6 +136,7 @@ pub async fn do_test_repo_chunks_storage(
         storage.as_ref(),
         &storage_settings,
         Arc::clone(&asset_manager),
+        NonZeroU16::try_from(10).unwrap(),
     )
     .await
     .unwrap();
@@ -158,6 +160,7 @@ pub async fn do_test_repo_chunks_storage(
         storage.as_ref(),
         &storage_settings,
         Arc::clone(&asset_manager),
+        NonZeroU16::try_from(10).unwrap(),
     )
     .await
     .unwrap();
@@ -188,6 +191,7 @@ pub async fn do_test_repo_chunks_storage(
         storage.as_ref(),
         &storage_settings,
         Arc::clone(&asset_manager),
+        NonZeroU16::try_from(10).unwrap(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
This adds concurrency to `repo_chunks_storage`.

I verified manually this improves performance very significantly, but benchmarks should be able to tell us.