### PR TITLE
Messing around with macos tests

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   rust:
     name: Rust CI
-    timeout-minutes: 35
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -126,10 +126,12 @@ jobs:
           just test
 
       - name: Run doc tests
+        if: matrix.os != 'macos-latest'
         run: |
           just doctest
 
       - name: Run examples
+        if: matrix.os != 'macos-latest'
         run: |
           just run-all-examples
 

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   rust:
     name: Rust CI
-    timeout-minutes: 30
+    timeout-minutes: 35
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -64,10 +64,38 @@ jobs:
         if: matrix.os != 'macos-latest'
         run: docker version
 
+      - name: Install Just (non-macos)
+        if: "!contains(matrix.os, 'macos')"
+        run: sudo snap install --edge --classic just
+
+      - name: Install Just (macos)
+        if: "contains(matrix.os, 'macos')"
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_UPGRADE: 1
+        run: brew install just
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update --no-self-update ${{ env.RUST_CHANNEL }}
+          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src clippy
+          rustup default ${{ env.RUST_CHANNEL }}
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          # workspaces: "rust -> target"
+          key: ${{ env.RUST_CHANNEL }}
+
       - name: Stand up docker services
         if: matrix.os != 'macos-latest'
         run: |
           docker compose up -d
+
+      - name: Compile tests (while containers start)
+        if: matrix.os != 'macos-latest'
+        run: |
+          just compile-tests "--locked"
 
       - name: Wait for containers to be ready
         if: matrix.os != 'macos-latest'
@@ -85,25 +113,6 @@ jobs:
               fi
               sleep 1
           done
-
-      - name: Install Just (non-macos)
-        if: "!contains(matrix.os, 'macos')"
-        run: sudo snap install --edge --classic just
-
-      - name: Install Just (macos)
-        run: cargo install just
-
-      - name: Install Rust toolchain
-        run: |
-          rustup update --no-self-update ${{ env.RUST_CHANNEL }}
-          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src clippy
-          rustup default ${{ env.RUST_CHANNEL }}
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          # workspaces: "rust -> target"
-          key: ${{ env.RUST_CHANNEL }}
 
       - name: Run tests with Docker services
         if: matrix.os != 'macos-latest'
@@ -125,7 +134,6 @@ jobs:
           TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}
 
         run: |
-          just compile-tests "--locked"
           just test
 
       - name: Run doc tests

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   rust:
     name: Rust CI
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set up Docker on macOS
         # docker installation not supported with most Mx Apple Chips
-        #(Might change once runners use M3: uses: douglascamata/setup-docker-macos-action@v1.0.1
+        #(Might change once runners use M3: https://github.com/douglascamata/setup-docker-macos-action#arm64-processors-m-series-used-on-macos-15-images-and-beyond-are-unsupported
         if: matrix.os == 'macos-15-intel'
         uses: douglascamata/setup-docker-macos-action@v1.0.1
         with:

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -86,9 +86,12 @@ jobs:
               sleep 1
           done
 
-      - name: Install Just
-        if: matrix.os != 'macos-latest'
+      - name: Install Just (non-macos)
+        if: "!contains(matrix.os, 'macos')"
         run: sudo snap install --edge --classic just
+
+      - name: Install Just (macos)
+        run: cargo install just
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -51,12 +51,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Stand up docker services
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           docker compose up -d
 
       - name: Wait for containers to be ready
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           for _ in {1..30}; do
               if curl --silent --fail http://localhost:9000/minio/health/live; then
@@ -73,7 +71,6 @@ jobs:
           done
 
       - name: Install Just
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: sudo snap install --edge --classic just
 
       - name: Install Rust toolchain
