### PR TITLE
More write operations on V1 repos

### DIFF
--- a/icechunk-python/tests/test_spec_versions.py
+++ b/icechunk-python/tests/test_spec_versions.py
@@ -43,3 +43,47 @@ def test_cannot_amend_with_spec_version_1():
     group.create_group("bar")
     with pytest.raises(ic.IcechunkError, match="upgrade"):
         session.amend("amend attempt")
+
+
+def test_can_create_branch_on_v1():
+    storage = ic.in_memory_storage()
+    repo = ic.Repository.create(storage, spec_version=1)
+    repo.create_branch("foo", "1CECHNKREP0F1RSTCMT0")
+    assert repo.list_branches() == {"main", "foo"}
+
+
+def test_can_create_tag_on_v1():
+    storage = ic.in_memory_storage()
+    repo = ic.Repository.create(storage, spec_version=1)
+    repo.create_tag("foo", "1CECHNKREP0F1RSTCMT0")
+    assert repo.list_tags() == {"foo"}
+
+
+def test_can_reset_branch_on_v1():
+    storage = ic.in_memory_storage()
+    repo = ic.Repository.create(storage, spec_version=1)
+    session = repo.writable_session("main")
+    group = zarr.group(store=session.store, overwrite=True)
+    group.create_group("foo")
+    commit_id = session.commit("make group")
+
+    repo.reset_branch("main", "1CECHNKREP0F1RSTCMT0", from_snapshot_id=commit_id)
+    assert repo.lookup_branch("main") == "1CECHNKREP0F1RSTCMT0"
+
+
+def test_can_delete_branch_on_v1():
+    storage = ic.in_memory_storage()
+    repo = ic.Repository.create(storage, spec_version=1)
+    repo.create_branch("foo", "1CECHNKREP0F1RSTCMT0")
+    assert repo.list_branches() == {"main", "foo"}
+    repo.delete_branch("foo")
+    assert repo.list_branches() == {"main"}
+
+
+def test_can_delete_tag_on_v1():
+    storage = ic.in_memory_storage()
+    repo = ic.Repository.create(storage, spec_version=1)
+    repo.create_tag("foo", "1CECHNKREP0F1RSTCMT0")
+    assert repo.list_tags() == {"foo"}
+    repo.delete_tag("foo")
+    assert repo.list_tags() == set()

--- a/icechunk/src/refs.rs
+++ b/icechunk/src/refs.rs
@@ -154,8 +154,7 @@ fn branch_key(branch_name: &str) -> RefResult<String> {
 }
 
 #[instrument(skip(storage, storage_settings))]
-#[allow(dead_code)]
-async fn create_tag(
+pub async fn create_tag(
     storage: &(dyn Storage + Send + Sync),
     storage_settings: &storage::Settings,
     name: &str,
@@ -342,8 +341,7 @@ pub async fn list_branches(
 }
 
 #[instrument(skip(storage, storage_settings))]
-#[allow(dead_code)]
-async fn delete_branch(
+pub async fn delete_branch(
     storage: &(dyn Storage + Send + Sync),
     storage_settings: &storage::Settings,
     branch: &str,
@@ -363,8 +361,7 @@ async fn delete_branch(
 }
 
 #[instrument(skip(storage, storage_settings))]
-#[allow(dead_code)]
-async fn delete_tag(
+pub async fn delete_tag(
     storage: &(dyn Storage + Send + Sync),
     storage_settings: &storage::Settings,
     tag: &str,


### PR DESCRIPTION
In this PR we add support for the following operations on spec vesion 1 repos:

- branch creation
- branch delete
- branch reset
- tag creation
- tag delete