### PR TITLE
Remove comment on extension config

### DIFF
--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -25,8 +25,6 @@ icechunk = { path = "../icechunk", version = "0.3.11", features = ["logs"] }
 itertools = "0.14.0"
 pyo3 = { version = "0.24.2", features = [
   "chrono",
-  #  do we really need this one?
-  #  "extension-module",
   "experimental-async",
   "multiple-pymethods",
 ] }


### PR DESCRIPTION
closes: https://github.com/earth-mover/icechunk/issues/1223

This was already handled in pyproject.toml! https://github.com/earth-mover/icechunk/blob/612a0a969936da7e1d28872513f8aaba5b1dea3f/icechunk-python/pyproject.toml#L116-L117

so removing the comment that sent me off on a rabbit hole of what an extension module is