### PR TITLE
Add CLI command to list Git-style references

### DIFF
--- a/icechunk/src/cli/interface.rs
+++ b/icechunk/src/cli/interface.rs
@@ -72,7 +72,10 @@ enum ConfigCommand {
 
 #[derive(Debug, Subcommand)]
 enum RefCommand {
-    #[clap(name = "list", about = "List all references (branches and tags) in a repository")]
+    #[clap(
+        name = "list",
+        about = "List all references (branches and tags) in a repository"
+    )]
     List(RefListCommand),
 }
 
@@ -603,9 +606,12 @@ mod tests {
 
         // Open the repository and create additional branches and tags
         let storage = get_storage(config.repos.get(&repo_alias).unwrap()).await.unwrap();
-        let repo_config = Some(config.repos.get(&repo_alias).unwrap().get_config().clone());
+        let repo_config =
+            Some(config.repos.get(&repo_alias).unwrap().get_config().clone());
         let repository =
-            Repository::open(repo_config, Arc::clone(&storage), HashMap::new()).await.unwrap();
+            Repository::open(repo_config, Arc::clone(&storage), HashMap::new())
+                .await
+                .unwrap();
 
         // Get the current snapshot ID from main branch
         let main_snapshot = repository.lookup_branch("main").await.unwrap();


### PR DESCRIPTION
## Summary

Implements a new `icechunk ref list` command that displays all branches and tags in an Icechunk repository, providing Git-style reference listing functionality from the CLI.

Fixes #827

## Motivation

Users need a convenient way to view all references (branches and tags) in their Icechunk repositories from the command line, similar to `git show-ref` or `git branch -a`. Currently, this requires using the Python API, which is less convenient for quick repository inspection.

## Approach

This PR adds a new `ref` subcommand to the Icechunk CLI with a `list` operation that:

1. **Follows existing patterns**: Implemented similarly to existing commands like `snapshot list` and `config list`
2. **Leverages existing APIs**: Uses `Repository::list_branches()` and `Repository::list_tags()` methods that are already available in the Rust codebase
3. **Clean output format**: Displays references in a clear format:
   ```
   branch: main
   branch: feature
   tag: v1.0
   ```

## Changes

- Added `Ref(RefCommand)` variant to the CLI `Command` enum
- Created `RefCommand` enum with `List(RefListCommand)` subcommand
- Implemented `ref_list()` handler function that:
  - Opens the repository from config
  - Retrieves all branches and tags
  - Formats output with clear labels
- Wired up the command in the `run_cli()` executor
- Added comprehensive test coverage

## Test Coverage

Added `test_ref_list()` integration test that:
- Creates a test repository with the main branch
- Adds an additional branch (`feature`) and tag (`v1.0`)
- Verifies all references appear in the output
- Validates output format and line count

Test passes with:
```bash
cargo test --lib --features cli cli::interface::tests::test_ref_list
```

## Usage

```bash
# List all references in a repository
icechunk ref list <repository-alias>

# Example output:
# branch: main
# branch: feature-x
# tag: v1.0.0
# tag: v2.0.0-beta
```

## Testing

Manually tested with:
```bash
cargo build --features cli
./target/debug/icechunk ref --help
./target/debug/icechunk ref list --help
```

All existing CLI tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)