### PR TITLE
TEST: Add stateful move

### DIFF
--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -294,7 +294,6 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         assume(array.size > 0)
         super().add_array(data, name, array_and_chunks)
 
-    @rule(data=st.data())
     def _compare_list_dir(
         self, model: ModelStore, store: ic.IcechunkStore, paths: set[str]
     ) -> None:


### PR DESCRIPTION
Builds on top of https://github.com/earth-mover/icechunk/pull/1602 to allow using preconditions appropriately. 


Beyond adding the move functionality I made two important changes:

1. check_list_dir

now will check the entire tree instead of a random directory
is used as an invariant

I think this is pretty low cost so wasn't worried about calling it more frequently.


2. added a rule to all inherited methods

Because we can't write to a store during a rearrange session we have to preclude several of the inherited methods from running during a re-arrange session. as far as I can tell this requires overriding them to add our pre-condtion. and also retyping the pre-conditions from the original method.


part of https://github.com/earth-mover/icechunk/issues/1513
