### PR TITLE
Revert "update test machinery to support multiple saves with dask (#1273)

### DIFF
--- a/icechunk-python/tests/run_xarray_backends_tests.py
+++ b/icechunk-python/tests/run_xarray_backends_tests.py
@@ -183,3 +183,8 @@ class TestIcechunkRegionAuto(ZarrRegionAutoTests):
         pytest.skip(
             "this test requires multiple saves, and is meant to exercise Xarray logic."
         )
+
+    def test_dataset_to_zarr_align_chunks_true(self, tmp_store) -> None:  # noqa: F811
+        pytest.skip(
+            "this test requires multiple saves, and is meant to exercise Xarray logic."
+        )


### PR DESCRIPTION
We just skip tests that require multiple saves. These test mostly check xarray logic