### PR TITLE
fix: link to Icechunk Python documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ that enhance performance, collaboration, and safety in a cloud-computing context
 - This page: a general overview of the project's goals and components.
 - [Icechunk Launch Blog Post](https://earthmover.io/blog/icechunk)
 - [Frequently Asked Questions](https://icechunk.io/en/latest/faq/)
-- Documentation for [Icechunk Python](https://icechunk.io/en/latest/icechunk-python), the main user-facing
+- Documentation for [Icechunk Python](https://icechunk.io/en/latest/), the main user-facing
   library
 - Documentation for the [Icechunk Rust Crate](https://icechunk.io/en/latest/icechunk-rust)
 - The [Contributor Guide](https://icechunk.io/en/latest/contributing)


### PR DESCRIPTION
The current link for the Python docs in the README (https://icechunk.io/en/latest/icechunk-python) leads to 404. 

My understanding is that https://icechunk.io/en/latest/ is the link to the general documentation which focuses on the user-facing Python documentation, so that felt like the most correct URL(?).

