### PR TITLE
Updates the glad-ingest jupyter notebook to reflect the new session fork and session merge capabilities

### DIFF
--- a/docs/docs/ingestion/glad-ingest.ipynb
+++ b/docs/docs/ingestion/glad-ingest.ipynb
@@ -488,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a07f0ef8-da71-480f-b79d-6e6f5564ac58",
    "metadata": {},
    "outputs": [],
@@ -1147,6 +1147,43 @@
     "\n",
     "Now that we have our infrastructure, we will generate a single task for each tile.\n",
     "\n",
+    "Writes are distributed via the `Session.fork()` method, this creates a new `ForkSession` object that can be pickled. Below we subtly update the `update_tile` function to use a `ForkSession` instead of a regular `Session` for better typehints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "690c6d88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icechunk.session import ForkSession\n",
+    "\n",
+    "def update_tile(\n",
+    "    *, session: ForkSession, tiling: TilingGrid, tile: str, year: int\n",
+    ") -> ForkSession:\n",
+    "    \"\"\"\n",
+    "    Read a single tile, and write it to the appropriate region of the Icechunk store using Zarr.\n",
+    "\n",
+    "    Returns the Icechunk session, to allow for coordinated distributed writes. See\n",
+    "    https://icechunk.io/en/latest/parallel/ for more.\n",
+    "    \"\"\"\n",
+    "    tile = read_tile(tile=tile, year=year, chunks=None)\n",
+    "    tile.drop_vars(\"spatial_ref\").to_zarr(\n",
+    "        session.store,\n",
+    "        region=tiling.get_region(tile),\n",
+    "        consolidated=False,\n",
+    "    )\n",
+    "    return session"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "215b40fe",
+   "metadata": {},
+   "source": [
+    "Next, we need to generate the tasks.\n",
+    "\n",
     "Helpfully the dataset comes with a text file listing available tiles ([example](https://storage.googleapis.com/earthenginepartners-hansen/GLCLU2000-2020/v2/2000.txt)).\n",
     "\n",
     "Each task will be responsible for reading a single tile with `read_tile` and writing it to the Icechunk store with `update_tile`.\n",
@@ -1156,12 +1193,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "92e6d4f5-a9ed-48c2-b421-253fe24313a3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_update_tile_tasks_for_year(year: int):\n",
+    "def get_update_tile_tasks_for_year(year: int, session: ic.Session):\n",
     "    \"\"\"\n",
     "    The GLAD dataset comes with a text file of available tiles.\n",
     "\n",
@@ -1172,10 +1209,12 @@
     "    import dask\n",
     "    import fsspec\n",
     "\n",
+    "    fork = session.fork()\n",
+    "\n",
     "    with fsspec.open(f\"{ROOT_URI}/{year}.txt\", mode=\"r\") as f:\n",
     "        return map(\n",
     "            lambda line: dask.delayed(update_tile)(\n",
-    "                session=session,\n",
+    "                session=fork,\n",
     "                tiling=tiling,\n",
     "                tile=line.split(\"/\")[-1].removesuffix(\".tif\"),\n",
     "                year=year,\n",
@@ -1209,11 +1248,11 @@
    "source": [
     "repo = ic.Repository.open(storage)\n",
     "session = repo.writable_session(\"main\")\n",
-    "with session.allow_pickling():\n",
-    "    tasks = [get_update_tile_tasks_for_year(year) for year in tiling.year]\n",
-    "    tasks = tuple(itertools.chain(*tasks))\n",
-    "    print(f\"Issuing {len(tasks)} tasks.\")\n",
-    "    sessions = dask.compute(*tasks, scheduler=client)"
+    "\n",
+    "tasks = [get_update_tile_tasks_for_year(year, session) for year in tiling.year]\n",
+    "tasks = tuple(itertools.chain(*tasks))\n",
+    "print(f\"Issuing {len(tasks)} tasks.\")\n",
+    "distributed_sessions = dask.compute(*tasks, scheduler=client)"
    ]
   },
   {
@@ -1221,7 +1260,8 @@
    "id": "cfe5eb6e-c44a-486c-8e0c-5f281738dafc",
    "metadata": {},
    "source": [
-    "### Merge the sessions and commit."
+    "### Merge the sessions and commit.\n",
+    "Bare in mind the return value of `session.merge()` is `None`, it modifies the session in place."
    ]
   },
   {
@@ -1231,9 +1271,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from icechunk.distributed import merge_sessions\n",
+    "session.merge(*distributed_sessions)\n",
     "\n",
-    "session = merge_sessions(session, *sessions)\n",
     "session.commit(\"write GLAD LCLU data\")"
    ]
   },


### PR DESCRIPTION
- Currently the notebook within the guide is out of date, still using the old allow_pickling context manager
- Updates the notebook to use the new behaviour described in [the docs](https://icechunk.io/en/stable/parallel/#cooperative-distributed-writes)
- Note to maintainers: I've not run this code, as I don't have access to coiled (nor do I want to incur the cost 👀 ) so you'll need to run this yourselves to get the output before updating the docs!