### PR TITLE
Speedup list_dir and list_prefix

### DIFF
--- a/icechunk/examples/low_level_dataset.rs
+++ b/icechunk/examples/low_level_dataset.rs
@@ -237,7 +237,7 @@ let ds = Repository::update(Arc::clone(&storage), ObjectId::from("{v2_id:?}"));
 async fn print_nodes(ds: &Session) -> Result<(), SessionError> {
     println!("### List of nodes");
     let rows = ds
-        .list_nodes()
+        .list_nodes(&Path::root())
         .await?
         .map(|n| n.unwrap())
         .sorted_by_key(|n| n.path.clone())

--- a/icechunk/src/conflicts/detector.rs
+++ b/icechunk/src/conflicts/detector.rs
@@ -63,7 +63,7 @@ impl ConflictSolver for ConflictDetector {
             Ok(None)
         });
 
-        let path_finder = PathFinder::new(current_repo.list_nodes().await?);
+        let path_finder = PathFinder::new(current_repo.list_nodes(&Path::root()).await?);
 
         let updated_arrays_already_updated = current_changes
             .updated_arrays()

--- a/icechunk/src/format/snapshot.rs
+++ b/icechunk/src/format/snapshot.rs
@@ -8,6 +8,8 @@ use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::format::lookup_index_by_key;
+
 use super::{
     AttributesId, ChunkIndices, IcechunkFormatError, IcechunkFormatErrorKind,
     IcechunkResult, ManifestId, NodeId, Path, SnapshotId,
@@ -524,14 +526,27 @@ impl Snapshot {
         res.try_into()
     }
 
+    pub fn get_node_index(&self, path: &Path) -> IcechunkResult<usize> {
+        let path_str = path.to_string();
+        let res =
+            lookup_index_by_key(self.root().nodes(), path_str.as_str(), |node, path| {
+                node.path().cmp(path)
+            })
+            .ok_or(IcechunkFormatError::from(
+                IcechunkFormatErrorKind::NodeNotFound { path: path.clone() },
+            ))?;
+        Ok(res)
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = IcechunkResult<NodeSnapshot>> + '_ {
         self.root().nodes().iter().map(|node| node.try_into().err_into())
     }
 
     pub fn iter_arc(
         self: Arc<Self>,
-    ) -> impl Iterator<Item = IcechunkResult<NodeSnapshot>> {
-        NodeIterator { snapshot: self, last_index: 0 }
+        parent_group: &Path,
+    ) -> impl Iterator<Item = IcechunkResult<NodeSnapshot>> + use<> {
+        NodeIterator::new(self, parent_group)
     }
 
     pub fn len(&self) -> usize {
@@ -554,7 +569,17 @@ impl Snapshot {
 
 struct NodeIterator {
     snapshot: Arc<Snapshot>,
-    last_index: usize,
+    next_index: usize,
+    prefix: String,
+}
+
+impl NodeIterator {
+    fn new(snapshot: Arc<Snapshot>, parent_group: &Path) -> Self {
+        let next_index = snapshot.get_node_index(parent_group).unwrap_or_default();
+        let prefix = parent_group.to_string();
+        let prefix = if prefix == "/" { String::new() } else { prefix };
+        NodeIterator { snapshot, next_index, prefix }
+    }
 }
 
 impl Iterator for NodeIterator {
@@ -562,10 +587,24 @@ impl Iterator for NodeIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         let nodes = self.snapshot.root().nodes();
-        if self.last_index < nodes.len() {
-            let res = Some(nodes.get(self.last_index).try_into().err_into());
-            self.last_index += 1;
-            res
+        if self.next_index < nodes.len() {
+            let node: IcechunkResult<NodeSnapshot> =
+                nodes.get(self.next_index).try_into();
+
+            match node {
+                Ok(res) => {
+                    if let Some(after_prefix) =
+                        res.path.to_string().strip_prefix(self.prefix.as_str())
+                        && (after_prefix.is_empty() || after_prefix.starts_with('/'))
+                    {
+                        self.next_index += 1;
+                        Some(Ok(res))
+                    } else {
+                        None
+                    }
+                }
+                Err(err) => Some(Err(err)),
+            }
         } else {
             None
         }

--- a/icechunk/src/format/transaction_log.rs
+++ b/icechunk/src/format/transaction_log.rs
@@ -260,9 +260,9 @@ impl DiffBuilder {
 
     pub async fn to_diff(self, from: &Session, to: &Session) -> SessionResult<Diff> {
         let nodes: HashMap<NodeId, Path> = from
-            .list_nodes()
+            .list_nodes(&Path::root())
             .await?
-            .chain(to.list_nodes().await?)
+            .chain(to.list_nodes(&Path::root()).await?)
             .map_ok(|n| (n.id, n.path))
             .try_collect()?;
         Ok(Diff::from_diff_builder(self, nodes))

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -860,7 +860,7 @@ impl Repository {
             if let Ok(snap) = asset_manager.fetch_snapshot(&snapshot_id).await {
                 let snap_c = Arc::clone(&snap);
                 for node in snap
-                    .iter_arc()
+                    .iter_arc(&Path::root())
                     .filter_ok(|node| node.node_type() == NodeType::Array)
                     // TODO: make configurable
                     .take(50)

--- a/icechunk/src/store.rs
+++ b/icechunk/src/store.rs
@@ -12,7 +12,7 @@ use std::{
 use async_stream::try_stream;
 use bytes::Bytes;
 use futures::{Stream, StreamExt, TryStreamExt};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use serde::{Deserialize, Serialize, de};
 use serde_with::{TryFromInto, serde_as};
 use thiserror::Error;
@@ -748,9 +748,27 @@ impl Store {
         strip_prefix: bool,
     ) -> StoreResult<impl Stream<Item = StoreResult<String>> + 'a + use<'a>> {
         let prefix = prefix.trim_end_matches('/');
+        // TODO: Handling preceding "/" is ugly!
+        let path =
+            format!("/{}", prefix.trim_start_matches('/')).try_into().map_err(|_| {
+                StoreErrorKind::BadKeyPrefix {
+                    prefix: prefix.to_owned(),
+                    message: "Cannot convert to a path".to_string(),
+                }
+            })?;
+
+        let session = Arc::clone(&self.session).read_owned().await;
+        if path != Path::root() {
+            let _ = session.get_node(&path).await.map_err(|_| {
+                StoreErrorKind::BadKeyPrefix {
+                    prefix: prefix.to_owned(),
+                    message: "Only prefixes pointing to a group or array are allowed"
+                        .to_string(),
+                }
+            })?;
+        }
         let res = try_stream! {
-            let session = Arc::clone(&self.session).read_owned().await;
-            for node in session.list_nodes().await? {
+            for node in session.list_nodes(&path).await? {
                 // TODO: handle non-utf8?
                 let meta_key = Key::Metadata { node_path: node?.path }.to_string();
                 if is_prefix_match(&meta_key, prefix) {
@@ -781,16 +799,23 @@ impl Store {
                 }
             })?;
 
-            if path != Path::root() {
-                let _ = session.get_node(&path).await.map_err(|_| {
+            let nodes = if path == Path::root() {
+                Either::Left(session.list_nodes(&Path::root()).await?)
+            } else {
+                let node = session.get_node(&path).await.map_err(|_| {
                     StoreErrorKind::BadKeyPrefix {
                         prefix: prefix.to_owned(),
                         message: "Only prefixes pointing to a group or array are allowed".to_string(),
                     }
                 })?;
-            }
+                match node.node_type() {
+                    NodeType::Group => Either::Left(session.list_nodes(&node.path).await?),
+                    NodeType::Array => Either::Right(iter::once(Ok(node))),
+                }
+            };
 
-            for node in session.list_nodes().await? {
+
+            for node in nodes {
                 let node = node?;
                 if node.node_type() == NodeType::Array &&
                     // FIXME: utf8 handling

--- a/icechunk/tests/test_concurrency.rs
+++ b/icechunk/tests/test_concurrency.rs
@@ -189,7 +189,7 @@ async fn list_task(ds: Arc<RwLock<Session>>, barrier: Arc<Barrier>) {
         let nodes = ds
             .read()
             .await
-            .list_nodes()
+            .list_nodes(&Path::root())
             .await
             .expect("list_nodes failed")
             .map(|n| n.unwrap().path.to_string())


### PR DESCRIPTION
This avoids going through every node each time `list_dir` is called. This is important because Zarr calls `list_dir` recursively to build `tree`.

In flat repositories with ~ 60k nodes, we verified ~15x performance improvement for `Group.tree`.