### PR TITLE
Update contributing.md with duplicate mention of minio docker setup

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -269,6 +269,10 @@ just compile-tests
 
 #### Testing
 
+The full Python test suite depends on S3 and Azure compatible object stores.
+
+They can be run from the root of the repo with `docker compose up` (`ctrl-c` then `docker compose down` once done to clean up.).
+
 ```bash
 # Run all tests
 just test


### PR DESCRIPTION
I missed the minio docker compose instructions because I clicked right into the Rust workflow. I think they are slim enough to copy, but can also move them to a separate section and reference them in Python and Rust testing sections if that