### PR TITLE
Fix icechunk dependency URL in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
         # /// script
         # requires-python = ">=3.11"
         # dependencies = [
-        #   "icechunk",
+        #   "icechunk<2",
         #   "zarr",
         # ]
         #


### PR DESCRIPTION
Addresses @elyall's comment in https://github.com/earth-mover/icechunk/issues/1463#issuecomment-3638375276 by updating the icechunk dependency URL in the bug report template.