### PR TITLE
docs: fix command for editable mode

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -66,7 +66,7 @@ Install `maturin`:
     or build the project in editable mode:
 
     ```bash
-    pip install -e icechunk@.
+    pip install -e .
     ```
 
 === "uv"

--- a/icechunk-python/README.md
+++ b/icechunk-python/README.md
@@ -26,7 +26,7 @@ maturin develop
 or build the project in editable mode:
 
 ```bash
-pip install -e icechunk@.
+pip install -e .
 ```
 
 **Note**: This only makes the python source code editable, the rust will need to be recompiled when it changes


### PR DESCRIPTION
Running `pip install -e icechunk@.` gives:

> ERROR: icechunk@. is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).

The package name does not need to be written.