### PR TITLE
Specify Python version for mypy check in upstream

### DIFF
--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -141,7 +141,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
-          mypy python 2>&1 | tee mypy-output.log
+          mypy --python-version ${{ env.PYTHON_VERSION }} python 2>&1 | tee mypy-output.log
 
       - name: Create or update mypy failure issue
         if: |


### PR DESCRIPTION
numpy 2.4 requries greater python than our min version so need this here

context: https://github.com/earth-mover/icechunk/actions/runs/20047031856/job/57494712220

and https://github.com/earth-mover/icechunk/blob/f3b4b645f34d81784cfa66ec29ca7dbec485f812/icechunk-python/pyproject.toml#L136C1-L136C24

thanks @samantha-earthmover for the find

closes: https://github.com/earth-mover/icechunk/issues/1460