### PR TITLE
Fix `Repository.total_chunks_storage` for V1 repos.

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1558,6 +1558,7 @@ class PyRepository:
         *,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        spec_version: int | None = None,
     ) -> PyRepository: ...
     @classmethod
     async def create_async(
@@ -1566,6 +1567,7 @@ class PyRepository:
         *,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        spec_version: int | None = None,
     ) -> PyRepository: ...
     @classmethod
     def open(
@@ -1590,6 +1592,7 @@ class PyRepository:
         *,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        create_version: int | None = None,
     ) -> PyRepository: ...
     @classmethod
     async def open_or_create_async(
@@ -1598,6 +1601,7 @@ class PyRepository:
         *,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        create_version: int | None = None,
     ) -> PyRepository: ...
     @staticmethod
     def exists(storage: Storage) -> bool: ...

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -33,6 +33,7 @@ class Repository:
         storage: Storage,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        spec_version: int | None = None,
     ) -> Self:
         """
         Create a new Icechunk repository.
@@ -55,6 +56,9 @@ class Repository:
             environment, or anonymous credentials will be used if the container allows it.
             As a security measure, Icechunk will block access to virtual chunks if the
             container is not authorized using this argument.
+        spec_version : int, optional
+            Use this version of the spec for the new repository. If not passed, the latest version
+            of the spec that was available before the library version release will be used.
 
         Returns
         -------
@@ -66,6 +70,7 @@ class Repository:
                 storage,
                 config=config,
                 authorize_virtual_chunk_access=authorize_virtual_chunk_access,
+                spec_version=spec_version,
             )
         )
 
@@ -75,6 +80,7 @@ class Repository:
         storage: Storage,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        spec_version: int | None = None,
     ) -> Self:
         """
         Create a new Icechunk repository asynchronously.
@@ -97,6 +103,9 @@ class Repository:
             environment, or anonymous credentials will be used if the container allows it.
             As a security measure, Icechunk will block access to virtual chunks if the
             container is not authorized using this argument.
+        spec_version : int, optional
+            Use this version of the spec for the new repository. If not passed, the latest version
+            of the spec that was available before the library version release will be used.
 
         Returns
         -------
@@ -108,6 +117,7 @@ class Repository:
                 storage,
                 config=config,
                 authorize_virtual_chunk_access=authorize_virtual_chunk_access,
+                spec_version=spec_version,
             )
         )
 
@@ -205,6 +215,7 @@ class Repository:
         storage: Storage,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        create_version: int | None = None,
     ) -> Self:
         """
         Open an existing Icechunk repository or create a new one if it does not exist.
@@ -230,6 +241,11 @@ class Repository:
             environment, or anonymous credentials will be used if the container allows it.
             As a security measure, Icechunk will block access to virtual chunks if the
             container is not authorized using this argument.
+        create_version : int, optional
+            Use this version of the spec for the new repository, if it needs to be created.
+            If not passed, the latest version of the spec that was available before the
+            library version release will be used.
+
 
         Returns
         -------
@@ -241,6 +257,7 @@ class Repository:
                 storage,
                 config=config,
                 authorize_virtual_chunk_access=authorize_virtual_chunk_access,
+                create_version=create_version,
             )
         )
 
@@ -250,6 +267,7 @@ class Repository:
         storage: Storage,
         config: RepositoryConfig | None = None,
         authorize_virtual_chunk_access: dict[str, AnyCredential | None] | None = None,
+        create_version: int | None = None,
     ) -> Self:
         """
         Open an existing Icechunk repository or create a new one if it does not exist (async version).
@@ -275,6 +293,10 @@ class Repository:
             environment, or anonymous credentials will be used if the container allows it.
             As a security measure, Icechunk will block access to virtual chunks if the
             container is not authorized using this argument.
+        create_version : int, optional
+            Use this version of the spec for the new repository, if it needs to be created.
+            If not passed, the latest version of the spec that was available before the
+            library version release will be used.
 
         Returns
         -------
@@ -286,6 +308,7 @@ class Repository:
                 storage,
                 config=config,
                 authorize_virtual_chunk_access=authorize_virtual_chunk_access,
+                create_version=create_version,
             )
         )
 

--- a/icechunk-python/tests/test_stats.py
+++ b/icechunk-python/tests/test_stats.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import icechunk as ic
@@ -54,3 +56,17 @@ async def test_total_chunks_storage_async() -> None:
     await session.commit_async("commit 1")
 
     assert await repo.total_chunks_storage_async() == 100 * 4
