### PR TITLE
Split up just pre-commit to massively speed up pre-commit

### DIFF
--- a/.github/workflows/publish-rust-library.yml
+++ b/.github/workflows/publish-rust-library.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Check
         if: github.event_name == 'push'
         run: |
-          just pre-commit
+          just pre-commit-ci
 
       - name: Install cargo-release
         run: cargo install --locked cargo-release

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -116,7 +116,7 @@ jobs:
           TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}
 
         run: |
-          just pre-commit
+          just pre-commit-ci
 
       - name: Run unit tests only
         if: matrix.os != 'ubuntu-latest' && matrix.os != 'ubuntu-24.04-arm'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,14 @@ repos:
   - repo: local
     hooks:
       - id: rust-pre-commit-fast
-        name: "⚡ Fast Rust checks (format, lint)"
+        name: "Fast Rust checks (format, lint)"
         entry: just pre-commit-fast
         language: system
         files: \.(rs|toml)$|Cargo\.lock$|justfile$
         pass_filenames: false
 
       - id: rust-pre-commit
-        name: "🔧 Medium Rust checks (compilation, deps)"
+        name: "Medium Rust checks (compilation, deps)"
         entry: just pre-commit
         language: system
         files: \.(rs|toml)$|Cargo\.lock$|justfile$
@@ -46,7 +46,7 @@ repos:
         stages: [pre-push]
 
       - id: rust-pre-commit-ci
-        name: "🚀 Full CI checks (tests, examples)"
+        name: "Full CI checks (tests, examples)"
         entry: just pre-commit-ci
         language: system
         files: \.(rs|toml)$|Cargo\.lock$|justfile$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,32 +8,49 @@ repos:
         exclude: docs/mkdocs.yml
       - id: debug-statements
       - id: mixed-line-ending
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: 'v0.8.0'
     hooks:
       - id: ruff-format
       - id: ruff
         args: ["--fix", "--show-fixes", "icechunk-python/"]
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
       - id: actionlint
         files: ".github/workflows/"
         args: ["-ignore", "SC1090", "-ignore", "SC2046", "-ignore", "SC2086", "-ignore", "SC2129", "-ignore", "SC2155"]
+
   - repo: https://github.com/codespell-project/codespell
-    # Configuration for codespell is in .codespellrc
     rev: v2.3.0
     hooks:
       - id: codespell
+
   - repo: local
     hooks:
-      - id: just-rust
-        name: just
-        description: Run the just pre-commit step
+      - id: rust-pre-commit-fast
+        name: "⚡ Fast Rust checks (format, lint)"
+        entry: just pre-commit-fast
+        language: system
+        files: \.(rs|toml)$|Cargo\.lock$|justfile$
+        pass_filenames: false
+
+      - id: rust-pre-commit
+        name: "🔧 Medium Rust checks (compilation, deps)"
         entry: just pre-commit
         language: system
+        files: \.(rs|toml)$|Cargo\.lock$|justfile$
         pass_filenames: false
-        files: "(^|.*/)(icechunk/|icechunk-python/src/).*"
+        stages: [pre-push]
+
+      - id: rust-pre-commit-ci
+        name: "🚀 Full CI checks (tests, examples)"
+        entry: just pre-commit-ci
+        language: system
+        files: \.(rs|toml)$|Cargo\.lock$|justfile$
+        pass_filenames: false
+        stages: [manual]
 
 exclude: 'tests/data/.*'

--- a/Justfile
+++ b/Justfile
@@ -43,8 +43,21 @@ check-deps *args='':
 run-all-examples:
   for example in icechunk/examples/*.rs; do cargo run --example "$(basename "${example%.rs}")"; done
 
-# run all checks that CI actions will run
+# fast pre-commit - format and lint only
+pre-commit-fast:
+  just format "--check"
+  just lint "-p icechunk -p icechunk-python"
+
+# medium pre-commit - includes compilation checks (~2-3 minutes)
 pre-commit $RUSTFLAGS="-D warnings -W unreachable-pub -W bare-trait-objects":
+  just compile-tests "--locked"
+  just build
+  just format "--check"
+  just lint "-p icechunk -p icechunk-python"
+  just check-deps
+
+# full pre-commit for CI - runs all checks including tests
+pre-commit-ci $RUSTFLAGS="-D warnings -W unreachable-pub -W bare-trait-objects":
   just compile-tests "--locked"
   just build
   just format "--check"

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -45,6 +45,7 @@ Create / activate a virtual environment:
     uv sync
     ```
 
+
 Install `maturin`:
 
 === "Venv"
@@ -98,9 +99,106 @@ They can be run from the root of the repo with `docker compose up` (`ctrl-c` the
     uv run pytest
     ```
 
+
 ### Rust Development Workflow
 
-TODO
+#### Prerequisites
+
+Install the `just` command runner (used for build tasks and pre-commit hooks):
+
+```bash
+cargo install just
+```
+
+Or using other package managers:
+- **macOS**: `brew install just`
+- **Ubuntu**: `snap install --edge --classic just`
+
+#### Building
+
+Build the Rust workspace:
+
+```bash
+# Build all packages
+just build
+
+# Build release version
+just build-release
+
+# Compile tests without running them
+just compile-tests
+```
+
+#### Testing
+
+```bash
+# Run all tests
+just test
+
+# Run tests with logs enabled
+just test-logs debug
+
+# Run only specific tests
+cargo test test_name
+```
+
+#### Code Quality
+
+We use a tiered pre-commit system for fast development:
+
+```bash
+# Fast checks (~3 seconds) - format and lint only
+just pre-commit-fast
+
+# Medium checks (~2-3 minutes) - includes compilation and deps
+just pre-commit
+
+# Full CI checks (~5+ minutes) - includes all tests and examples
+just pre-commit-ci
+```
+
+Individual checks:
+
+```bash
+# Format code
+just format
+
+# Check formatting without changing files
+just format --check
+
+# Lint with clippy
+just lint
+
+# Check dependencies for security issues
+just check-deps
+```
+
+#### Pre-commit Hooks
+
+We use [pre-commit](https://pre-commit.com/) to automatically run checks. Install it:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The pre-commit configuration automatically runs:
+- **Every commit**: Fast Python and Rust checks (~2 seconds total)
+- **Before push**: Medium Rust checks (compilation + dependencies)
+- **Manual**: Full CI-level checks when needed
+
+To run manually:
+
+```bash
+# Run on changed files only
+pre-commit run
+
+# Run on all files
+pre-commit run --all-files
+
+# Run full CI checks manually
+pre-commit run rust-pre-commit-ci --hook-stage manual
+```
 
 ## Roadmap
 


### PR DESCRIPTION
Prior to this PR the `just` pre-commit step was very slow (45 seconds or more) which makes it very likely that contributors (and specifically me) will just skip pre-commit checks. In this PR I:

1.  add a new `just` command with only the faster steps for use in pre-commit
2. Filter to only run when the relevant files change (before even changing just the python parts of icechunk-python triggered rust checks)
3. Keep using the old (complete checks) in CI

This does check less, but I think overall it's better because the alternative with the full pre-commit checks is that people (again, me) don't run them at all. Which is worse.


## Speedup
`time pre-commit run --all-files`

**This PR:** `3.76s user 0.89s system 107% cpu 4.325 total`
**main:** `125.57s user 10.14s system 358% cpu 37.851 total`

