### PR TITLE
Fix anonymous parameter not passed to S3Options in storage functions

### DIFF
--- a/icechunk-python/python/icechunk/storage.py
+++ b/icechunk-python/python/icechunk/storage.py
@@ -103,7 +103,7 @@ def s3_store(
         force_path_style=force_path_style,
         network_stream_timeout_seconds=network_stream_timeout_seconds,
         requester_pays=requester_pays,
-        anonymous=anonymous or False,
+        anonymous=anonymous,
     )
     return (
         ObjectStoreConfig.S3Compatible(options)


### PR DESCRIPTION
- [x] Closes #1183 

The anonymous parameter was accepted by s3_storage, s3_store, s3_object_store_storage, tigris_storage, and r2_storage functions but not passed to S3Options, causing __repr__ to show anonymous=false even when anonymous=True was specified.

Now it is showing `anonymous=True` when expected.
