### PR TITLE
Separate tests requiring secrets - require approval to run on PRs from forks [EAR-2132]

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -10,7 +10,7 @@ on:
       - main
   schedule:
     # three times a day to run the integration tests that take a long time
-    - cron:  '33 3,10,15 * * *'
+    - cron: "33 3,10,15 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +23,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings -W unreachable-pub -W bare-trait-objects"
   RUSTUP_MAX_RETRIES: 10
-  RUST_CHANNEL: '1.89.0'
+  RUST_CHANNEL: "1.89.0"
 
 jobs:
   rust-safe:
@@ -104,20 +104,6 @@ jobs:
         run: |
           cargo test --lib
 
-  debug-external-pr-check:
-    name: Debug External PR Check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Debug PR info
-        run: |
-          echo "=== PR Debug Info ==="
-          echo "Event: ${{ github.event_name }}"
-          echo "Head repo: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "Base repo: ${{ github.repository }}"
-          echo "Are they equal: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
-          echo "Condition result: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository) }}"
-
   rust-external-services:
     name: Rust CI (External Services)
     timeout-minutes: 30
@@ -148,17 +134,8 @@ jobs:
         with:
           key: ${{ env.RUST_CHANNEL }}
 
-      - name: Debug job execution
-        run: |
-          echo "=== Debug Job Execution ==="
-          echo "Event: ${{ github.event_name }}"
-          echo "Head repo: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "Base repo: ${{ github.repository }}"
-          echo "Should run: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository) }}"
-
       - name: Run external service tests
         env:
-          RUST_LOG: trace
           R2_BUCKET: ${{ vars.R2_BUCKET }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Attempt at separating out tests requiring secrets so that PRs from forks require approval for anything with external srevices secrets. 

Currently just manual approval for enabling these. But I think it's also possible with applying a label, however I coudn't get that without essentially duplicating the entire workflow. So for now just keeping it simple. Having a PR label approach can be a future step.

👀 
<img width="730" height="67" alt="image" src="https://github.com/user-attachments/assets/ed42009a-d927-4754-98d6-d70b9ae84314" />
