### PR TITLE
Add memory-efficient chunk storage stats via prefix listing

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1810,6 +1810,7 @@ class PyRepository:
         max_compressed_manifest_mem_bytes: int = 512 * 1024 * 1024,
         max_concurrent_manifest_fetches: int = 500,
     ) -> ChunkStorageStats: ...
+    async def chunk_storage_stats_by_prefix_async(self) -> ChunkStorageStats: ...
     def total_chunks_storage(
         self,
         *,

--- a/icechunk-python/python/icechunk/repository.py
+++ b/icechunk-python/python/icechunk/repository.py
@@ -1736,6 +1736,24 @@ class Repository:
         )
         return stats.native_bytes
 
+    async def chunk_storage_stats_by_prefix_async(self) -> ChunkStorageStats:
+        """Calculate storage stats by listing the chunks prefix directly (async version).
+
+        This is a memory-efficient alternative to chunk_storage_stats_async that lists
+        objects in storage directly instead of fetching and parsing manifests. This
+        dramatically reduces memory usage for large repositories.
+
+        Note: This method only calculates native_bytes. Virtual and inline chunk
+        statistics will be zero since they cannot be determined from storage listings alone.
+
+        Returns
+        -------
+        ChunkStorageStats
+            Storage statistics with native_bytes populated from storage listing.
+            virtual_bytes and inlined_bytes will be 0.
+        """
+        return await self._repository.chunk_storage_stats_by_prefix_async()
+
     def inspect_snapshot(self, snapshot_id: str, *, pretty: bool = True) -> str:
         return self._repository.inspect_snapshot(snapshot_id, pretty=pretty)
 

--- a/icechunk-python/tests/test_stats.py
+++ b/icechunk-python/tests/test_stats.py
@@ -75,3 +75,52 @@ def test_chunk_storage_on_filesystem(dir: str) -> None:
         f.stat().st_size for f in (Path(dir) / "chunks").glob("*") if f.is_file()
     )
     assert actual == expected
+
+
+@pytest.mark.filterwarnings("ignore:datetime.datetime.utcnow")
+async def test_chunk_storage_by_prefix_async(any_spec_version: int | None) -> None:
+    """Test the memory-efficient by_prefix async version"""
+
+    repo = await ic.Repository.create_async(
+        storage=ic.in_memory_storage(),
+        config=ic.RepositoryConfig(inline_chunk_threshold_bytes=0),
+        spec_version=any_spec_version,
+    )
+    session = await repo.writable_session_async("main")
+    store = session.store
+
+    group = zarr.group(store=store, overwrite=True)
+    array = group.create_array(
+        "array",
+        shape=(100),
+        chunks=(1,),
+        dtype="i4",
+        compressors=None,
+    )
+
+    array[:] = 42
+    await session.commit_async("commit 1")
+
+    # Test the by_prefix method
+    stats = await repo.chunk_storage_stats_by_prefix_async()
+    assert stats.native_bytes == 100 * 4
+    # Virtual and inline should be 0 since we're only listing storage
+    assert stats.virtual_bytes == 0
+    assert stats.inlined_bytes == 0
+
+
+@pytest.mark.parametrize(
+    "dir", ["./tests/data/test-repo-v2", "./tests/data/test-repo-v1"]
+)
+async def test_chunk_storage_by_prefix_on_filesystem(dir: str) -> None:
+    """Test that by_prefix method gives same results as listing filesystem"""
+    repo = await ic.Repository.open_async(
+        storage=ic.local_filesystem_storage(dir),
+    )
+    stats = await repo.chunk_storage_stats_by_prefix_async()
+    expected = sum(
+        f.stat().st_size for f in (Path(dir) / "chunks").glob("*") if f.is_file()
+    )
+    assert stats.native_bytes == expected
+    assert stats.virtual_bytes == 0
+    assert stats.inlined_bytes == 0


### PR DESCRIPTION
> [!WARNING]
> This entire PR was written by Claude Code. Review accordingly.

## Summary

Adds `chunk_storage_stats_by_prefix_async()` as a memory-efficient alternative to the existing chunk storage stats methods. Instead of fetching and parsing all manifests (which builds massive HashSets of every chunk ID), this just lists objects under the `chunks/` prefix and sums their sizes.

## The Problem

`total_chunks_storage_async()` and `chunk_storage_stats_async()` go ballistic on memory usage for large repos because they:
1. Fetch all manifests from all snapshots
2. Parse every chunk payload in every manifest
3. Build giant HashSets to deduplicate chunks (both `seen_native_chunks` and `seen_virtual_chunks`)

For a repo with millions of chunks, this eats ridiculous amounts of memory.

## The Solution (Such As It Is)

Just list the storage prefix. Native chunks are already stored deduplicated in the `chunks/` directory with their chunk ID as the key, so we can just:
1. Call `storage.list_objects("chunks/")`
2. Sum up the `size_bytes` from the listing
3. Return that as `native_bytes`

Memory usage is now constant regardless of repo size.

## Caveats / Why This Might Be Hot Garbage

1. **Uses deprecated methods**: The implementation uses `storage()` and `storage_settings()` which are marked deprecated. They still work, but this probably isn't the "right" way to access storage in the future.

2. **Only counts native_bytes**: Virtual and inline chunks can't be calculated from storage listings, so `virtual_bytes` and `inlined_bytes` are always 0. This is probably fine since the old `total_chunks_storage_async()` only returned native_bytes anyway, but it's less complete than `chunk_storage_stats_async()`.

3. **Untested on huge repos**: This has only been tested with the existing small test repos. It *should* work great on massive repos, but I haven't actually verified it doesn't blow up.

4. **May not handle all storage backends correctly**: Different storage implementations might behave differently when listing prefixes. Should be fine, but who knows.

5. **The whole approach feels hacky**: Instead of properly optimizing the manifest parsing path (maybe streaming, maybe better data structures), this just goes around it entirely. It works, but it's a bit of a cop-out.

## API

```python
# New memory-efficient method
stats = await repo.chunk_storage_stats_by_prefix_async()
print(stats.native_bytes)  # Works!
print(stats.virtual_bytes)  # Always 0
print(stats.inlined_bytes)  # Always 0
```

## Testing

Added two new test cases:
- Basic test with in-memory storage
- Test against existing filesystem repos to verify it matches the old implementation

Both pass. Compiles cleanly with just the expected deprecation warnings.

## Should This Be Merged?

¯\_(ツ)_/¯ 

It solves the immediate memory problem in a simple way. Whether it's the "right" solution long-term is debatable. Would love feedback from maintainers on whether this approach is acceptable or if you'd prefer something more sophisticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)