### PR TITLE
Avoid creating Rust Vec instances on the Python edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "miette",
  "pyo3",
  "pyo3-async-runtimes",
+ "pyo3-bytes",
  "rand 0.9.2",
  "rmp-serde",
  "serde",
@@ -2539,6 +2540,16 @@ checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-bytes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781c3168801c4ae94f1e642e6d41b7a1db67b62ab1bf6138e0771f76d29529b3"
+dependencies = [
+ "bytes",
+ "pyo3",
 ]
 
 [[package]]

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -42,6 +42,7 @@ miette = { version = "7.6.0", features = ["fancy"] }
 clap = { version = "4.5", features = ["derive"], optional = true }
 rand = "0.9.2"
 rmp-serde = "1.3.0"
+pyo3-bytes = "0.2.0"
 
 [features]
 cli = ["clap", "icechunk/cli"]


### PR DESCRIPTION
Functions such as `zarr.Store.get` and `zarr.Store.set` were using `Vec<u8>` as the interface mechanism. This proved to be very slow in usages where there is high single threded concurrency.

We are now using
[PyBytes](https://docs.rs/pyo3-bytes/0.2.0/pyo3_bytes/index.html) which uses unsafe Rust to avoid copying and allocation.

In tests, we get a bandwidth improvement between 10x and 20x when copyng from and to local filesystem or in memory stores.