### PR TITLE
use the to_icechunk method for coordinated writes

### DIFF
--- a/docs/docs/ingestion/glad-ingest.ipynb
+++ b/docs/docs/ingestion/glad-ingest.ipynb
@@ -1147,7 +1147,7 @@
     "\n",
     "Now that we have our infrastructure, we will generate a single task for each tile.\n",
     "\n",
-    "Writes are distributed via the `Session.fork()` method, this creates a new `ForkSession` object that can be pickled. Below we update the `update_tile` function to use the `to_icechunk` function, this is a requirement for distributed writes, `to_zarr` does not support pickling, alongisde the `ForkSession` object."
+    "Writes are distributed via the `Session.fork()` method, this creates a new `ForkSession` object that can be pickled. Below we update the `update_tile` function to use the `to_icechunk` function, this is a requirement for distributed writes, `to_zarr` does not support pickling, furthermore we make the changes required to use the `ForkSession` object."
    ]
   },
   {


### PR DESCRIPTION
- follow up to my comments [here](https://github.com/earth-mover/icechunk/pull/1110)
- to_icechunk must be used for coordinated writes, to zarr doesn't work