### PR TITLE
fix RTD build - limit python to what PyO3 accepts

### DIFF
--- a/docs/doc-env.yml
+++ b/docs/doc-env.yml
@@ -1,10 +1,9 @@
-
 name: icechunk-docs
 channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.12
+  - python=3.13
   - pip
   - maturin
   - cairo


### PR DESCRIPTION
```
--- stderr
  error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
  = help: please check if an updated version of PyO3 is available. Current version: 0.24.2
```