### PR TITLE
Fix Rendering of some code blocks

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -81,7 +81,8 @@ Icechunk allows repos to contain [virtual chunks](./virtual.md). To allow for re
 
 For example, if we wanted to configure an icechunk repo to be able to contain virtual chunks from an `s3` bucket called `my-s3-bucket` in `us-east-1`, we would do the following:
 
-```python exec="on" session="config" source="material-block"
+```python
+
 config.virtual_chunk_containers = [
     icechunk.VirtualChunkContainer(
         url_prefix="s3://my-s3-bucket/",
@@ -94,7 +95,7 @@ config.virtual_chunk_containers = [
 
 If we also wanted to configure the repo to be able to contain virtual chunks from another `s3` bucket called `my-other-s3-bucket` in `us-west-2`, we would do the following:
 
-```python exec="on" session="config" source="material-block"
+```python
 config.set_virtual_chunk_container(
     icechunk.VirtualChunkContainer(
         url_prefix="s3://my-other-s3-bucket/",

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -114,7 +114,7 @@ Now at read time, if Icechunk encounters a virtual chunk url that starts with `s
 
 ### [`manifest`](./reference.md#icechunk.RepositoryConfig.manifest)
 
-The manifest configuration for the repository. [`ManifestConfig`](./reference.md#icechunk.ManifestConfig) allows you to configure behavior for how manifests are loaded. in particular, the `preload` parameter allows you to configure the preload behavior of the manifest using a [`ManifestPreloadConfig`](./reference.md#icechunk.ManifestPreloadConfig). This allows you to control the number of references that are loaded into memory when a session is created, along with which manifests are available to be preloaded.
+The manifest configuration for the repository. [`ManifestConfig`](./reference.md#icechunk.ManifestConfig) allows you to configure behavior for how manifests are loaded. In particular, the `preload` parameter allows you to configure the preload behavior of the manifest using a [`ManifestPreloadConfig`](./reference.md#icechunk.ManifestPreloadConfig). This allows you to control the number of references that are loaded into memory when a session is created, along with which manifests are available to be preloaded.
 
 #### Example
 


### PR DESCRIPTION
These blocks were not rendering properly: https://icechunk.io/en/latest/configuration/#example

<img width="750" height="516" alt="image" src="https://github.com/user-attachments/assets/9aa9c46d-dd30-4d1e-aeaf-f791bac240ee" />



I am a little alarmed that there were no errors thrown by the CI, but this at least means the docs will look good in the short term