### PR TITLE
Update docs on virtual references to match VirtualiZarr v2.0's updated API

### DIFF
--- a/icechunk-python/docs/docs/virtual.md
+++ b/icechunk-python/docs/docs/virtual.md
@@ -288,7 +288,7 @@ Here is how we can set the chunk at key `c/0` to point to a file on my local fil
 
 ```python
 config = ic.config.RepositoryConfig.default()
-config.set_virtual_chunk_container(ic.virtual.VirtualChunkContainer("s3://mybucket/my/data/", ic.storage.local_filesystem_store("/path/to/my")))
+config.set_virtual_chunk_container(ic.virtual.VirtualChunkContainer("file:///path/to/my/", ic.storage.local_filesystem_store("/path/to/my")))
 repo = ic.Repository.create(storage, config)
 session = repo.writable_session("main")
 session.store.set_virtual_ref('c/0', 'file:///path/to/my/file.nc', offset=20, length=100)


### PR DESCRIPTION
We should re-run the example to double-check everything still works as expected.