### PR TITLE
Ignore mypy complaint about `dask.__version__`

### DIFF
--- a/icechunk-python/python/icechunk/dask.py
+++ b/icechunk-python/python/icechunk/dask.py
@@ -47,9 +47,10 @@ def merge_sessions_array_kwargs(
 
 
 def _assert_correct_dask_version() -> None:
-    if Version(dask.__version__) < Version("2024.11.0"):
+    dask_version = dask.__version__  # type: ignore[attr-defined]
+    if Version(dask_version) < Version("2024.11.0"):
         raise ValueError(
-            f"Writing to icechunk requires dask>=2024.11.0 but you have {dask.__version__}. Please upgrade."
+            f"Writing to icechunk requires dask>=2024.11.0 but you have {dask_version}. Please upgrade."
         )
 
 


### PR DESCRIPTION
Fix the mypy error seen in #1373, by ignoring it.