### PR TITLE
chore: add pep-723 metadata to default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
         # ]
         # ///
         #
-        # This script automatically imports the development branch of zarr to check for issues
+        # This script automatically imports the development branch of icechunk to check for issues
 
         import icechunk
         icechunk.print_debug_info()

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,6 +39,24 @@ body:
         - [Minimal Complete Verifiable Examples](https://stackoverflow.com/help/mcve)
         - [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports)
 
+        You must list dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example).
+        When put in a file named `issue.py` calling `uv run issue.py` should show the issue.
+      value: |
+        ```python
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "icechunk@git+https://github.com/earthmover/icechunk.git@main",
+        #   "zarr@git+https://github.com/zarr-developers/zarr-python.git@main",
+        # ]
+        # ///
+        #
+        # This script automatically imports the development branch of zarr to check for issues
+
+        import icechunk
+        icechunk.print_debug_info()
+        # your reproducer code
+        ```
       options:
         - label: Minimal example — the example is as focused as reasonably possible to demonstrate the underlying issue in xarray.
         - label: Complete example — the example is self-contained, including all data and the text of any traceback.


### PR DESCRIPTION
Add pep-723 style metadata to the default issue template. This should render as in: https://github.com/zarr-developers/zarr-python/issues/new?template=bug_report.yml

<img width="1084" height="511" alt="image" src="https://github.com/user-attachments/assets/84bd0728-d23c-4d4b-9d70-604a2c0814c3" />


the hope being that this will guide users to 

1. test their bugs against the dev version of icechunk
2. make sure they are truly reproducible.
3. make bug reports that are very easy to verify