### PR TITLE
Fix redirect test failure (only happening on macos)

### DIFF
--- a/icechunk-python/tests/test_redirect_storage.py
+++ b/icechunk-python/tests/test_redirect_storage.py
@@ -49,7 +49,7 @@ def test_era5_with_redirect() -> None:
     try:
         port = find_free_port()
         (server, thread) = run_server(port)
-        storage = ic.redirect_storage(f"http://localhost:{port}")
+        storage = ic.redirect_storage(f"http://127.0.0.1:{port}")
         repo = ic.Repository.open(storage=storage)
 
         # redirect server is no longer needed at this point

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -860,7 +860,7 @@ pub async fn test_http_storage() -> Result<(), Box<dyn std::error::Error>> {
 
     let join = tokio::task::spawn(server.run());
 
-    let url = format!("http://localhost:{port}");
+    let url = format!("http://127.0.0.1:{port}");
     let storage1 = new_http_storage(url.as_str(), None)?;
     let storage2 = new_http_storage(url.as_str(), None)?;
     for storage in [storage1, storage2] {
@@ -932,7 +932,7 @@ pub async fn test_redirect_storage() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let join = tokio::task::spawn(server.run());
-    let url = format!("http://localhost:{port}");
+    let url = format!("http://127.0.0.1:{port}");
     let storage = new_redirect_storage(url.as_str())?;
     let mut data = Vec::with_capacity(1_024);
     let settings = storage.default_settings().await?;


### PR DESCRIPTION
When running the local rust tests I was getting: 
```
ailures:

---- test_redirect_storage stdout ----
Error: ICError { kind: BadRedirect("Redirect Storage response must be a redirect, no location header detected"), context: SpanTrace [] }


failures:
    test_redirect_storage

test result: FAILED. 15 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.32s

error: test failed, to rerun pass `-p icechunk --test test_storage`
error: Recipe `test` failed on line 6 with exit code 101
```
Thanks to the suggestion of @li-em and some clauding I was able to fix this by replacing all occurences of `localhost` to `127.0.0.1` (apparently macos defaults to `::1`). 