### PR TITLE
Validate url on set_virtual_ref[s]

### DIFF
--- a/icechunk-python/src/errors.rs
+++ b/icechunk-python/src/errors.rs
@@ -1,6 +1,6 @@
 use icechunk::{
     StorageError,
-    format::IcechunkFormatError,
+    format::{IcechunkFormatError, manifest::VirtualReferenceError},
     ops::{gc::GCError, manifests::ManifestOpsError},
     repository::RepositoryError,
     session::{SessionError, SessionErrorKind},
@@ -40,6 +40,8 @@ pub(crate) enum PyIcechunkStoreError {
     GCError(#[from] GCError),
     #[error(transparent)]
     ManifestOpsError(#[from] ManifestOpsError),
+    #[error(transparent)]
+    VirtualReferenceError(#[from] VirtualReferenceError),
     #[error("{0}")]
     PyKeyError(String),
     #[error("{0}")]

--- a/icechunk/src/format/manifest.rs
+++ b/icechunk/src/format/manifest.rs
@@ -215,8 +215,12 @@ pub enum VirtualReferenceErrorKind {
         "no virtual chunk container can handle the chunk location ({0}), edit the repository configuration adding a virtual chunk container for the chunk references, see https://icechunk.io/en/stable/virtual/"
     )]
     NoContainerForUrl(String),
-    #[error("error parsing virtual ref URL")]
-    CannotParseUrl(#[from] url::ParseError),
+    #[error("error parsing virtual ref URL: {url}")]
+    CannotParseUrl {
+        #[source]
+        cause: url::ParseError,
+        url: String,
+    },
     #[error("invalid credentials for virtual reference of type {0}")]
     InvalidCredentials(String),
     #[error("a virtual chunk in this repository resolves to the url prefix {url}, to be able to fetch the chunk you need to authorize the virtual chunk container when you open/create the repository, see https://icechunk.io/en/stable/virtual/", url = .0.url_prefix())]
@@ -253,15 +257,21 @@ where
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct VirtualChunkLocation(pub String);
+pub struct VirtualChunkLocation(String);
 
 impl VirtualChunkLocation {
+    pub fn url(&self) -> &str {
+        self.0.as_str()
+    }
+
     pub fn from_absolute_path(
         path: &str,
     ) -> Result<VirtualChunkLocation, VirtualReferenceError> {
         // make sure we can parse the provided URL before creating the enum
         // TODO: consider other validation here.
-        let url = url::Url::parse(path)?;
+        let url = url::Url::parse(path).map_err(|e| {
+            VirtualReferenceErrorKind::CannotParseUrl { cause: e, url: path.to_string() }
+        })?;
         let scheme = url.scheme();
         let new_path: String = url
             .path_segments()

--- a/icechunk/src/format/manifest.rs
+++ b/icechunk/src/format/manifest.rs
@@ -215,7 +215,7 @@ pub enum VirtualReferenceErrorKind {
         "no virtual chunk container can handle the chunk location ({0}), edit the repository configuration adding a virtual chunk container for the chunk references, see https://icechunk.io/en/stable/virtual/"
     )]
     NoContainerForUrl(String),
-    #[error("error parsing virtual ref URL: {url}")]
+    #[error("error parsing virtual ref URL: {url:?}")]
     CannotParseUrl {
         #[source]
         cause: url::ParseError,

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -309,7 +309,7 @@ impl Session {
         &self,
         chunk_location: &VirtualChunkLocation,
     ) -> Option<&VirtualChunkContainer> {
-        self.virtual_resolver.matching_container(chunk_location.0.as_str())
+        self.virtual_resolver.matching_container(chunk_location.url())
     }
 
     /// Compute an overview of the current session changes
@@ -745,11 +745,7 @@ impl Session {
                 Ok(Some(
                     async move {
                         resolver
-                            .fetch_chunk(
-                                location.0.as_str(),
-                                &byte_range,
-                                checksum.as_ref(),
-                            )
+                            .fetch_chunk(location.url(), &byte_range, checksum.as_ref())
                             .await
                             .map_err(|e| e.into())
                     }
@@ -907,7 +903,9 @@ impl Session {
     ) -> SessionResult<impl Stream<Item = SessionResult<String>> + '_> {
         let stream =
             self.all_chunks().await?.try_filter_map(|(_, info)| match info.payload {
-                ChunkPayload::Virtual(reference) => ready(Ok(Some(reference.location.0))),
+                ChunkPayload::Virtual(reference) => {
+                    ready(Ok(Some(reference.location.url().to_string())))
+                }
                 _ => ready(Ok(None)),
             });
         Ok(stream)

--- a/icechunk/src/store.rs
+++ b/icechunk/src/store.rs
@@ -379,7 +379,7 @@ impl Store {
                     && session.matching_container(&reference.location).is_none()
                 {
                     return Err(StoreErrorKind::InvalidVirtualChunkContainer {
-                        chunk_location: reference.location.0,
+                        chunk_location: reference.location.url().to_string(),
                     }
                     .into());
                 }

--- a/icechunk/src/virtual_chunks.rs
+++ b/icechunk/src/virtual_chunks.rs
@@ -303,8 +303,12 @@ impl VirtualChunkResolver {
         checksum: Option<&Checksum>,
     ) -> Result<Bytes, VirtualReferenceError> {
         // this resolves things like /../
-        let url = Url::parse(chunk_location)
-            .map_err(VirtualReferenceErrorKind::CannotParseUrl)?;
+        let url = Url::parse(chunk_location).map_err(|e| {
+            VirtualReferenceErrorKind::CannotParseUrl {
+                cause: e,
+                url: chunk_location.to_string(),
+            }
+        })?;
         let fetcher = self.get_fetcher(&url).await?;
         fetcher.fetch_chunk(&url, range, checksum).await
     }

--- a/icechunk/tests/test_large_manifests.rs
+++ b/icechunk/tests/test_large_manifests.rs
@@ -68,7 +68,6 @@ async fn test_write_large_number_of_refs() -> Result<(), Box<dyn std::error::Err
 
     let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_TASKS));
 
-    ("num_tasks", &NUM_TASKS);
     for i in 0..NUM_TASKS {
         let semaphore = semaphore.clone();
         let cloned_session = Arc::clone(&session);
@@ -87,10 +86,12 @@ async fn test_write_large_number_of_refs() -> Result<(), Box<dyn std::error::Err
 
 async fn write_chunk_refs_batch(session: Arc<RwLock<Session>>, batch: usize) {
     // let mut guard = session.write().await;
-    ("starting batch", &batch);
     for i in batch * TASK_CHUNK_SIZE..(batch + 1) * TASK_CHUNK_SIZE {
         let payload = ChunkPayload::Virtual(VirtualChunkRef {
-            location: VirtualChunkLocation(format!("s3://foo/bar/{i}")),
+            location: VirtualChunkLocation::from_absolute_path(
+                format!("s3://foo/bar/{i}").as_str(),
+            )
+            .unwrap(),
             offset: 0,
             length: 1,
             checksum: None,
@@ -106,5 +107,4 @@ async fn write_chunk_refs_batch(session: Arc<RwLock<Session>>, batch: usize) {
             .await
             .expect("Failed to write chunk ref");
     }
-    ("finished batch", &batch);
 }

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -540,7 +540,7 @@ async fn test_zarr_store_virtual_refs_minio_set_and_get()
     };
     assert!(matches!(
                 store.set_virtual_ref("array/c/0/0/0", bad_ref, true).await,
-                Err(StoreError{kind: StoreErrorKind::InvalidVirtualChunkContainer { chunk_location },..}) if chunk_location == bad_location.0));
+                Err(StoreError{kind: StoreErrorKind::InvalidVirtualChunkContainer { chunk_location },..}) if chunk_location == bad_location.url()));
     Ok(())
 }
 


### PR DESCRIPTION
Now we verify the URL can be parsed as an absolute URL and fail immediately if it cannot.

This will have a small impart on `set_virtual_refs` performance.