### PR TITLE
Add `Session.flush` to allow anonymous snapshot creation

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1688,6 +1688,16 @@ class PySession:
         rebase_with: ConflictSolver | None = None,
         rebase_tries: int = 1_000,
     ) -> str: ...
+    def flush(
+        self,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> str: ...
+    async def flush_async(
+        self,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> str: ...
     def rebase(self, solver: ConflictSolver) -> None: ...
     async def rebase_async(self, solver: ConflictSolver) -> None: ...
 

--- a/icechunk-python/python/icechunk/session.py
+++ b/icechunk-python/python/icechunk/session.py
@@ -318,6 +318,68 @@ class Session:
             message, metadata, rebase_with=rebase_with, rebase_tries=rebase_tries
         )
 
+    def flush(
+        self,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """
+        Save the changes in the session to a new snapshot without modifying the current branch.
+
+        When successful, the writable session is completed and the session is now read-only and based on the new snapshot. The ID of the new snapshot is returned.
+
+        Parameters
+        ----------
+        message : str
+            The message to write with the commit.
+        metadata : dict[str, Any] | None, optional
+            Additional metadata to store with the commit snapshot.
+
+        Returns
+        -------
+        str
+            The ID of the new snapshot.
+        """
+        if self._allow_changes:
+            warnings.warn(
+                "Committing a session after forking, and without merging will not work. "
+                "Merge back in the remote changes first using Session.merge().",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self._session.flush(message, metadata)
+
+    async def flush_async(
+        self,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """
+        Save the changes in the session to a new snapshot without modifying the current branch.
+
+        When successful, the writable session is completed and the session is now read-only and based on the new snapshot. The ID of the new snapshot is returned.
+
+        Parameters
+        ----------
+        message : str
+            The message to write with the commit.
+        metadata : dict[str, Any] | None, optional
+            Additional metadata to store with the commit snapshot.
+
+        Returns
+        -------
+        str
+            The ID of the new snapshot.
+        """
+        if self._allow_changes:
+            warnings.warn(
+                "Flushing a session after forking, and without merging will not work. "
+                "Merge back in the remote changes first using Session.merge().",
+                UserWarning,
+                stacklevel=2,
+            )
+        return await self._session.flush_async(message, metadata)
+
     def rebase(self, solver: ConflictSolver) -> None:
         """
         Rebase the session to the latest ancestry of the branch.
@@ -450,6 +512,28 @@ class ForkSession(Session):
     ) -> NoReturn:
         raise TypeError(
             "Cannot commit a fork of a Session. If you are using uncooperative writes, "
+            "please send the Repository object to your workers, not a Session. "
+            "See https://icechunk.io/en/stable/icechunk-python/parallel/#distributed-writes for more."
+        )
+
+    def flush(
+        self,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> NoReturn:
+        raise TypeError(
+            "Cannot flush a fork of a Session. If you are using uncooperative writes, "
+            "please send the Repository object to your workers, not a Session. "
+            "See https://icechunk.io/en/stable/icechunk-python/parallel/#distributed-writes for more."
+        )
+
+    async def flush_async(
+        self,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> NoReturn:
+        raise TypeError(
+            "Cannot flush a fork of a Session. If you are using uncooperative writes, "
             "please send the Repository object to your workers, not a Session. "
             "See https://icechunk.io/en/stable/icechunk-python/parallel/#distributed-writes for more."
         )

--- a/icechunk-python/src/session.rs
+++ b/icechunk-python/src/session.rs
@@ -293,6 +293,47 @@ impl PySession {
         })
     }
 
+    #[pyo3(signature = (message, metadata=None))]
+    pub fn flush(
+        &self,
+        py: Python<'_>,
+        message: &str,
+        metadata: Option<PySnapshotProperties>,
+    ) -> PyResult<String> {
+        let metadata = metadata.map(|m| m.into());
+        // This is blocking function, we need to release the Gil
+        py.allow_threads(move || {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let mut session = self.0.write().await;
+                let snapshot_id = session
+                    .flush(message, metadata)
+                    .await
+                    .map_err(PyIcechunkStoreError::SessionError)?;
+                Ok(snapshot_id.to_string())
+            })
+        })
+    }
+
+    pub fn flush_async<'py>(
+        &'py self,
+        py: Python<'py>,
+        message: &str,
+        metadata: Option<PySnapshotProperties>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let session = self.0.clone();
+        let message = message.to_owned();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let metadata = metadata.map(|m| m.into());
+            let mut session = session.write().await;
+            let snapshot_id = session
+                .flush(&message, metadata)
+                .await
+                .map_err(PyIcechunkStoreError::SessionError)?;
+            Ok(snapshot_id.to_string())
+        })
+    }
+
     pub fn rebase(&self, solver: PyConflictSolver, py: Python<'_>) -> PyResult<()> {
         // This is blocking function, we need to release the Gil
         py.allow_threads(move || {

--- a/icechunk-python/tests/test_timetravel.py
+++ b/icechunk-python/tests/test_timetravel.py
@@ -17,7 +17,11 @@ async def async_ancestry(
     return [parent async for parent in repo.async_ancestry(**kwargs)]
 
 
-def test_timetravel() -> None:
+@pytest.mark.parametrize(
+    "using_flush",
+    [False, True],
+)
+def test_timetravel(using_flush: bool) -> None:
     config = ic.RepositoryConfig.default()
     config.inline_chunk_threshold_bytes = 1
     repo = ic.Repository.create(
@@ -48,7 +52,12 @@ def test_timetravel() -> None:
     assert status.updated_arrays == set()
     assert status.updated_groups == set()
 
-    first_snapshot_id = session.commit("commit 1")
+    if using_flush:
+        first_snapshot_id = session.flush("commit 1")
+        repo.reset_branch("main", first_snapshot_id)
+    else:
+        first_snapshot_id = session.commit("commit 1")
+
     assert session.read_only
 
     session = repo.writable_session("main")
@@ -59,7 +68,11 @@ def test_timetravel() -> None:
     air_temp[:, :] = 54
     assert air_temp[200, 6] == 54
 
-    new_snapshot_id = session.commit("commit 2")
+    if using_flush:
+        new_snapshot_id = session.flush("commit 2")
+        repo.reset_branch("main", new_snapshot_id)
+    else:
+        new_snapshot_id = session.commit("commit 2")
 
     session = repo.readonly_session(snapshot_id=first_snapshot_id)
     store = session.store
@@ -99,7 +112,12 @@ def test_timetravel() -> None:
     group = zarr.open_group(store=store)
     air_temp = cast(zarr.core.array.Array, group["air_temp"])
     air_temp[:, :] = 90
-    feature_snapshot_id = session.commit("commit 3")
+
+    if using_flush:
+        feature_snapshot_id = session.flush("commit 3")
+        repo.reset_branch("feature", feature_snapshot_id)
+    else:
+        feature_snapshot_id = session.commit("commit 3")
 
     branches = repo.list_branches()
     assert branches == set(["main", "feature"])
@@ -325,7 +343,11 @@ async def test_default_commit_metadata() -> None:
     assert snap.metadata == {"user": "test"}
 
 
-async def test_timetravel_async() -> None:
+@pytest.mark.parametrize(
+    "using_flush",
+    [False, True],
+)
+async def test_timetravel_async(using_flush: bool) -> None:
     config = ic.RepositoryConfig.default()
     config.inline_chunk_threshold_bytes = 1
     repo = await ic.Repository.create_async(
@@ -354,7 +376,11 @@ async def test_timetravel_async() -> None:
     assert status.updated_arrays == set()
     assert status.updated_groups == set()
 
-    first_snapshot_id = await session.commit_async("commit 1")
+    if using_flush:
+        first_snapshot_id = await session.flush_async("commit 1")
+        await repo.reset_branch_async("main", first_snapshot_id)
+    else:
+        first_snapshot_id = await session.commit_async("commit 1")
     assert session.read_only
 
     session = await repo.writable_session_async("main")
@@ -364,7 +390,11 @@ async def test_timetravel_async() -> None:
     air_temp[:, :] = 54
     assert air_temp[200, 6] == 54
 
-    new_snapshot_id = await session.commit_async("commit 2")
+    if using_flush:
+        new_snapshot_id = await session.flush_async("commit 2")
+        await repo.reset_branch_async("main", new_snapshot_id)
+    else:
+        new_snapshot_id = await session.commit_async("commit 2")
 
     session = await repo.readonly_session_async(snapshot_id=first_snapshot_id)
     store = session.store
@@ -401,7 +431,12 @@ async def test_timetravel_async() -> None:
     group = zarr.open_group(store=session.store)
     air_temp = cast(zarr.core.array.Array, group["air_temp"])
     air_temp[:, :] = 90
-    feature_snapshot_id = await session.commit_async("commit 3")
+
+    if using_flush:
+        feature_snapshot_id = await session.flush_async("commit 3")
+        await repo.reset_branch_async("feature", feature_snapshot_id)
+    else:
+        feature_snapshot_id = await session.commit_async("commit 3")
 
     branches = await repo.list_branches_async()
     assert branches == set(["main", "feature"])


### PR DESCRIPTION
Users can now choose to save their sessions to an anonymous snapshot instead of committing, which updates a branch.

For this they use the `Session.flush` method. `flush` takes the same arguments as `commit` (without the rebase-related arguments), and returns the ID of the newly created snapshot.

The new snapshot is not pointed by any branches or tags.