### PR TITLE
GC and expiration for V1 repos

### DIFF
--- a/icechunk-python/tests/conftest.py
+++ b/icechunk-python/tests/conftest.py
@@ -52,3 +52,8 @@ def write_chunks_to_minio(
         etags.append(etag)
 
     return etags
+
+
+@pytest.fixture(scope="function", params=[1, 2, None])
+def any_spec_version(request: pytest.FixtureRequest) -> int | None:
+    return request.param

--- a/icechunk-python/tests/test_gc.py
+++ b/icechunk-python/tests/test_gc.py
@@ -9,7 +9,7 @@ import zarr
 from tests.conftest import get_minio_client
 
 
-def mk_repo() -> tuple[str, ic.Repository]:
+def mk_repo(spec_version) -> tuple[str, ic.Repository]:
     prefix = "test-repo__" + str(time.time())
     repo = ic.Repository.create(
         storage=ic.s3_storage(
@@ -23,14 +23,15 @@ def mk_repo() -> tuple[str, ic.Repository]:
             secret_access_key="minio123",
         ),
         config=ic.RepositoryConfig(inline_chunk_threshold_bytes=0),
+        spec_version=spec_version,
     )
     return (prefix, repo)
 
 
 @pytest.mark.filterwarnings("ignore:datetime.datetime.utcnow")
 @pytest.mark.parametrize("use_async", [True, False])
-async def test_expire_and_gc(use_async: bool) -> None:
-    prefix, repo = mk_repo()
+async def test_expire_and_gc(use_async: bool, any_spec_version: int | None) -> None:
+    prefix, repo = mk_repo(any_spec_version)
 
     session = repo.writable_session("main")
     store = session.store

--- a/icechunk-python/tests/test_stateful_repo_ops.py
+++ b/icechunk-python/tests/test_stateful_repo_ops.py
@@ -301,7 +301,11 @@ class VersionControlStateMachine(RuleBasedStateMachine):
 
     @initialize(data=st.data(), target=branches)
     def initialize(self, data: st.DataObject) -> str:
-        self.repo = Repository.create(in_memory_storage())
+        # FIXME: currently this test is IC2 only
+        spec_version = data.draw(
+            st.one_of(st.integers(min_value=2, max_value=2), st.none())
+        )
+        self.repo = Repository.create(in_memory_storage(), spec_version=spec_version)
         self.session = self.repo.writable_session(DEFAULT_BRANCH)
 
         snap = next(iter(self.repo.ancestry(branch=DEFAULT_BRANCH)))

--- a/icechunk-python/tests/test_timetravel.py
+++ b/icechunk-python/tests/test_timetravel.py
@@ -18,20 +18,16 @@ async def async_ancestry(
 
 
 @pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-@pytest.mark.parametrize(
     "using_flush",
     [False, True],
 )
-def test_timetravel(using_flush: bool, spec_version: int | None) -> None:
+def test_timetravel(using_flush: bool, any_spec_version: int | None) -> None:
     config = ic.RepositoryConfig.default()
     config.inline_chunk_threshold_bytes = 1
     repo = ic.Repository.create(
         storage=ic.in_memory_storage(),
         config=config,
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     session = repo.writable_session("main")
@@ -236,17 +232,13 @@ Arrays deleted:
     assert actual == repo.lookup_snapshot(actual.id)
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_branch_reset(spec_version: int | None) -> None:
+async def test_branch_reset(any_spec_version: int | None) -> None:
     config = ic.RepositoryConfig.default()
     config.inline_chunk_threshold_bytes = 1
     repo = ic.Repository.create(
         storage=ic.in_memory_storage(),
         config=config,
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     session = repo.writable_session("main")
@@ -289,14 +281,10 @@ async def test_branch_reset(spec_version: int | None) -> None:
     ) is None
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_tag_delete(spec_version: int | None) -> None:
+async def test_tag_delete(any_spec_version: int | None) -> None:
     repo = ic.Repository.create(
         storage=ic.in_memory_storage(),
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     snap = repo.lookup_branch("main")
@@ -310,14 +298,10 @@ async def test_tag_delete(spec_version: int | None) -> None:
         repo.create_tag("tag", snap)
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_session_with_as_of(spec_version: int | None) -> None:
+async def test_session_with_as_of(any_spec_version: int | None) -> None:
     repo = ic.Repository.create(
         storage=ic.in_memory_storage(),
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     session = repo.writable_session("main")
@@ -350,14 +334,10 @@ async def test_session_with_as_of(spec_version: int | None) -> None:
         assert expected_children == actual_children
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_default_commit_metadata(spec_version: int | None) -> None:
+async def test_default_commit_metadata(any_spec_version: int | None) -> None:
     repo = ic.Repository.create(
         storage=ic.in_memory_storage(),
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     repo.set_default_commit_metadata({"user": "test"})
@@ -370,20 +350,16 @@ async def test_default_commit_metadata(spec_version: int | None) -> None:
 
 
 @pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-@pytest.mark.parametrize(
     "using_flush",
     [False, True],
 )
-async def test_timetravel_async(using_flush: bool, spec_version: int | None) -> None:
+async def test_timetravel_async(using_flush: bool, any_spec_version: int | None) -> None:
     config = ic.RepositoryConfig.default()
     config.inline_chunk_threshold_bytes = 1
     repo = await ic.Repository.create_async(
         storage=ic.in_memory_storage(),
         config=config,
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     session = await repo.writable_session_async("main")
@@ -569,7 +545,7 @@ Arrays deleted:
     actual = next(iter([parent async for parent in repo.async_ancestry(tag="v1.0")]))
     assert actual == await repo.lookup_snapshot_async(actual.id)
 
-    if spec_version is None or spec_version > 1:
+    if any_spec_version is None or any_spec_version > 1:
         ops = [type(op) for op in repo.ops_log()]
         flush_or_commit = (
             [ic.NewCommitUpdate]
@@ -592,17 +568,13 @@ Arrays deleted:
         assert ops == expected
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_branch_reset_async(spec_version: int | None) -> None:
+async def test_branch_reset_async(any_spec_version: int | None) -> None:
     config = ic.RepositoryConfig.default()
     config.inline_chunk_threshold_bytes = 1
     repo = await ic.Repository.create_async(
         storage=ic.in_memory_storage(),
         config=config,
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     session = await repo.writable_session_async("main")
@@ -633,13 +605,9 @@ async def test_branch_reset_async(spec_version: int | None) -> None:
     ) is None
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_tag_delete_async(spec_version: int | None) -> None:
+async def test_tag_delete_async(any_spec_version: int | None) -> None:
     repo = await ic.Repository.create_async(
-        storage=ic.in_memory_storage(), spec_version=spec_version
+        storage=ic.in_memory_storage(), spec_version=any_spec_version
     )
 
     snap = await repo.lookup_branch_async("main")
@@ -653,13 +621,9 @@ async def test_tag_delete_async(spec_version: int | None) -> None:
         await repo.create_tag_async("tag", snap)
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_session_with_as_of_async(spec_version: int | None) -> None:
+async def test_session_with_as_of_async(any_spec_version: int | None) -> None:
     repo = await ic.Repository.create_async(
-        storage=ic.in_memory_storage(), spec_version=spec_version
+        storage=ic.in_memory_storage(), spec_version=any_spec_version
     )
 
     session = await repo.writable_session_async("main")
@@ -692,15 +656,9 @@ async def test_session_with_as_of_async(spec_version: int | None) -> None:
         assert expected_children == actual_children
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [2, None],
-    # FIXME: test on version 1
-    # [1, 2, None],
-)
-async def test_tag_expiration_async(spec_version: int | None) -> None:
+async def test_tag_expiration_async(any_spec_version: int | None) -> None:
     repo = await ic.Repository.create_async(
-        storage=ic.in_memory_storage(), spec_version=spec_version
+        storage=ic.in_memory_storage(), spec_version=any_spec_version
     )
 
     session = await repo.writable_session_async("main")
@@ -729,15 +687,10 @@ async def test_tag_expiration_async(spec_version: int | None) -> None:
     assert await repo.list_tags_async() == set()
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [2, None],
-    # FIXME: test on version 1
-    # [1, 2, None],
-)
-async def test_branch_expiration_async(spec_version: int | None) -> None:
+async def test_branch_expiration_async(any_spec_version: int | None) -> None:
     repo = await ic.Repository.open_or_create_async(
-        storage=ic.in_memory_storage(), create_version=spec_version
+        storage=ic.in_memory_storage(),
+        create_version=any_spec_version,
     )
     session = await repo.writable_session_async("main")
     root = zarr.group(store=session.store, overwrite=True)
@@ -762,21 +715,21 @@ async def test_branch_expiration_async(spec_version: int | None) -> None:
     assert "branch" not in await repo.list_branches_async()
 
     for snap in (a, b):
-        with pytest.raises(ic.IcechunkError):
+        # In IC > 1 expired snapshot can no longer be reached
+        if any_spec_version is None or any_spec_version > 1:
+            with pytest.raises(ic.IcechunkError):
+                await repo.lookup_snapshot_async(snap)
+        else:
             await repo.lookup_snapshot_async(snap)
 
     # should succeed
     await repo.lookup_snapshot_async(c)
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [2, None],
-    # FIXME: test on version 1
-    # [1, 2, None],
-)
-def test_tag_expiration(spec_version: int | None) -> None:
-    repo = ic.Repository.create(storage=ic.in_memory_storage(), spec_version=spec_version)
+def test_tag_expiration(any_spec_version: int | None) -> None:
+    repo = ic.Repository.create(
+        storage=ic.in_memory_storage(), spec_version=any_spec_version
+    )
     session = repo.writable_session("main")
     root = zarr.group(store=session.store, overwrite=True)
     a = session.commit("a")
@@ -803,14 +756,10 @@ def test_tag_expiration(spec_version: int | None) -> None:
     assert repo.list_tags() == set()
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [2, None],
-    # FIXME: test on version 1
-    # [1, 2, None],
-)
-def test_branch_expiration(spec_version: int | None) -> None:
-    repo = ic.Repository.create(storage=ic.in_memory_storage(), spec_version=spec_version)
+def test_branch_expiration(any_spec_version: int | None) -> None:
+    repo = ic.Repository.create(
+        storage=ic.in_memory_storage(), spec_version=any_spec_version
+    )
     session = repo.writable_session("main")
     root = zarr.group(store=session.store, overwrite=True)
     a = session.commit("a")
@@ -834,18 +783,18 @@ def test_branch_expiration(spec_version: int | None) -> None:
     assert "branch" not in repo.list_branches()
 
     for snap in (a, b):
-        with pytest.raises(ic.IcechunkError):
+        # In IC > 1 expired snapshot can no longer be reached
+        if any_spec_version is None or any_spec_version > 1:
+            with pytest.raises(ic.IcechunkError):
+                repo.lookup_snapshot(snap)
+        else:
             repo.lookup_snapshot(snap)
 
     # should succeed
     repo.lookup_snapshot(c)
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_repository_lifecycle_async(spec_version: int | None) -> None:
+async def test_repository_lifecycle_async(any_spec_version: int | None) -> None:
     """Test Repository configuration and lifecycle async methods."""
     storage = ic.in_memory_storage()
 
@@ -863,7 +812,7 @@ async def test_repository_lifecycle_async(spec_version: int | None) -> None:
     repo = await ic.Repository.create_async(
         storage=storage,
         config=custom_config,
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     # Test exists_async with existing repo
@@ -905,16 +854,12 @@ async def test_repository_lifecycle_async(spec_version: int | None) -> None:
     assert not await ic.Repository.exists_async(new_storage)
 
 
-@pytest.mark.parametrize(
-    "spec_version",
-    [1, 2, None],
-)
-async def test_rewrite_manifests_async(spec_version: int | None) -> None:
+async def test_rewrite_manifests_async(any_spec_version: int | None) -> None:
     """Test Repository.rewrite_manifests_async method."""
     repo = await ic.Repository.create_async(
         storage=ic.in_memory_storage(),
         config=ic.RepositoryConfig(inline_chunk_threshold_bytes=0),
-        spec_version=spec_version,
+        spec_version=any_spec_version,
     )
 
     # Create some data to generate manifests
@@ -954,7 +899,7 @@ async def test_rewrite_manifests_async(spec_version: int | None) -> None:
 
     # Verify ancestry after rewrite
     new_ancestry = [snap async for snap in repo.async_ancestry(branch="main")]
-    extra_commits = 1 if spec_version == 1 else 0  # we do amend in IC2+
+    extra_commits = 1 if any_spec_version == 1 else 0  # we do amend in IC2+
     assert len(new_ancestry) == len(initial_ancestry) + extra_commits
     assert new_ancestry[0].message == "rewritten manifests"
 

--- a/icechunk/src/format/snapshot.rs
+++ b/icechunk/src/format/snapshot.rs
@@ -513,6 +513,26 @@ impl Snapshot {
         self.root().manifest_files().iter().map(|mf| mf.into())
     }
 
+    /// Cretase a new `Snapshot` with all the same data as `new_child` but `self` as parent
+    #[deprecated(
+        since = "2.0.0",
+        note = "Shouldn't be necessary after 2.0, only to support Icechunk 1 repos"
+    )]
+    pub fn adopt(&self, new_child: &Snapshot) -> IcechunkResult<Self> {
+        // Rust flatbuffers implementation doesn't allow mutation of scalars, so we need to
+        // create a whole new buffer and write to it in full
+
+        Snapshot::from_iter(
+            Some(new_child.id()),
+            Some(self.id()),
+            new_child.message().clone(),
+            Some(new_child.metadata()?.clone()),
+            new_child.manifest_files().collect(),
+            Some(new_child.flushed_at()?),
+            new_child.iter(),
+        )
+    }
+
     pub fn get_node(&self, path: &Path) -> IcechunkResult<NodeSnapshot> {
         let res = self
             .root()

--- a/icechunk/src/ops/expiration_v1.rs
+++ b/icechunk/src/ops/expiration_v1.rs
@@ -1,0 +1,231 @@
+use std::{collections::HashSet, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use futures::{StreamExt, TryStreamExt, stream};
+use tokio::pin;
+use tracing::instrument;
+
+use crate::{
+    asset_manager::AssetManager,
+    format::SnapshotId,
+    ops::gc::{ExpireResult, ExpiredRefAction, GCError, GCResult},
+    refs::{Ref, delete_branch, delete_tag, list_refs},
+    repository::RepositoryErrorKind,
+};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ExpireRefResult {
+    NothingToDo {
+        ref_is_expired: bool,
+    },
+    Done {
+        released_snapshots: HashSet<SnapshotId>,
+        edited_snapshot: SnapshotId,
+        ref_is_expired: bool,
+    },
+}
+
+/// Expire snapshots older than a threshold.
+///
+/// This only processes snapshots found by navigating `reference`
+/// ancestry. Any other snapshots are not touched.
+///
+/// The operation will edit in place the oldest non-expired snapshot,
+/// changing its parent to be the root of the repo.
+///
+/// For this reasons, it's recommended to invalidate any snapshot
+/// caches before traversing history againg. The cache in the
+/// passed `asset_manager` is invalidated here, but other caches
+/// may exist, for example, in [`Repository`] instances.
+///
+/// Returns the ids of all snapshots considered expired and skipped
+/// from history. Notice that this snapshot are not necessarily
+/// available for garbage collection, they could still be pointed by
+/// ether refs.
+///
+/// See: https://github.com/earth-mover/icechunk/blob/main/design-docs/007-basic-expiration.md
+#[instrument(skip(asset_manager))]
+pub async fn expire_ref(
+    asset_manager: Arc<AssetManager>,
+    reference: &Ref,
+    older_than: DateTime<Utc>,
+) -> GCResult<ExpireRefResult> {
+    #[allow(deprecated)]
+    let snap_id = reference
+        .fetch(asset_manager.storage().as_ref(), asset_manager.storage_settings())
+        .await
+        .map(|ref_data| ref_data.snapshot)?;
+
+    tracing::info!("Starting expiration at ref {}", snap_id);
+
+    // the algorithm works by finding the oldest non expired snap and the root of the repo
+    // we do that in a single pass through the ancestry
+    // we keep two "pointer" the last editable_snap and the root, and we keep
+    // updating them as we navigate the ancestry
+    let mut editable_snap = snap_id.clone();
+    let mut root = snap_id.clone();
+
+    // here we'll populate the results of every expired snapshot
+    let mut released = HashSet::new();
+    #[allow(deprecated)]
+    let ancestry =
+        Arc::clone(&asset_manager).snapshot_ancestry_v1(&snap_id).await?.peekable();
+
+    pin!(ancestry);
+
+    let mut ref_is_expired = false;
+    if let Some(Ok(info)) = ancestry.as_mut().peek().await
+        && info.flushed_at()? < older_than
+    {
+        tracing::debug!(flushed_at = %info.flushed_at()?, "Ref flagged as expired");
+        ref_is_expired = true;
+    }
+
+    while let Some(parent) = ancestry.try_next().await? {
+        let flushed_at = parent.flushed_at()?;
+        let parent_id = parent.id();
+        if parent.flushed_at()? >= older_than {
+            tracing::debug!(snap = %parent_id, flushed_at = %flushed_at, "Processing non expired snapshot");
+            // we are navigating non-expired snaps, last will be kept in editable_snap
+            editable_snap = parent_id;
+        } else {
+            tracing::debug!(snap = %parent_id, flushed_at = %flushed_at, "Processing expired snapshot");
+            released.insert(parent_id.clone());
+            root = parent_id;
+        }
+    }
+
+    // we counted the root as released, but it's not
+    released.remove(&root);
+
+    let editable_snap = asset_manager.fetch_snapshot(&editable_snap).await?;
+
+    #[allow(deprecated)]
+    let old_parent_id = editable_snap.parent_id();
+    if editable_snap.id() == root    // only root can be expired
+        || Some(&root) == old_parent_id.as_ref()
+        // we never found an expirable snap
+        || root == snap_id
+    {
+        // Either the reference is the root, or it is pointing to the root as first parent
+        // Nothing to do
+        tracing::info!("Nothing to expire for this ref");
+        return Ok(ExpireRefResult::NothingToDo { ref_is_expired });
+    }
+
+    let root = asset_manager.fetch_snapshot(&root).await?;
+    // we don't want to create loops, so:
+    // we never edit the root of a tree
+    #[allow(deprecated)]
+    {
+        assert!(editable_snap.parent_id().is_some());
+    }
+    // and, we only set a root as parent
+    #[allow(deprecated)]
+    {
+        assert!(root.parent_id().is_none());
+    }
+
+    tracing::info!(root = %root.id(), editable_snap=%editable_snap.id(), "Expiration needed for this ref");
+
+    // TODO: add properties to the snapshot that tell us it was history edited
+    #[allow(deprecated)]
+    let new_snapshot = Arc::new(root.adopt(&editable_snap)?);
+    asset_manager.write_snapshot(new_snapshot).await?;
+    tracing::info!("Snapshot overwritten");
+
+    Ok(ExpireRefResult::Done {
+        released_snapshots: released,
+        edited_snapshot: editable_snap.id().clone(),
+        ref_is_expired,
+    })
+}
+
+/// Expire all snapshots older than a threshold.
+///
+/// This processes snapshots found by navigating all references in
+/// the repo, tags first, branches leter, both in lexicographical order.
+///
+/// The operation will edit in place the oldest non-expired snapshot,
+/// in every ancestry, changing its parent to be the root of the repo.
+///
+/// For this reasons, it's recommended to invalidate any snapshot
+/// caches before traversing history againg. The cache in the
+/// passed `asset_manager` is invalidated here, but other caches
+/// may exist, for example, in [`Repository`] instances.
+///
+/// Notice that the snapshot returned as released, are not necessarily
+/// available for garbage collection, they could still be pointed by
+/// ether refs.
+///
+/// See: https://github.com/earth-mover/icechunk/blob/main/design-docs/007-basic-expiration.md
+#[instrument(skip(asset_manager))]
+pub async fn expire(
+    asset_manager: Arc<AssetManager>,
+    older_than: DateTime<Utc>,
+    expired_branches: ExpiredRefAction,
+    expired_tags: ExpiredRefAction,
+) -> GCResult<ExpireResult> {
+    #[allow(deprecated)]
+    let storage = asset_manager.storage().as_ref();
+    #[allow(deprecated)]
+    let storage_settings = asset_manager.storage_settings();
+    if !storage.can_write().await? {
+        return Err(GCError::Repository(
+            RepositoryErrorKind::ReadonlyStorage("Cannot expire snapshots".to_string())
+                .into(),
+        ));
+    }
+
+    let all_refs = stream::iter(list_refs(storage, storage_settings).await?);
+    let asset_manager = Arc::clone(&asset_manager.clone());
+
+    all_refs
+        .then(move |r| {
+            let asset_manager = asset_manager.clone();
+            async move {
+                let ref_result = expire_ref(asset_manager, &r, older_than).await?;
+                Ok::<(Ref, ExpireRefResult), GCError>((r, ref_result))
+            }
+        })
+        .try_fold(ExpireResult::default(), |mut result, (r, ref_result)| async move {
+            let ref_is_expired = match ref_result {
+                ExpireRefResult::Done {
+                    released_snapshots,
+                    edited_snapshot,
+                    ref_is_expired,
+                } => {
+                    result.released_snapshots.extend(released_snapshots.into_iter());
+                    result.edited_snapshots.insert(edited_snapshot);
+                    ref_is_expired
+                }
+                ExpireRefResult::NothingToDo { ref_is_expired } => ref_is_expired,
+            };
+            if ref_is_expired {
+                match &r {
+                    Ref::Tag(name) => {
+                        if expired_tags == ExpiredRefAction::Delete {
+                            tracing::info!(name, "Deleting expired tag");
+                            delete_tag(storage, storage_settings, name.as_str())
+                                .await
+                                .map_err(GCError::Ref)?;
+                            result.deleted_refs.insert(r);
+                        }
+                    }
+                    Ref::Branch(name) => {
+                        if expired_branches == ExpiredRefAction::Delete
+                            && name != Ref::DEFAULT_BRANCH
+                        {
+                            tracing::info!(name, "Deleting expired branch");
+                            delete_branch(storage, storage_settings, name.as_str())
+                                .await
+                                .map_err(GCError::Ref)?;
+                            result.deleted_refs.insert(r);
+                        }
+                    }
+                }
+            }
+            Ok(result)
+        })
+        .await
+}

--- a/icechunk/src/ops/mod.rs
+++ b/icechunk/src/ops/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     refs::{RefResult, list_refs},
     repository::{RepositoryError, RepositoryResult},
 };
+pub mod expiration_v1;
 pub mod gc;
 pub mod manifests;
 pub mod stats;


### PR DESCRIPTION
Also in this PR: a pytest fixture to test across spec versions as suggested by @dcherian.

TODO in other PR: make the stateful test work for V1. It currently assumes the IC2 behavior that differs slightly, for example, by making expired snapshots not findable.