### PR TITLE
Force virtual chunk containers ur_prefix to finish in /

### DIFF
--- a/icechunk-python/tests/test_can_read_old.py
+++ b/icechunk-python/tests/test_can_read_old.py
@@ -46,7 +46,7 @@ def mk_repo(
             s3_compatible=True,
             force_path_style=True,
         )
-        container = ic.VirtualChunkContainer("s3://testbucket", virtual_store_config)
+        container = ic.VirtualChunkContainer("s3://testbucket/", virtual_store_config)
         config.set_virtual_chunk_container(container)
     credentials = ic.containers_credentials(
         {

--- a/icechunk-python/tests/test_concurrency.py
+++ b/icechunk-python/tests/test_concurrency.py
@@ -123,7 +123,7 @@ async def test_thread_concurrency() -> None:
         force_path_style=True,
         s3_compatible=True,
     )
-    container = icechunk.VirtualChunkContainer("s3://testbucket", store_config)
+    container = icechunk.VirtualChunkContainer("s3://testbucket/", store_config)
     config.set_virtual_chunk_container(container)
     config.inline_chunk_threshold_bytes = 0
     credentials = icechunk.containers_credentials(

--- a/icechunk-python/tests/test_config.py
+++ b/icechunk-python/tests/test_config.py
@@ -124,7 +124,7 @@ def test_virtual_chunk_containers() -> None:
         allow_http=True,
         s3_compatible=True,
     )
-    container = icechunk.VirtualChunkContainer("s3://testbucket", store_config)
+    container = icechunk.VirtualChunkContainer("s3://testbucket/", store_config)
     config.set_virtual_chunk_container(container)
     assert re.match(
         r"RepositoryConfig\(inline_chunk_threshold_bytes=None, get_partial_values_concurrency=None, compression=None, caching=None, storage=None, manifest=.*\)",
@@ -132,14 +132,14 @@ def test_virtual_chunk_containers() -> None:
     )
     assert config.virtual_chunk_containers
     assert len(config.virtual_chunk_containers) == 1
-    assert config.virtual_chunk_containers["s3://testbucket"] == container
+    assert config.virtual_chunk_containers["s3://testbucket/"] == container
 
     config.clear_virtual_chunk_containers()
     assert {} == config.virtual_chunk_containers
 
     config.set_virtual_chunk_container(container)
     assert len(config.virtual_chunk_containers) == 1
-    assert config.virtual_chunk_containers["s3://testbucket"] == container
+    assert config.virtual_chunk_containers["s3://testbucket/"] == container
 
 
 def test_can_change_deep_config_values() -> None:

--- a/icechunk-python/tests/test_regressions.py
+++ b/icechunk-python/tests/test_regressions.py
@@ -41,7 +41,7 @@ async def test_issue_418() -> None:
         s3_compatible=True,
         force_path_style=True,
     )
