### PR TITLE
add nightly wheel upload [EAR-2133]

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -196,7 +196,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload nightly wheels
-        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd7672769da06
+        uses: scientific-python/upload-nightly-action@b36e8c0c10dbcfd2e05bf95f17ef8c14fd708dbf
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
Pretty sure that path for the artifacts will work, but it's hard to test ahead of time 🤷 

will probably just have to wait until tonight to find out if this breaks. We can't usse the workflow dispatch, because that is how we actually make a release.