### PR TITLE
Make `validate_container` default to True in `set_virtual_ref[s]`

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1435,13 +1435,14 @@ class PyStore:
         offset: int,
         length: int,
         checksum: str | datetime.datetime | None = None,
-        validate_container: bool = False,
+        validate_container: bool = True,
     ) -> None: ...
     def set_virtual_refs(
         self,
         array_path: str,
         chunks: list[VirtualChunkSpec],
-        validate_containers: bool,
+        *,
+        validate_containers: bool = True,
     ) -> list[tuple[int, ...]] | None: ...
     async def delete(self, key: str) -> None: ...
     async def delete_dir(self, prefix: str) -> None: ...

--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -240,7 +240,7 @@ class IcechunkStore(Store, SyncMixin):
         offset: int,
         length: int,
         checksum: str | datetime | None = None,
-        validate_container: bool = False,
+        validate_container: bool = True,
     ) -> None:
         """Store a virtual reference to a chunk.
 
@@ -268,7 +268,7 @@ class IcechunkStore(Store, SyncMixin):
         array_path: str,
         chunks: list[VirtualChunkSpec],
         *,
-        validate_containers: bool = False,
+        validate_containers: bool = True,
     ) -> list[tuple[int, ...]] | None:
         """Store multiple virtual references for the same array.
 


### PR DESCRIPTION
Now that virtual chunk containers are mandatory for reads, we should make them at least the default (if not mandatory) for writes.

This gives better UX, users of VZ won't produce repos that are broken for reads, just because they forget to create the containers.