### PR TITLE
Introduce an HTTP concurrency limiter per repo

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -993,6 +993,7 @@ class RepositoryConfig:
         inline_chunk_threshold_bytes: int | None = None,
         get_partial_values_concurrency: int | None = None,
         compression: CompressionConfig | None = None,
+        max_concurrent_requests: int | None = None,
         caching: CachingConfig | None = None,
         storage: StorageSettings | None = None,
         virtual_chunk_containers: dict[str, VirtualChunkContainer] | None = None,
@@ -1009,6 +1010,9 @@ class RepositoryConfig:
             The number of concurrent requests to make when getting partial values from storage.
         compression: CompressionConfig | None
             The compression configuration for the repository.
+        max_concurrent_requests: int | None
+            The maximum number of concurrent HTTP requests Icechunk will do for this repo.
+            Default is 256.
         caching: CachingConfig | None
             The caching configuration for the repository.
         storage: StorageSettings | None
@@ -1077,6 +1081,28 @@ class RepositoryConfig:
         ----------
         value: CompressionConfig | None
             The compression configuration for the repository.
+        """
+        ...
+    @property
+    def max_concurrent_requests(self) -> int | None:
+        """
+        The maximum number of concurrent HTTP requests Icechunk will do for this repo.
+
+        Returns
+        -------
+        int | None
+            The maximum number of concurrent HTTP requests Icechunk will do for this repo.
+        """
+        ...
+    @max_concurrent_requests.setter
+    def max_concurrent_requests(self, value: int | None) -> None:
+        """
+        Set the maximum number of concurrent HTTP requests Icechunk should do for this repo.
+
+        Parameters
+        ----------
+        value: int | None
+            The maximum allowed.
         """
         ...
     @property

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1429,6 +1429,8 @@ pub struct PyRepositoryConfig {
     #[pyo3(get, set)]
     pub compression: Option<Py<PyCompressionConfig>>,
     #[pyo3(get, set)]
+    pub max_concurrent_requests: Option<u16>,
+    #[pyo3(get, set)]
     pub caching: Option<Py<PyCachingConfig>>,
     #[pyo3(get, set)]
     pub storage: Option<Py<PyStorageSettings>>,
@@ -1464,6 +1466,7 @@ impl TryFrom<&PyRepositoryConfig> for RepositoryConfig {
                 inline_chunk_threshold_bytes: value.inline_chunk_threshold_bytes,
                 get_partial_values_concurrency: value.get_partial_values_concurrency,
                 compression: value.compression.as_ref().map(|c| (&*c.borrow(py)).into()),
+                max_concurrent_requests: value.max_concurrent_requests,
                 caching: value.caching.as_ref().map(|c| (&*c.borrow(py)).into()),
                 storage: value.storage.as_ref().map(|s| (&*s.borrow(py)).into()),
                 virtual_chunk_containers: cont,
@@ -1483,6 +1486,7 @@ impl From<RepositoryConfig> for PyRepositoryConfig {
                 Py::new(py, Into::<PyCompressionConfig>::into(c))
                     .expect("Cannot create instance of CompressionConfig")
             }),
+            max_concurrent_requests: value.max_concurrent_requests,
             caching: value.caching.map(|c| {
                 Py::new(py, Into::<PyCachingConfig>::into(c))
                     .expect("Cannot create instance of CachingConfig")
@@ -1512,12 +1516,13 @@ impl PyRepositoryConfig {
     }
 
     #[new]
-    #[pyo3(signature = (inline_chunk_threshold_bytes = None, get_partial_values_concurrency = None, compression = None, caching = None, storage = None, virtual_chunk_containers = None, manifest = None))]
+    #[pyo3(signature = (inline_chunk_threshold_bytes = None, get_partial_values_concurrency = None, compression = None, max_concurrent_requests = None, caching = None, storage = None, virtual_chunk_containers = None, manifest = None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         inline_chunk_threshold_bytes: Option<u16>,
         get_partial_values_concurrency: Option<u16>,
         compression: Option<Py<PyCompressionConfig>>,
+        max_concurrent_requests: Option<u16>,
         caching: Option<Py<PyCachingConfig>>,
         storage: Option<Py<PyStorageSettings>>,
         virtual_chunk_containers: Option<HashMap<String, PyVirtualChunkContainer>>,
@@ -1527,6 +1532,7 @@ impl PyRepositoryConfig {
             inline_chunk_threshold_bytes,
             get_partial_values_concurrency,
             compression,
+            max_concurrent_requests,
             caching,
             storage,
             virtual_chunk_containers,

--- a/icechunk-python/tests/test_config.py
+++ b/icechunk-python/tests/test_config.py
@@ -166,6 +166,7 @@ def test_can_change_deep_config_values() -> None:
     config.storage.storage_class = "STANDARD_IA"
     config.manifest = icechunk.ManifestConfig()
     config.manifest.preload = icechunk.ManifestPreloadConfig(max_total_refs=42)
+    config.max_concurrent_requests = 10
     config.manifest.preload.preload_if = icechunk.ManifestPreloadCondition.and_conditions(
         [
             icechunk.ManifestPreloadCondition.true(),
@@ -188,6 +189,7 @@ def test_can_change_deep_config_values() -> None:
     assert stored_config.inline_chunk_threshold_bytes == 5
     assert stored_config.compression
     assert stored_config.compression.level == 2
+    assert stored_config.max_concurrent_requests == 10
     assert stored_config.caching
     assert stored_config.caching.num_chunk_refs == 8
     assert stored_config.storage

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -2616,8 +2616,12 @@ mod tests {
     async fn test_repository_with_updates() -> Result<(), Box<dyn Error>> {
         let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
         let storage_settings = storage.default_settings();
-        let asset_manager =
-            AssetManager::new_no_cache(Arc::clone(&storage), storage_settings.clone(), 1);
+        let asset_manager = AssetManager::new_no_cache(
+            Arc::clone(&storage),
+            storage_settings.clone(),
+            1,
+            100,
+        );
 
         let array_id = NodeId::random();
         let chunk1 = ChunkInfo {

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -13,8 +13,8 @@ use icechunk::{
     Repository, RepositoryConfig, Storage,
     asset_manager::AssetManager,
     config::{
-        ManifestConfig, ManifestSplitCondition, ManifestSplitDim,
-        ManifestSplitDimCondition, ManifestSplittingConfig,
+        DEFAULT_MAX_CONCURRENT_REQUESTS, ManifestConfig, ManifestSplitCondition,
+        ManifestSplitDim, ManifestSplitDimCondition, ManifestSplittingConfig,
     },
     format::{ByteRange, ChunkIndices, Path, snapshot::ArrayShape},
     new_in_memory_storage,
@@ -620,6 +620,7 @@ pub async fn do_test_expire_and_garbage_collect(
         storage.clone(),
         storage_settings.clone(),
         1,
+        DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
 
     let result = expire(
@@ -675,6 +676,7 @@ pub async fn do_test_expire_and_garbage_collect(
         storage.clone(),
         storage_settings.clone(),
         1,
+        DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
 
     let summary = garbage_collect(
@@ -740,6 +742,7 @@ pub async fn test_expire_and_garbage_collect_deliting_expired_refs()
         storage.clone(),
         storage_settings.clone(),
         1,
+        DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
 
     let result = expire(

--- a/icechunk/tests/test_stats.rs
+++ b/icechunk/tests/test_stats.rs
@@ -10,6 +10,7 @@ use chrono::Utc;
 use icechunk::{
     Repository, RepositoryConfig, Storage,
     asset_manager::AssetManager,
+    config::DEFAULT_MAX_CONCURRENT_REQUESTS,
     format::{
         ChunkIndices, Path,
         manifest::{ChunkPayload, VirtualChunkLocation, VirtualChunkRef},
@@ -70,6 +71,7 @@ pub async fn do_test_repo_chunks_storage(
         storage.clone(),
         storage_settings.clone(),
         1,
+        DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
 
     let repo = Repository::create(


### PR DESCRIPTION
This PR is in no way final, or perfect. It adds a semaphore to the AssetManager, which will limit concurrency per repo to a certain configurable value (default 256 concurrent requests).

Known ways in which this is not great:
* There is a minor source of extra concurrency: large objects can be further devided in smaller requests by the `Storage` implementation. This is solvable by having the Storage share the same semaphore.
* The semaphore doesn't survive serialization. If the repo is serialized now there are two semaphores and double the max requests. Users should half the permitted max manually.
* Limits are per repo, users having multiple repos open at once will see more requests (this is again solvable by users by lowering the allowed max, but not ideal)