### PR TITLE
Add Python reprs (implemented in python)

### DIFF
--- a/icechunk-python/python/icechunk/display.py
+++ b/icechunk-python/python/icechunk/display.py
@@ -1,0 +1,35 @@
+def dataclass_repr(
+    obj: object,
+    # make this default to inspecting the cls?
+    cls_name: str,
+    attributes: list[str] = None,
+    # TODO optional indent
+) -> str:
+    """
+    Dynamically create a repr for this dataclass-like object.
+
+    Parameters
+    ----------
+    obj : object
+        Object for which to make a repr.
+    cls_name : Type
+        What to display as the name of the class, including submodule.
+    attributes : list[str] | None
+        Names of attributes or properties to display the values of. 
+        These must all exist on the instance and be printable.
+
+    Returns
+    -------
+    str
+        Repr for the class.
+    """
+    header = f"<{cls_name}>"
+
+    if not attributes:
+        return header
+    else:
+        contents = []
+        for attr_name in attributes:
+            line = f"{attr_name}: {getattr(obj, attr_name)}"
+            contents.append(line)
+        return "\n".join([header] + contents)

--- a/icechunk-python/python/icechunk/session.py
+++ b/icechunk-python/python/icechunk/session.py
@@ -10,43 +10,7 @@ from icechunk import (
 )
 from icechunk._icechunk_python import PySession
 from icechunk.store import IcechunkStore
-
-
-def dataclass_repr(
-    obj: object,
-    # make this default to inspecting the cls?
-    cls_name: str,
-    attributes: list[str] = None,
-    # TODO optional indent
-) -> str:
-    """
-    Dynamically create a repr for this dataclass-like object.
-
-    Parameters
-    ----------
-    obj : object
-        Object for which to make a repr.
-    cls_name : Type
-        What to display as the name of the class, including submodule.
-    attributes : list[str] | None
-        Names of attributes or properties to display the values of. 
-        These must all exist on the instance and be printable.
-
-    Returns
-    -------
-    str
-        Repr for the class.
-    """
-    header = f"<{cls_name}>"
-
-    if not attributes:
-        return header
-    else:
-        contents = []
-        for attr_name in attributes:
-            line = f"{attr_name}: {getattr(obj, attr_name)}"
-            contents.append(line)
-        return "\n".join([header] + contents)
+import icechunk.display as display
 
 
 class Session:
@@ -68,7 +32,7 @@ class Session:
         if not self.read_only:
             mutable_attributes += ["branch", "has_uncommitted_changes"]
 
-        return dataclass_repr(
+        return display.dataclass_repr(
             obj=self,
             cls_name="icechunk.Session",
             attributes=mutable_attributes,

--- a/icechunk-python/python/icechunk/session.py
+++ b/icechunk-python/python/icechunk/session.py
@@ -12,6 +12,43 @@ from icechunk._icechunk_python import PySession
 from icechunk.store import IcechunkStore
 
 
+def dataclass_repr(
+    obj: object,
+    # make this default to inspecting the cls?
+    cls_name: str,
+    attributes: list[str] = None,
+    # TODO optional indent
+) -> str:
+    """
+    Dynamically create a repr for this dataclass-like object.
+
+    Parameters
+    ----------
+    obj : object
+        Object for which to make a repr.
+    cls_name : Type
+        What to display as the name of the class, including submodule.
+    attributes : list[str] | None
+        Names of attributes or properties to display the values of. 
+        These must all exist on the instance and be printable.
+
+    Returns
+    -------
+    str
+        Repr for the class.
+    """
+    header = f"<{cls_name}>"
+
+    if not attributes:
+        return header
+    else:
+        contents = []
+        for attr_name in attributes:
+            line = f"{attr_name}: {getattr(obj, attr_name)}"
+            contents.append(line)
+        return "\n".join([header] + contents)
+
+
 class Session:
     """A session object that allows for reading and writing data from an Icechunk repository."""
 
@@ -21,6 +58,21 @@ class Session:
     def __init__(self, session: PySession):
         self._session = session
         self._allow_changes = False
+
+    def __repr__(self) -> str:
+        mutable_attributes=[
+            "read_only",
+            "snapshot_id",
+        ]
+        
+        if not self.read_only:
+            mutable_attributes += ["branch", "has_uncommitted_changes"]
+
+        return dataclass_repr(
+            obj=self,
+            cls_name="icechunk.Session",
+            attributes=mutable_attributes,
+        )
 
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, Session):


### PR DESCRIPTION
With this we get

```python
In [1]: import icechunk
   ...: 
   ...: storage = icechunk.in_memory_storage()
   ...: repo = icechunk.Repository.create(storage)

In [2]: repo.readonly_session("main")
Out[2]: 
<icechunk.Session>
read_only: True
snapshot_id: 1CECHNKREP0F1RSTCMT0

In [3]: repo.writable_session("main")
Out[3]: 
<icechunk.Session>
read_only: False
snapshot_id: 1CECHNKREP0F1RSTCMT0
branch: main
has_uncommitted_changes: False
```

For compound classes I want to have them make nested repr calls, i.e. `Repository.__repr__` includes `RepositoryConfig.__repr__` and `Storage.__repr__`, passed as "attributes". This way we should be able to have nice nested reprs for all classes be implemented simply and consistently.

Then once that works we can use the same approach but for HTML reprs.