### PR TITLE
QOL: add a warnign if you slightly misspell icechunk for logs

### DIFF
--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -43,6 +43,7 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 rand = "0.9.2"
 rmp-serde = "1.3.0"
 pyo3-bytes = "0.2.0"
+strsim = "0.11"
 
 [features]
 cli = ["clap", "icechunk/cli"]

--- a/icechunk-python/tests/test_logs.py
+++ b/icechunk-python/tests/test_logs.py
@@ -98,3 +98,89 @@ def test_warn_on_small_caches(capfd) -> None:
     assert re.search("keep 0 references", out)
     assert re.search("3 nodes", out)
     assert re.search("keep 0 nodes", out)
+
+
+def test_misspelling_warnings_for_icechunk(capfd) -> None:
+    """Test that misspelled variations of 'icechunk' trigger warnings."""
+    # Test common misspellings
+    ic.set_logs_filter("icehunk:trace")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "icehunk" in err_output
+
+    ic.set_logs_filter("icecunk:debug")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "icecunk" in err_output
+
+    ic.set_logs_filter("iecchunk:info")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "iecchunk" in err_output
+
+    ic.set_logs_filter("ichunk:warn")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "ichunk" in err_output
+
+
+def test_no_false_positives_for_correct_spelling(capfd) -> None:
+    """Test that correct 'icechunk' spelling doesn't trigger warnings."""
+    ic.set_logs_filter("icechunk:debug")
+    assert "Warning" not in capfd.readouterr().err
+
+    ic.set_logs_filter("icechunk::repository:trace")
+    assert "Warning" not in capfd.readouterr().err
+
+
+def test_no_warnings_for_generic_log_levels(capfd) -> None:
+    """Test that generic log levels don't trigger warnings."""
+    ic.set_logs_filter("debug")
+    assert "Warning" not in capfd.readouterr().err
+
+    ic.set_logs_filter("trace")
+    assert "Warning" not in capfd.readouterr().err
+
+    ic.set_logs_filter("info")
+    assert "Warning" not in capfd.readouterr().err
+
+
+def test_no_warnings_for_unrelated_modules(capfd) -> None:
+    """Test that unrelated module names don't trigger warnings."""
+    ic.set_logs_filter("tokio:debug")
+    assert "Warning" not in capfd.readouterr().err
+
+    ic.set_logs_filter("serde:info")
+    assert "Warning" not in capfd.readouterr().err
+
+    ic.set_logs_filter("my_app::module:warn")
+    assert "Warning" not in capfd.readouterr().err
+
+
+def test_complex_filter_strings_with_misspellings(capfd) -> None:
+    """Test complex filter strings with multiple modules."""
+    ic.set_logs_filter("icehunk:trace,debug,tokio::io:warn")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "icehunk" in err_output
+    # Should not warn about tokio
+    assert "tokio" not in err_output
+
+    ic.set_logs_filter("debug,icecunk:info,warn")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "icecunk" in err_output
+
+
+def test_nested_module_paths_with_misspellings(capfd) -> None:
+    """Test nested module paths like icehunk::repository:trace."""
+    ic.set_logs_filter("icehunk::repository:trace")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "icehunk" in err_output
+
+    ic.set_logs_filter("icecunk::store::manager:debug")
+    err_output = capfd.readouterr().err
+    assert "Warning" in err_output and "icecunk" in err_output
+
+
+def test_short_strings_not_flagged(capfd) -> None:
+    """Test that very short strings don't get flagged as misspellings."""
+    ic.set_logs_filter("ice:debug")
+    assert "Warning" not in capfd.readouterr().err
+
+    ic.set_logs_filter("chunk:info")
+    assert "Warning" not in capfd.readouterr().err


### PR DESCRIPTION
Close #1202


Compare name in the logs_filter using levenstein distance 
Example output:
```
Warning: Did you mean 'icechunk' instead of 'icehunk' in log filter?
```

but it also gets colorcodes:

so it will look like this:

<img width="502" height="44" alt="image" src="https://github.com/user-attachments/assets/936db071-272f-47ac-98d4-76a8b0a13377" />
