### PR TITLE
Support `gs://` prefix in virtual chunk containers in IC V1 (#1363)

### DIFF
--- a/icechunk/src/virtual_chunks.rs
+++ b/icechunk/src/virtual_chunks.rs
@@ -79,10 +79,11 @@ impl VirtualChunkContainer {
                     );
                 }
             }
-            ("gcs", ObjectStoreConfig::Gcs(_)) => {
+            ("gcs" | "gs", ObjectStoreConfig::Gcs(_)) => {
                 if !url.has_host() {
-                    return Err("Url prefix for gcs:// containers must include a host"
-                        .to_string());
+                    return Err(
+                        "Url prefix for GCS containers must include a host".to_string()
+                    );
                 }
             }
             ("az" | "azure" | "abfs", ObjectStoreConfig::Azure(..)) => {

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -148,11 +148,17 @@ async fn create_local_repository(
             ObjectStoreConfig::Gcs(Default::default()),
         )
         .unwrap(),
+        VirtualChunkContainer::new(
+            "gs://testbucket/".to_string(),
+            ObjectStoreConfig::Gcs(Default::default()),
+        )
+        .unwrap(),
     ];
 
     let mut creds: HashMap<_, Option<Credentials>> = [
         ("s3://testbucket".to_string(), None),
         ("gcs://testbucket".to_string(), None),
+        ("gs://testbucket".to_string(), None),
         (
             "s3://earthmover-sample-data".to_string(),
             Some(Credentials::S3(S3Credentials::Anonymous)),


### PR DESCRIPTION
Same as #1363 but going into the IC1 support branch (FYI @ianhi)