+
+
+@pytest.mark.parametrize(
+    "dir", ["./tests/data/test-repo-v2", "./tests/data/test-repo-v1"]
+)
+def test_chunk_storage_on_filesystem(dir: str) -> None:
+    repo = ic.Repository.open(
+        storage=ic.local_filesystem_storage(dir),
+    )
+    actual = repo.total_chunks_storage()
+    expected = sum(
+        f.stat().st_size for f in (Path(dir) / "chunks").glob("*") if f.is_file()
+    )
+    assert actual == expected

--- a/icechunk/examples/low_level_dataset.rs
+++ b/icechunk/examples/low_level_dataset.rs
@@ -27,7 +27,8 @@ let mut ds = Repository::create(Arc::clone(&storage));
     );
 
     let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
-    let repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+    let repo =
+        Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
     let mut ds = repo.writable_session("main").await?;
 
     println!();

--- a/icechunk/examples/multithreaded_get_chunk_refs.rs
+++ b/icechunk/examples/multithreaded_get_chunk_refs.rs
@@ -52,7 +52,8 @@ async fn mk_repo(
         }),
         ..RepositoryConfig::default()
     };
-    let repo = Repository::open_or_create(Some(config), storage, HashMap::new()).await?;
+    let repo =
+        Repository::open_or_create(Some(config), storage, HashMap::new(), None).await?;
     Ok(repo)
 }
 

--- a/icechunk/examples/multithreaded_store.rs
+++ b/icechunk/examples/multithreaded_store.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         inline_chunk_threshold_bytes: Some(128),
         ..Default::default()
     };
-    let repo = Repository::create(Some(config), storage, HashMap::new()).await?;
+    let repo = Repository::create(Some(config), storage, HashMap::new(), None).await?;
     let ds = Arc::new(RwLock::new(repo.writable_session("main").await?));
     let store = Store::from_session(Arc::clone(&ds)).await;
 