-    container = VirtualChunkContainer("s3://testbucket", store_config)
+    container = VirtualChunkContainer("s3://testbucket/", store_config)
     config.set_virtual_chunk_container(container)
     credentials = containers_credentials(
         {

--- a/icechunk-python/tests/test_virtual_ref.py
+++ b/icechunk-python/tests/test_virtual_ref.py
@@ -46,7 +46,7 @@ async def test_write_minio_virtual_refs() -> None:
         s3_compatible=True,
         force_path_style=True,
     )
-    container = VirtualChunkContainer("s3://testbucket", store_config)
+    container = VirtualChunkContainer("s3://testbucket/", store_config)
     config.set_virtual_chunk_container(container)
     credentials = containers_credentials(
         {
@@ -225,12 +225,12 @@ async def test_write_minio_virtual_refs() -> None:
     [
         (
             "s3",
-            "s3://earthmover-sample-data",
+            "s3://earthmover-sample-data/",
             ObjectStoreConfig.S3(S3Options(region="us-east-1", anonymous=True)),
         ),
         (
             "http",
-            "https://earthmover-sample-data.s3.amazonaws.com",
+            "https://earthmover-sample-data.s3.amazonaws.com/",
             http_store(),
         ),
     ],
@@ -384,7 +384,7 @@ def test_error_on_nonexisting_virtual_chunk_container() -> None:
 
 def test_error_on_non_authorized_virtual_chunk_container() -> None:
     store_config = local_filesystem_store("/foo")
-    container = VirtualChunkContainer("file:///foo", store_config)
+    container = VirtualChunkContainer("file:///foo/", store_config)
     config = RepositoryConfig.default()
     config.set_virtual_chunk_container(container)
     repo = Repository.open_or_create(
@@ -405,7 +405,7 @@ def test_error_on_non_authorized_virtual_chunk_container() -> None:
         chunks=[
             VirtualChunkSpec(
                 index=[0],
-                location="file:///foo",
+                location="file:///foo/bar",
                 offset=0,
                 length=4,
             ),

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -112,7 +112,7 @@ async fn create_local_repository(
 
     let mut containers = vec![
         VirtualChunkContainer::new(
-            "s3://testbucket".to_string(),
+            "s3://testbucket/".to_string(),
             ObjectStoreConfig::S3(S3Options {
                 region: Some("us-east-1".to_string()),
                 endpoint_url: None,
@@ -123,7 +123,7 @@ async fn create_local_repository(
         )
         .unwrap(),
         VirtualChunkContainer::new(
-            "s3://earthmover-sample-data".to_string(),
+            "s3://earthmover-sample-data/".to_string(),
             ObjectStoreConfig::S3(S3Options {
                 region: Some("us-east-1".to_string()),
                 endpoint_url: None,
@@ -134,12 +134,12 @@ async fn create_local_repository(
         )
         .unwrap(),
         VirtualChunkContainer::new(
-            "gcs://testbucket".to_string(),
+            "gcs://testbucket/".to_string(),
             ObjectStoreConfig::Gcs(Default::default()),
         )
         .unwrap(),
         VirtualChunkContainer::new(
-            "gcs://earthmover-sample-data".to_string(),
+            "gcs://earthmover-sample-data/".to_string(),
             ObjectStoreConfig::Gcs(Default::default()),
         )
         .unwrap(),
@@ -160,7 +160,7 @@ async fn create_local_repository(
     .into();
 
     if let Some(chunks_path) = chunks_path {
-        let prefix = format!("file://{}", chunks_path.to_str().unwrap());
+        let prefix = format!("file://{}/", chunks_path.to_str().unwrap());
         containers.push(
             VirtualChunkContainer::new(
                 prefix.clone(),
@@ -183,7 +183,7 @@ async fn create_minio_repository() -> Repository {
 
     let containers = vec![
         VirtualChunkContainer::new(
-            "s3://testbucket".to_string(),
+            "s3://testbucket/".to_string(),
             ObjectStoreConfig::S3Compatible(S3Options {
                 region: Some(String::from("us-east-1")),
                 endpoint_url: Some("http://localhost:9000".to_string()),
@@ -196,7 +196,7 @@ async fn create_minio_repository() -> Repository {
     ];
 
     let credentials = [(
-        "s3://testbucket".to_string(),
+        "s3://testbucket/".to_string(),
         Some(Credentials::S3(S3Credentials::Static(S3StaticCredentials {
             access_key_id: "minio123".to_string(),
             secret_access_key: "minio123".to_string(),
@@ -688,7 +688,7 @@ async fn test_zarr_store_with_multiple_virtual_chunk_containers()
 
     let containers = vec![
         VirtualChunkContainer::new(
-            "s3://testbucket".to_string(),
+            "s3://testbucket/".to_string(),
             ObjectStoreConfig::S3Compatible(S3Options {
                 region: Some(String::from("us-east-1")),
                 endpoint_url: Some("http://localhost:9000".to_string()),
@@ -699,12 +699,12 @@ async fn test_zarr_store_with_multiple_virtual_chunk_containers()
         )
         .unwrap(),
         VirtualChunkContainer::new(
-            format!("file://{}", chunk_dir.path().to_str().unwrap()),
+            format!("file://{}/", chunk_dir.path().to_str().unwrap()),
             ObjectStoreConfig::LocalFileSystem(PathBuf::new()),
         )
         .unwrap(),
         VirtualChunkContainer::new(
-            "s3://earthmover-sample-data".to_string(),
+            "s3://earthmover-sample-data/".to_string(),
             ObjectStoreConfig::S3(S3Options {
                 region: Some(String::from("us-east-1")),
                 endpoint_url: None,


### PR DESCRIPTION
This is more secure: Now repository creators cannot create containers with prefixes such as `s3://a` which would match too more than intended.

Example: same for things like bucket like `foo-dev` and `foo-prod`, can no longer be both authorized by a `s3://foo` container.

Existing containers, persisted to config files still work because Icechunk will automatically add the trailing `/` if needed.

Closes: #1125
Closes: #1100