### PR TITLE
Warn if caches are too small

### DIFF
--- a/icechunk-python/tests/test_logs.py
+++ b/icechunk-python/tests/test_logs.py
@@ -1,7 +1,9 @@
 import os
+import re
 from unittest import mock
 
 import icechunk as ic
+import zarr
 
 
 @mock.patch.dict(os.environ, {"ICECHUNK_LOG": "debug"}, clear=True)
@@ -55,3 +57,44 @@ def test_change_log_levels_from_argument(capfd) -> None:
     ic.set_logs_filter("debug")
     ic.Repository.create(storage=ic.in_memory_storage())
     assert "Creating Repository" in capfd.readouterr().out
+
+
+def test_warn_on_small_caches(capfd) -> None:
+    # first with logs disabled
+    ic.set_logs_filter("warn")
+    config = ic.RepositoryConfig(
+        caching=ic.CachingConfig(num_chunk_refs=0, num_snapshot_nodes=0),
+    )
+    repo = ic.Repository.create(storage=ic.in_memory_storage(), config=config)
+    session = repo.writable_session("main")
+
+    array1 = zarr.create_array(
+        name="array1",
+        store=session.store,
+        shape=(10),
+        dtype="int64",
+        zarr_format=3,
+        chunks=(2,),
+        fill_value=-1,
+    )
+    array2 = zarr.create_array(
+        name="array2",
+        store=session.store,
+        shape=(10),
+        dtype="int64",
+        zarr_format=3,
+        chunks=(2,),
+        fill_value=-1,
+    )
+    array1[:] = 42
+    array2[:] = 42
+    session.commit("msg")
+
+    out = capfd.readouterr().out
+    # we only warn once for manifests and once for snapshots
+    assert len(re.findall("WARN", out)) == 2
+
+    assert re.search("5 chunk references", out)
+    assert re.search("keep 0 references", out)
+    assert re.search("3 nodes", out)
+    assert re.search("keep 0 nodes", out)


### PR DESCRIPTION
We are emiting a warning first time we see a manifest that is more than half the cache size. Same for snapshots that are larger than 1/5 the cache size.

Closes: #1112 