--- a/icechunk/src/asset_manager.rs
+++ b/icechunk/src/asset_manager.rs
@@ -1,3 +1,4 @@
+use async_stream::try_stream;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{Stream, StreamExt as _, TryStreamExt, stream::BoxStream};
@@ -47,6 +48,7 @@ use crate::{
 pub struct AssetManager {
     storage: Arc<dyn Storage + Send + Sync>,
     storage_settings: storage::Settings,
+    spec_version: SpecVersionBin,
     num_snapshot_nodes: u64,
     num_chunk_refs: u64,
     num_transaction_changes: u64,
@@ -80,6 +82,7 @@ impl private::Sealed for AssetManager {}
 struct AssetManagerSerializer {
     storage: Arc<dyn Storage + Send + Sync>,
     storage_settings: storage::Settings,
+    spec_version: SpecVersionBin,
     num_snapshot_nodes: u64,
     num_chunk_refs: u64,
     num_transaction_changes: u64,
@@ -94,6 +97,7 @@ impl From<AssetManagerSerializer> for AssetManager {
         AssetManager::new(
             value.storage,
             value.storage_settings,
+            value.spec_version,
             value.num_snapshot_nodes,
             value.num_chunk_refs,
             value.num_transaction_changes,
@@ -110,6 +114,7 @@ impl AssetManager {
     pub fn new(
         storage: Arc<dyn Storage + Send + Sync>,
         storage_settings: storage::Settings,
+        spec_version: SpecVersionBin,
         num_snapshot_nodes: u64,
         num_chunk_refs: u64,
         num_transaction_changes: u64,
@@ -128,6 +133,7 @@ impl AssetManager {
             max_concurrent_requests,
             storage,
             storage_settings,
+            spec_version,
             snapshot_cache: Cache::with_weighter(1, num_snapshot_nodes, FileWeighter),
             manifest_cache: Cache::with_weighter(1, num_chunk_refs, FileWeighter),
             transactions_cache: Cache::with_weighter(
@@ -145,12 +151,14 @@ impl AssetManager {
     pub fn new_no_cache(
         storage: Arc<dyn Storage + Send + Sync>,
         storage_settings: storage::Settings,
+        spec_version: SpecVersionBin,
         compression_level: u8,
         max_concurrent_requests: u16,
     ) -> Self {
         Self::new(
             storage,
             storage_settings,
+            spec_version,
             0,
             0,
             0,
@@ -164,6 +172,7 @@ impl AssetManager {
     pub fn new_with_config(
         storage: Arc<dyn Storage + Send + Sync>,
         storage_settings: storage::Settings,
+        spec_version: SpecVersionBin,
         config: &CachingConfig,
         compression_level: u8,
         max_concurrent_requests: u16,
@@ -171,6 +180,7 @@ impl AssetManager {
         Self::new(
             storage,
             storage_settings,
+            spec_version,
             config.num_snapshot_nodes(),
             config.num_chunk_refs(),
             config.num_transaction_changes(),
@@ -179,6 +189,10 @@ impl AssetManager {
             compression_level,
             max_concurrent_requests,
         )
+    }
+
+    pub fn spec_version(&self) -> SpecVersionBin {
+        self.spec_version
     }
 
     pub fn limit_retries_repo_update(
@@ -705,6 +719,44 @@ impl AssetManager {
 
     pub fn backup_path_for_repo_info(&self) -> String {
         backup_destination(REPO_INFO_FILE_PATH)
+    }
+
+    #[deprecated(
+        since = "2.0.0",
+        note = "Shouldn't be necessary after 2.0, only to support Icechunk 1 repos"
+    )]
+    pub fn storage(&self) -> &Arc<dyn Storage + Send + Sync> {
+        &self.storage
+    }
+
+    #[deprecated(
+        since = "2.0.0",
+        note = "Shouldn't be necessary after 2.0, only to support Icechunk 1 repos"
+    )]
+    pub fn storage_settings(&self) -> &storage::Settings {
+        &self.storage_settings
+    }
+
+    #[deprecated(
+        since = "2.0.0",
+        note = "Shouldn't be necessary after 2.0, only to support Icechunk 1 repos"
+    )]
+    pub async fn snapshot_ancestry_v1(
+        self: Arc<Self>,
+        snapshot_id: &SnapshotId,
+    ) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + use<>>
+    {
+        let mut this = self.fetch_snapshot(snapshot_id).await?;
+        let stream = try_stream! {
+            yield Arc::clone(&this);
+            #[allow(deprecated)]
+            while let Some(parent) = this.parent_id() {
+                let snap = self.fetch_snapshot(&parent).await?;
+                yield Arc::clone(&snap);
+                this = snap;
+            }
+        };
+        Ok(stream)
     }
 }
 
@@ -1275,8 +1327,13 @@ mod test {
     async fn test_caching_caches() -> Result<(), Box<dyn std::error::Error>> {
         let backend: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
         let settings = storage::Settings::default();
-        let manager =
-            AssetManager::new_no_cache(backend.clone(), settings.clone(), 1, 100);
+        let manager = AssetManager::new_no_cache(
+            backend.clone(),
+            settings.clone(),
+            SpecVersionBin::default(),
+            1,
+            100,
+        );
 
         let node1 = NodeId::random();
         let node2 = NodeId::random();
@@ -1301,6 +1358,7 @@ mod test {
         let caching = AssetManager::new_with_config(
             Arc::clone(&logging_c),
             settings,
+            SpecVersionBin::default(),
             &CachingConfig::default(),
             1,
             100,
@@ -1371,8 +1429,13 @@ mod test {
     async fn test_caching_storage_has_limit() -> Result<(), Box<dyn std::error::Error>> {
         let backend: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
         let settings = storage::Settings::default();
-        let manager =
-            AssetManager::new_no_cache(backend.clone(), settings.clone(), 1, 100);
+        let manager = AssetManager::new_no_cache(
+            backend.clone(),
+            settings.clone(),
+            SpecVersionBin::default(),
+            1,
+            100,
+        );
 
         let ci1 = ChunkInfo {
             node: NodeId::random(),
@@ -1406,6 +1469,7 @@ mod test {
         let caching = AssetManager::new_with_config(
             logging_c,
             settings,
+            SpecVersionBin::default(),
             // the cache can only fit 6 refs.
             &CachingConfig {
                 num_snapshot_nodes: Some(0),
@@ -1439,6 +1503,7 @@ mod test {
         let manager = Arc::new(AssetManager::new_no_cache(
             storage.clone(),
             settings.clone(),
+            SpecVersionBin::default(),
             1,
             100,
         ));
@@ -1460,6 +1525,7 @@ mod test {
         let manager = Arc::new(AssetManager::new_with_config(
             logging_c.clone(),
             settings,
+            SpecVersionBin::default(),
             &CachingConfig::default(),
             1,
             100,

--- a/icechunk/src/cli/interface.rs
+++ b/icechunk/src/cli/interface.rs
@@ -210,7 +210,7 @@ async fn repo_create(init_cmd: &CreateCommand, config: &CliConfig) -> Result<()>
 
     let config = Some(repo.get_config().clone());
 
-    Repository::create(config, Arc::clone(&storage), HashMap::new())
+    Repository::create(config, Arc::clone(&storage), HashMap::new(), None)
         .await
         .context(format!("Failed to create repository {:?}", init_cmd.repo))?;
 

--- a/icechunk/src/format/mod.rs
+++ b/icechunk/src/format/mod.rs
@@ -361,9 +361,10 @@ pub mod format_constants {
     }
 
     #[repr(u8)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
     pub enum SpecVersionBin {
         V1dot0 = 1u8,
+        #[default]
         V2dot0 = 2u8,
     }
 
@@ -381,7 +382,7 @@ pub mod format_constants {
 
     impl SpecVersionBin {
         pub fn current() -> Self {
-            Self::V2dot0
+            Default::default()
         }
     }
 

--- a/icechunk/src/ops/mod.rs
+++ b/icechunk/src/ops/mod.rs
@@ -2,20 +2,25 @@ use std::{collections::HashSet, sync::Arc};
 
 use async_stream::try_stream;
 use err_into::ErrorInto as _;
-use futures::Stream;
+use futures::{Stream, StreamExt as _, TryStreamExt as _, stream};
+use tokio::pin;
 use tracing::instrument;
 
 use crate::{
     asset_manager::AssetManager,
-    format::{SnapshotId, repo_info::RepoInfo, snapshot::Snapshot},
-    repository::RepositoryResult,
+    format::{
+        SnapshotId, format_constants::SpecVersionBin, repo_info::RepoInfo,
+        snapshot::Snapshot,
+    },
+    refs::{RefResult, list_refs},
+    repository::{RepositoryError, RepositoryResult},
 };
 pub mod gc;
 pub mod manifests;
 pub mod stats;
 
 #[instrument(skip_all)]
-pub fn all_roots<'a>(
+pub fn all_roots_v2<'a>(
     repo_info: &'a RepoInfo,
     extra_roots: &'a HashSet<SnapshotId>,
 ) -> RepositoryResult<impl Iterator<Item = RepositoryResult<SnapshotId>> + 'a> {
@@ -29,7 +34,7 @@ pub fn all_roots<'a>(
 }
 
 #[instrument(skip_all)]
-pub async fn pointed_snapshots<'a>(
+pub async fn pointed_snapshots_v2<'a>(
     asset_manager: Arc<AssetManager>,
     extra_roots: &'a HashSet<SnapshotId>,
 ) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + 'a> {
@@ -37,7 +42,7 @@ pub async fn pointed_snapshots<'a>(
     let (repo_info, _) = asset_manager.fetch_repo_info().await?;
     let res = try_stream! {
 
-        let roots = all_roots(repo_info.as_ref(), extra_roots)?;
+        let roots = all_roots_v2(repo_info.as_ref(), extra_roots)?;
         for pointed_snap_id in roots {
             let pointed_snap_id = pointed_snap_id?;
             if ! seen.contains(&pointed_snap_id)
@@ -62,6 +67,81 @@ pub async fn pointed_snapshots<'a>(
     Ok(res)
 }
 
+#[instrument(skip_all)]
+pub async fn pointed_snapshots_v1<'a>(
+    asset_manager: Arc<AssetManager>,
+    extra_roots: &'a HashSet<SnapshotId>,
+) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + 'a> {
+    let mut seen: HashSet<SnapshotId> = HashSet::new();
+    let res = try_stream! {
+        let roots = all_roots_v1(Arc::clone(&asset_manager), extra_roots)
+            .await?
+            .err_into::<RepositoryError>();
+        pin!(roots);
+
+        while let Some(pointed_snap_id) = roots.try_next().await? {
+            if ! seen.contains(&pointed_snap_id) {
+                #[allow(deprecated)]
+                let parents = Arc::clone(&asset_manager).snapshot_ancestry_v1(&pointed_snap_id).await?;
+                for await parent in parents {
+                    let parent = parent?;
+                    let snap_id = parent.id();
+                    if seen.insert(snap_id) {
+                        // it's a new snapshot
+                        yield parent
+                    } else {
+                        // as soon as we find a repeated snapshot
+                        // there is no point in continuing to retrieve
+                        // the rest of the ancestry, it must be already
+                        // retrieved from other ref
+                        break
+                    }
+                }
+            }
+        }
+    };
+    Ok(res)
+}
+pub async fn all_roots_v1<'a>(
+    asset_manager: Arc<AssetManager>,
+    extra_roots: &'a HashSet<SnapshotId>,
+) -> RefResult<impl Stream<Item = RefResult<SnapshotId>> + 'a> {
+    #[allow(deprecated)]
+    let all_refs =
+        list_refs(asset_manager.storage().as_ref(), asset_manager.storage_settings())
+            .await?;
+    let roots = stream::iter(all_refs)
+        .then(move |r| {
+            let asset_manager = asset_manager.clone();
+            async move {
+                #[allow(deprecated)]
+                r.fetch(
+                    asset_manager.storage().as_ref(),
+                    asset_manager.storage_settings(),
+                )
+                .await
+                .map(|ref_data| ref_data.snapshot)
+            }
+        })
+        .err_into()
+        .chain(stream::iter(extra_roots.iter().cloned()).map(Ok));
+    Ok(roots)
+}
+
+pub async fn pointed_snapshots<'a>(
+    asset_manager: Arc<AssetManager>,
+    extra_roots: &'a HashSet<SnapshotId>,
+) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + 'a> {
+    match asset_manager.spec_version() {
+        SpecVersionBin::V1dot0 => {
+            Ok(pointed_snapshots_v1(asset_manager, extra_roots).await?.left_stream())
+        }
+        SpecVersionBin::V2dot0 => {
+            Ok(pointed_snapshots_v2(asset_manager, extra_roots).await?.right_stream())
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -78,7 +158,8 @@ mod tests {
     async fn test_pointed_snapshots_duplicate() -> Result<(), Box<dyn std::error::Error>>
     {
         let storage = new_in_memory_storage().await?;
-        let repo = Repository::create(None, storage.clone(), HashMap::new()).await?;
+        let repo =
+            Repository::create(None, storage.clone(), HashMap::new(), None).await?;
         let mut session = repo.writable_session("main").await?;
         session.add_group(Path::root(), Bytes::new()).await?;
         let snap = session.commit("commit", None).await?;

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -2571,6 +2571,7 @@ mod tests {
             detector::ConflictDetector,
         },
         format::{
+            format_constants::SpecVersionBin,
             manifest::{ManifestExtents, ManifestSplits},
             repo_info::RepoInfo,
         },
@@ -2593,7 +2594,7 @@ mod tests {
     async fn create_memory_store_repository() -> Repository {
         let storage =
             new_in_memory_storage().await.expect("failed to create in-memory store");
-        Repository::create(None, storage, HashMap::new()).await.unwrap()
+        Repository::create(None, storage, HashMap::new(), None).await.unwrap()
     }
 
     #[proptest(async = "tokio")]
@@ -2868,6 +2869,7 @@ mod tests {
             }),
             storage,
             HashMap::new(),
+            None,
         )
         .await?;
         let mut session = repo.writable_session("main").await?;
@@ -2967,6 +2969,7 @@ mod tests {
         let asset_manager = AssetManager::new_no_cache(
             Arc::clone(&storage),
             storage_settings.clone(),
+            SpecVersionBin::current(),
             1,
             100,
         );
@@ -3244,7 +3247,7 @@ mod tests {
             ..Default::default()
         };
         let repository =
-            Repository::create(Some(config), storage, HashMap::new()).await?;
+            Repository::create(Some(config), storage, HashMap::new(), None).await?;
 
         let mut ds = repository.writable_session("main").await?;
 
@@ -3671,7 +3674,7 @@ mod tests {
     #[tokio_test(flavor = "multi_thread")]
     async fn test_all_chunks_iterator() -> Result<(), Box<dyn Error>> {
         let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
-        let repo = Repository::create(None, storage, HashMap::new()).await?;
+        let repo = Repository::create(None, storage, HashMap::new(), None).await?;
         let mut ds = repo.writable_session("main").await?;
         let def = Bytes::copy_from_slice(b"");
 
@@ -3741,7 +3744,8 @@ mod tests {
     async fn test_manifests_shrink() -> Result<(), Box<dyn Error>> {
         let in_mem_storage = Arc::new(ObjectStorage::new_in_memory().await?);
         let storage: Arc<dyn Storage + Send + Sync> = in_mem_storage.clone();
-        let repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+        let repo =
+            Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
 
         // there should be no manifests yet
         assert!(
@@ -4171,7 +4175,8 @@ mod tests {
     async fn test_basic_move() -> Result<(), Box<dyn Error>> {
         let in_mem_storage = new_in_memory_storage().await?;
         let storage: Arc<dyn Storage + Send + Sync> = in_mem_storage.clone();
-        let repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+        let repo =
+            Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
         let mut session = repo.writable_session("main").await?;
 
         let shape = ArrayShape::new(vec![(5, 2), (5, 2)]).unwrap();
@@ -4230,7 +4235,8 @@ mod tests {
     async fn test_move_errors() -> Result<(), Box<dyn Error>> {
         let in_mem_storage = new_in_memory_storage().await?;
         let storage: Arc<dyn Storage + Send + Sync> = in_mem_storage.clone();
-        let repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+        let repo =
+            Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
         let mut session = repo.writable_session("main").await?;
 
         let shape = ArrayShape::new(vec![(5, 2), (5, 2)]).unwrap();
@@ -4260,7 +4266,8 @@ mod tests {
     async fn test_setting_w_invalid_coords() -> Result<(), Box<dyn Error>> {
         let in_mem_storage = new_in_memory_storage().await?;
         let storage: Arc<dyn Storage + Send + Sync> = in_mem_storage.clone();
-        let repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+        let repo =
+            Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
         let mut ds = repo.writable_session("main").await?;
 
         let shape = ArrayShape::new(vec![(5, 2), (5, 2)]).unwrap();
@@ -4321,7 +4328,8 @@ mod tests {
     async fn test_array_shift() -> Result<(), Box<dyn Error>> {
         let in_mem_storage = new_in_memory_storage().await?;
         let storage: Arc<dyn Storage + Send + Sync> = in_mem_storage.clone();
-        let repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+        let repo =
+            Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
         let mut session = repo.writable_session("main").await?;
         let shape = ArrayShape::new(vec![(20, 2)]).unwrap();
         session.add_group(Path::root(), Bytes::new()).await?;

--- a/icechunk/src/store.rs
+++ b/icechunk/src/store.rs
@@ -1263,7 +1263,7 @@ mod tests {
     async fn create_memory_store_repository() -> Repository {
         let storage =
             new_in_memory_storage().await.expect("failed to create in-memory store");
-        Repository::create(None, storage, HashMap::new()).await.unwrap()
+        Repository::create(None, storage, HashMap::new(), None).await.unwrap()
     }
 
     async fn all_keys(store: &Store) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -2401,7 +2401,7 @@ mod tests {
                 .expect("could not create storage"),
         );
 
-        let repo = Repository::create(None, storage, HashMap::new()).await.unwrap();
+        let repo = Repository::create(None, storage, HashMap::new(), None).await.unwrap();
         let ds = Arc::new(RwLock::new(repo.writable_session("main").await.unwrap()));
         let store = Store::from_session(Arc::clone(&ds)).await;
         store

--- a/icechunk/tests/test_concurrency.rs
+++ b/icechunk/tests/test_concurrency.rs
@@ -79,7 +79,7 @@ async fn do_test_concurrency(
         }),
         ..Default::default()
     };
-    let repo = Repository::create(Some(config), storage, HashMap::new()).await?;
+    let repo = Repository::create(Some(config), storage, HashMap::new(), None).await?;
 
     let mut ds = repo.writable_session("main").await?;
 

--- a/icechunk/tests/test_distributed_writes.rs
+++ b/icechunk/tests/test_distributed_writes.rs
@@ -26,7 +26,7 @@ async fn mk_repo(
             inline_chunk_threshold_bytes: Some(0),
             ..RepositoryConfig::default()
         };
-        Ok(Repository::create(Some(config), storage, HashMap::new()).await?)
+        Ok(Repository::create(Some(config), storage, HashMap::new(), None).await?)
     } else {
         Ok(Repository::open(None, storage, HashMap::new()).await?)
     }

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -16,7 +16,10 @@ use icechunk::{
         DEFAULT_MAX_CONCURRENT_REQUESTS, ManifestConfig, ManifestSplitCondition,
         ManifestSplitDim, ManifestSplitDimCondition, ManifestSplittingConfig,
     },
-    format::{ByteRange, ChunkIndices, Path, snapshot::ArrayShape},
+    format::{
+        ByteRange, ChunkIndices, Path, format_constants::SpecVersionBin,
+        snapshot::ArrayShape,
+    },
     new_in_memory_storage,
     ops::gc::{ExpiredRefAction, GCConfig, GCSummary, expire, garbage_collect},
     repository::VersionInfo,
@@ -87,6 +90,7 @@ pub async fn do_test_gc(
         }),
         Arc::clone(&storage),
         HashMap::new(),
+        None,
     )
     .await?;
 
@@ -340,13 +344,15 @@ pub async fn do_test_expire_and_garbage_collect(
     storage: Arc<dyn Storage + Send + Sync>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage_settings = storage.default_settings().await?;
-    let mut repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+    let mut repo =
+        Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
 
     let expire_older_than = make_design_doc_repo(&mut repo).await?;
 
     let asset_manager = Arc::new(AssetManager::new_no_cache(
         storage.clone(),
         storage_settings.clone(),
+        SpecVersionBin::current(),
         1,
         DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
@@ -405,6 +411,7 @@ pub async fn do_test_expire_and_garbage_collect(
     let asset_manager = Arc::new(AssetManager::new_no_cache(
         storage.clone(),
         storage_settings.clone(),
+        SpecVersionBin::current(),
         1,
         DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
@@ -447,13 +454,15 @@ pub async fn test_expire_and_garbage_collect_deleting_expired_refs()
 -> Result<(), Box<dyn std::error::Error>> {
     let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
     let storage_settings = storage.default_settings().await?;
-    let mut repo = Repository::create(None, Arc::clone(&storage), HashMap::new()).await?;
+    let mut repo =
+        Repository::create(None, Arc::clone(&storage), HashMap::new(), None).await?;
 
     let expire_older_than = make_design_doc_repo(&mut repo).await?;
 
     let asset_manager = Arc::new(AssetManager::new_no_cache(
         storage.clone(),
         storage_settings.clone(),
+        SpecVersionBin::current(),
         1,
         DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));

--- a/icechunk/tests/test_large_manifests.rs
+++ b/icechunk/tests/test_large_manifests.rs
@@ -34,7 +34,7 @@ async fn test_write_large_number_of_refs() -> Result<(), Box<dyn std::error::Err
         }),
         ..Default::default()
     };
-    let repo = Repository::create(Some(config), storage, HashMap::new()).await?;
+    let repo = Repository::create(Some(config), storage, HashMap::new(), None).await?;
     let session = Arc::new(RwLock::new(repo.writable_session("main").await?));
     let store = Store::from_session(Arc::clone(&session)).await;
 

--- a/icechunk/tests/test_stats.rs
+++ b/icechunk/tests/test_stats.rs
@@ -13,6 +13,7 @@ use icechunk::{
     config::DEFAULT_MAX_CONCURRENT_REQUESTS,
     format::{
         ChunkIndices, Path,
+        format_constants::SpecVersionBin,
         manifest::{ChunkPayload, VirtualChunkLocation, VirtualChunkRef},
         snapshot::ArrayShape,
     },
@@ -70,6 +71,7 @@ pub async fn do_test_repo_chunks_storage(
     let asset_manager = Arc::new(AssetManager::new_no_cache(
         storage.clone(),
         storage_settings.clone(),
+        SpecVersionBin::current(),
         1,
         DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
@@ -81,6 +83,7 @@ pub async fn do_test_repo_chunks_storage(
         }),
         Arc::clone(&storage),
         Default::default(),
+        None,
     )
     .await?;
 

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -11,7 +11,8 @@ use icechunk::{
     },
     format::{
         CHUNKS_FILE_PATH, ChunkId, MANIFESTS_FILE_PATH, Path, SNAPSHOTS_FILE_PATH,
-        SnapshotId, TRANSACTION_LOGS_FILE_PATH, snapshot::Snapshot,
+        SnapshotId, TRANSACTION_LOGS_FILE_PATH, format_constants::SpecVersionBin,
+        snapshot::Snapshot,
     },
     new_local_filesystem_storage,
     refs::{RefData, RefErrorKind},
@@ -257,7 +258,7 @@ pub async fn test_object_write_read() -> Result<(), Box<dyn std::error::Error>> 
 #[tokio_test]
 pub async fn test_tag_write_get() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(|_, storage| async move {
-        let repo = Repository::create(None, storage, Default::default()).await?;
+        let repo = Repository::create(None, storage, Default::default(), None).await?;
         repo.create_tag("mytag", &Snapshot::INITIAL_SNAPSHOT_ID).await?;
         let back = repo.lookup_tag("mytag").await?;
         assert_eq!(Snapshot::INITIAL_SNAPSHOT_ID, back);
@@ -270,7 +271,7 @@ pub async fn test_tag_write_get() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio_test]
 pub async fn test_fetch_non_existing_tag() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(|_, storage| async move {
-        let repo = Repository::create(None, storage, Default::default()).await?;
+        let repo = Repository::create(None, storage, Default::default(), None).await?;
         repo.create_tag("mytag", &Snapshot::INITIAL_SNAPSHOT_ID).await?;
         let back = repo.lookup_tag("non-existing-tag").await;
         assert!(
@@ -289,7 +290,7 @@ pub async fn test_fetch_non_existing_tag() -> Result<(), Box<dyn std::error::Err
 #[tokio_test]
 pub async fn test_create_existing_tag() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(|_, storage| async move {
-        let repo = Repository::create(None, storage, Default::default()).await?;
+        let repo = Repository::create(None, storage, Default::default(), None).await?;
         repo.create_tag("mytag", &Snapshot::INITIAL_SNAPSHOT_ID).await?;
         let res  = repo.create_tag("mytag", &Snapshot::INITIAL_SNAPSHOT_ID).await;
         assert!(
@@ -508,7 +509,7 @@ pub async fn test_delete_objects() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio_test]
 pub async fn test_fetch_non_existing_branch() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(|_, storage| async move {
-        let repo = Repository::create(None, storage, Default::default()).await?;
+        let repo = Repository::create(None, storage, Default::default(), None).await?;
         let back = repo.lookup_branch("non-existing-branch").await;
         assert!(
             matches!(
@@ -531,6 +532,7 @@ pub async fn test_write_config_on_empty() -> Result<(), Box<dyn std::error::Erro
         let am = Arc::new(AssetManager::new_no_cache(
             storage,
             storage_settings,
+            SpecVersionBin::current(),
             1, // we are only reading, compression doesn't matter
             DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
@@ -564,6 +566,7 @@ pub async fn test_write_config_on_existing() -> Result<(), Box<dyn std::error::E
         let am = Arc::new(AssetManager::new_no_cache(
             Arc::clone(&storage),
             storage.default_settings().await?,
+            SpecVersionBin::current(),
             1, // we are only reading, compression doesn't matter
             DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
@@ -604,6 +607,7 @@ pub async fn test_write_config_fails_on_bad_version_when_non_existing()
     let am = Arc::new(AssetManager::new_no_cache(
         storage,
         storage_settings,
+        SpecVersionBin::current(),
         1, // we are only reading, compression doesn't matter
         DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
@@ -634,6 +638,7 @@ pub async fn test_write_config_fails_on_bad_version_when_existing()
         let am = Arc::new(AssetManager::new_no_cache(
             storage,
             storage_settings,
+            SpecVersionBin::current(),
             1, // we are only reading, compression doesn't matter
             DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
@@ -692,6 +697,7 @@ pub async fn test_write_config_can_overwrite_with_unsafe_config()
         let am = Arc::new(AssetManager::new_no_cache(
             storage,
             storage_settings,
+            SpecVersionBin::current(),
             1, // we are only reading, compression doesn't matter
             DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -80,6 +80,7 @@ async fn create_repository(
         }),
         storage,
         credentials,
+        None,
     )
     .await
     .expect("Failed to initialize repository")
@@ -851,7 +852,7 @@ async fn test_zarr_store_with_multiple_virtual_chunk_containers()
         config.set_virtual_chunk_container(container);
     }
 
-    let repo = Repository::create(Some(config), storage, virtual_creds).await?;
+    let repo = Repository::create(Some(config), storage, virtual_creds, None).await?;
 
     let old_timestamp = SecondsSinceEpoch(chrono::Utc::now().timestamp() as u32 - 5);
 


### PR DESCRIPTION
TODO in future PR: actually allow the creation of V1 repos. Currently the API is added, but the parameter is ignored.

Closes: #1220