### PR TITLE
New method Repository.manifest_files to get the snap manifests

### DIFF
--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -280,10 +280,10 @@ And commit
 snap = session.commit("Add 5 chunks")
 ```
 
-Use [`repo.lookup_snapshot`](./reference.md#icechunk.Repository.lookup_snapshot) to examine the manifests associated with a Snapshot
+Use [`repo.manifest_files`](./reference.md#icechunk.Repository.manifest_files) to examine the manifests associated with a Snapshot
 
 ```python exec="on" session="perf" source="material-block"
-print(repo.lookup_snapshot(snap).manifests)
+print(repo.manifest_files(snap))
 ```
 
 Let's open the Repository again with a different splitting config --- where 5 chunk references are in a single manifest.
@@ -308,7 +308,7 @@ print(session.status())
 
 ```python  exec="on" session="perf" source="material-block"
 snap2 = session.commit("appended data")
-repo.lookup_snapshot(snap2).manifests
+repo.manifest_files(snap2)
 ```
 
 Look carefully, only one new manifest with the 3 new chunk refs has been written.
@@ -328,7 +328,7 @@ print(session.status())
 
 ```python  exec="on" session="perf" source="material-block"
 snap3 = session.commit("rewrite [3,7)")
-print(repo.lookup_snapshot(snap3).manifests)
+print(repo.manifest_files(snap3))
 ```
 
 This ends up rewriting all refs to two new manifests.
@@ -361,7 +361,7 @@ snap4 = new_repo.rewrite_manifests(
 `rewrite_snapshots` will create a new commit on `branch` with the provided `message`.
 
 ```python exec="on" session="perf" source="material-block"
-print(repo.lookup_snapshot(snap4).manifests)
+print(repo.manifest_files(snap4))
 ```
 
 The splitting configuration is saved in the snapshot metadata.
@@ -397,7 +397,7 @@ repo.create_branch("split-experiment-1", repo.lookup_branch("main"))
 snap = repo.rewrite_manifests(
     f"rewrite_manifests with new config", branch="split-experiment-1"
 )
-print(repo.lookup_snapshot(snap).manifests)
+print(repo.manifest_files(snap))
 ```
 
 Now benchmark reads on `main` vs `split-experiment-1`

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1513,6 +1513,22 @@ class GCRanUpdate(UpdateType):
 class ExpirationRanUpdate(UpdateType):
     pass
 
