### PR TITLE
fix pickling error in tests

### DIFF
--- a/icechunk-python/src/errors.rs
+++ b/icechunk-python/src/errors.rs
@@ -9,6 +9,7 @@ use icechunk::{
 use miette::{Diagnostic, GraphicalReportHandler};
 use pyo3::{
     PyErr,
+    conversion::IntoPyObjectExt,
     exceptions::{PyException, PyKeyError, PyValueError},
     prelude::*,
 };
@@ -147,6 +148,13 @@ impl IcechunkError {
     fn __str__(&self) -> String {
         self.message.clone()
     }
+
+    // Control pickling to work with tblib
+    fn __reduce__(&self, py: Python<'_>) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
+        let cls = py.get_type::<IcechunkError>().into_py_any(py)?;
+        let args = (self.message.clone(),).into_py_any(py)?;
+        Ok((cls, args))
+    }
 }
 
 impl_pickle!(IcechunkError);
@@ -190,6 +198,14 @@ impl PyConflictError {
             self.expected_parent, self.actual_parent
         )
     }
+
+    // Control pickling to work with tblib
+    fn __reduce__(&self, py: Python<'_>) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
+        let cls = py.get_type::<PyConflictError>().into_py_any(py)?;
+        let args =
+            (self.expected_parent.clone(), self.actual_parent.clone()).into_py_any(py)?;
+        Ok((cls, args))
+    }
 }
 
 impl_pickle!(PyConflictError);
@@ -231,6 +247,13 @@ impl PyRebaseFailedError {
             self.snapshot,
             self.conflicts.len()
         )
+    }
+
+    // Control pickling to work with tblib
+    fn __reduce__(&self, py: Python<'_>) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
+        let cls = py.get_type::<PyRebaseFailedError>().into_py_any(py)?;
+        let args = (self.snapshot.clone(), self.conflicts.clone()).into_py_any(py)?;
+        Ok((cls, args))
     }
 }
 


### PR DESCRIPTION
Implements `__reduce__` to wokr with tblib 3.2.0 (https://python-tblib.readthedocs.io/en/latest/changelog.html#id1) which we pick up via dask distributed