### PR TITLE
simplify dask check

### DIFF
--- a/icechunk-python/python/icechunk/xarray.py
+++ b/icechunk-python/python/icechunk/xarray.py
@@ -1,4 +1,3 @@
-import importlib
 from collections.abc import Hashable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, overload
@@ -21,11 +20,6 @@ Region = Mapping[str, slice | Literal["auto"]] | Literal["auto"] | None
 ZarrWriteModes = Literal["w", "w-", "a", "a-", "r+", "r"]
 
 
-try:
-    has_dask = importlib.util.find_spec("dask") is not None
-except ImportError:
-    has_dask = False
-
 if Version(xr.__version__) < Version("2024.10.0"):
     raise ValueError(
         f"Writing to icechunk requires Xarray>=2024.10.0 but you have {xr.__version__}. Please upgrade."
@@ -41,11 +35,11 @@ else:
 
 
 def is_dask_collection(x: Any) -> bool:
-    if has_dask:
-        import dask
+    try:
+        from dask.base import is_dask_collection
 
-        return dask.base.is_dask_collection(x)
-    else:
+        return is_dask_collection(x)
+    except ImportError:
         return False
 
 


### PR DESCRIPTION
Inspired by some pyright warnings I was getting about directly using both dask.base and importlib.util we were apparently relying on not perfectly defined import behavior https://discuss.python.org/t/python3-11-importlib-no-longer-exposes-util/25641/23

<img width="857" height="80" alt="image" src="https://github.com/user-attachments/assets/dfee8879-6be6-4081-8463-1f7b01a4be29" />
<img width="725" height="151" alt="image" src="https://github.com/user-attachments/assets/c10d04dc-00cd-4166-9c4f-8df8bbb77b46" />

this simplifies this a bit and removes the warnings that were driving me nuts, and i think is slightly more secure against weird importing importlib errors.