+class ManifestFileInfo:
+    """Manifest file metadata"""
+
+    @property
+    def id(self) -> str:
+        """The manifest id"""
+        ...
+    @property
+    def size_bytes(self) -> int:
+        """The size in bytes of the"""
+        ...
+    @property
+    def num_chunk_refs(self) -> int:
+        """The number of chunk references contained in this manifest"""
+        ...
+
 class PyRepository:
     @classmethod
     def create(
@@ -1610,6 +1626,8 @@ class PyRepository:
     async def lookup_branch_async(self, branch: str) -> str: ...
     def lookup_snapshot(self, snapshot_id: str) -> SnapshotInfo: ...
     async def lookup_snapshot_async(self, snapshot_id: str) -> SnapshotInfo: ...
+    def manifest_files(self, snapshot_id: str) -> list[ManifestFileInfo]: ...
+    async def manifest_files_async(self, snapshot_id: str) -> list[ManifestFileInfo]: ...
     def reset_branch(
         self, branch: str, to_snapshot_id: str, from_snapshot_id: str | None
     ) -> None: ...
@@ -1868,22 +1886,6 @@ class PyStore:
 class PyAsyncStringGenerator(AsyncGenerator[str, None], metaclass=abc.ABCMeta):
     def __aiter__(self) -> PyAsyncStringGenerator: ...
     async def __anext__(self) -> str: ...
-
-class ManifestFileInfo:
-    """Manifest file metadata"""
-
-    @property
-    def id(self) -> str:
-        """The manifest id"""
-        ...
-    @property
-    def size_bytes(self) -> int:
-        """The size in bytes of the"""
-        ...
-    @property
-    def num_chunk_refs(self) -> int:
-        """The number of chunk references contained in this manifest"""
-        ...
 
 class SnapshotInfo:
     """Metadata for a snapshot"""

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -7,6 +7,7 @@ from icechunk import ConflictSolver
 from icechunk._icechunk_python import (
     Diff,
     GCSummary,
+    ManifestFileInfo,
     PyRepository,
     RepositoryConfig,
     SnapshotInfo,
@@ -713,6 +714,36 @@ class Repository:
         SnapshotInfo
         """
         return await self._repository.lookup_snapshot_async(snapshot_id)
+
+    def manifest_files(self, snapshot_id: str) -> list[ManifestFileInfo]:
+        """
+        Get the manifest files used by the given snapshot ID
+
+        Parameters
+        ----------
+        snapshot_id : str
+            The id of the snapshot to get information for
+
+        Returns
+        -------
+        list[ManifestFileInfo]
+        """
+        return self._repository.manifest_files(snapshot_id)
+
+    async def manifest_files_async(self, snapshot_id: str) -> list[ManifestFileInfo]:
+        """
+        Get the manifest files used by the given snapshot ID
+
+        Parameters
+        ----------
+        snapshot_id : str
+            The id of the snapshot to get information for
+
+        Returns
+        -------
+        list[ManifestFileInfo]
+        """
+        return await self._repository.manifest_files_async(snapshot_id)
 
     def reset_branch(
         self, branch: str, snapshot_id: str, *, from_snapshot_id: str | None = None

--- a/icechunk-python/tests/test_can_read_old.py
+++ b/icechunk-python/tests/test_can_read_old.py
@@ -151,23 +151,19 @@ async def do_icechunk_can_read_old_repo_with_manifest_splitting(path: str) -> No
 
     init_snapshot = ancestry[1]
     assert init_snapshot.message == "empty structure"
-    # FIXME: uncomment
-    # assert len(init_snapshot.manifests) == 0
+    assert len(repo.manifest_files(init_snapshot.id)) == 0
 
     snapshot = ancestry[2]
     assert snapshot.message == "write data"
-    # FIXME: uncomment
-    # assert len(snapshot.manifests) == 9
+    assert len(repo.manifest_files(snapshot.id)) == 9
 
     snapshot = ancestry[3]
     assert snapshot.message == "write data again"
-    # FIXME: uncomment
-    # assert len(snapshot.manifests) == 9
+    assert len(await repo.manifest_files_async(snapshot.id)) == 9
 
     snapshot = ancestry[4]
     assert snapshot.message == "write data again with more splits"
-    # FIXME: uncomment
-    # assert len(snapshot.manifests) == 17
+    assert len(await repo.manifest_files_async(snapshot.id)) == 17
 
     assert repo.config.manifest
     assert repo.config.manifest.splitting == UPDATED_SPLITTING_CONFIG

--- a/icechunk-python/tests/test_timetravel.py
+++ b/icechunk-python/tests/test_timetravel.py
@@ -145,8 +145,7 @@ def test_timetravel(using_flush: bool) -> None:
         "Repository initialized",
     ]
     assert parents[-1].id == "1CECHNKREP0F1RSTCMT0"
-    # FIXME: uncomment
-    # assert [len(snap.manifests) for snap in parents] == [1, 1, 1, 0]
+    assert [len(repo.manifest_files(snap.id)) for snap in parents] == [1, 1, 1, 0]
     assert sorted(parents, key=lambda p: p.written_at) == list(reversed(parents))
     assert len(set([snap.id for snap in parents])) == 4
     assert list(repo.ancestry(tag="v1.0")) == parents
@@ -467,8 +466,7 @@ async def test_timetravel_async(using_flush: bool) -> None:
         "Repository initialized",
     ]
     assert parents[-1].id == "1CECHNKREP0F1RSTCMT0"
-    # FIXME: uncomment
-    # assert [len(snap.manifests) for snap in parents] == [1, 1, 1, 0]
+    assert [len(repo.manifest_files(snap.id)) for snap in parents] == [1, 1, 1, 0]
     assert sorted(parents, key=lambda p: p.written_at) == list(reversed(parents))
     assert len(set([snap.id for snap in parents])) == 4
     assert [parent async for parent in repo.async_ancestry(tag="v1.0")] == parents


### PR DESCRIPTION
This replaces the previous API of `SnapshotInfo.manifests` and it's the only API breaking change in Icechunk 2. We don't expect the old API to be heavily used.