@@ -89,7 +86,6 @@ jobs:
           key: ${{ env.RUST_CHANNEL }}
 
       - name: Run tests with Docker services
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         env:
           RUST_LOG: icechunk=trace
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
@@ -112,19 +108,12 @@ jobs:
           just test
 
       - name: Run doc tests
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           just doctest
 
       - name: Run examples
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           just run-all-examples
-
-      - name: Run unit tests only
-        if: matrix.os != 'ubuntu-latest' && matrix.os != 'ubuntu-24.04-arm'
-        run: |
-          cargo test --lib
 
       - name: Run integration tests against object stores
         if: github.event_name == 'cron'

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -51,20 +51,26 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker on macOS
-        if: contains(matrix.os, 'macos')
-        uses: douglascamata/setup-docker-macos-action@v1 # Use the latest version tag
+        # docker installation not supported with most Mx Apple Chips
+        #(Might change once runners use M3: uses: douglascamata/setup-docker-macos-action@v1.0.1
+        if: matrix.os == 'macos-15-intel'
+        uses: douglascamata/setup-docker-macos-action@v1.0.1
         with:
-          colima-version: 'latest'
-          docker-version: 'latest'
+          lima: v1.2.1
+          colima: v0.9.1
+          colima-network-address: false
 
       - name: Verify Docker installation
+        if: matrix.os != 'macos-latest'
         run: docker version
 
       - name: Stand up docker services
+        if: matrix.os != 'macos-latest'
         run: |
           docker compose up -d
 
       - name: Wait for containers to be ready
+        if: matrix.os != 'macos-latest'
         run: |
           for _ in {1..30}; do
               if curl --silent --fail http://localhost:9000/minio/health/live; then
@@ -81,6 +87,7 @@ jobs:
           done
 
       - name: Install Just
+        if: matrix.os != 'macos-latest'
         run: sudo snap install --edge --classic just
 
       - name: Install Rust toolchain
@@ -96,6 +103,7 @@ jobs:
           key: ${{ env.RUST_CHANNEL }}
 
       - name: Run tests with Docker services
+        if: matrix.os != 'macos-latest'
         env:
           RUST_LOG: icechunk=trace
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
@@ -145,3 +153,8 @@ jobs:
 
         run: |
           cargo test --all --all-targets -- --ignored
+
+      - name: Run unit tests only
+        if: matrix.os == 'macos-latest'
+        run: |
+          cargo test --lib

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -50,6 +50,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Set up Docker on macOS
+        if: contains(matrix.os, 'macos')
+        uses: douglascamata/setup-docker-macos-action@v1 # Use the latest version tag
+        with:
+          colima-version: 'latest'
+          docker-version: 'latest'
+
+      - name: Verify Docker installation
+        run: docker version
+
       - name: Stand up docker services
         run: |
           docker compose up -d


### PR DESCRIPTION
This is an attempt to expand the full testing (not just unit tests) to macos runners.

Apparently it is very difficult (if not impossible?) to run docker within (already virtualized?) runners (see [here](https://github.com/douglascamata/setup-docker-macos-action#arm64-processors-m-series-used-on-macos-15-images-and-beyond-are-unsupported)). 

My initial hope was to catch #1654 here before implementing a fix, but it seems like this is a behavior that was either changed after macos 15 or is somehow unique to my machine.

Either way I thought it could be good to test fully against at least one macos version?

The remaining question is if its worth carrying these tests as they are significantly slower (still working on that). 

**Positive side effect of this endeavour**: With claudes help I was able to reorganize the order and start compiling the tests while the docker setup finishes in parallel, which saves ~2 min on each test:

## Before
<img width="271" height="84" alt="image" src="https://github.com/user-attachments/assets/cfda4278-fc52-4ac6-8a1e-991f9420417b" />
<img width="264" height="82" alt="image" src="https://github.com/user-attachments/assets/02376cee-1994-4fed-b4d9-c7657e51652f" />

## After
<img width="248" height="88" alt="image" src="https://github.com/user-attachments/assets/f952800e-2016-4b01-8bc4-7825688168c3" />
<img width="245" height="61" alt="image" src="https://github.com/user-attachments/assets/a4a34192-2db8-4f2d-90af-091c37cfb169" />

