### PR TITLE
Initialize spec_version when copying a ModelStore

### DIFF
--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -54,6 +54,7 @@ class ModelStore(MemoryStore):
     async def copy(self) -> "ModelStore":
         """Create a copy of this store."""
         new_store = ModelStore()
+        new_store.spec_version = self.spec_version
         async for key in self.list_prefix(""):
             data = await self.get(key, prototype=PROTOTYPE)
             if data is not None:


### PR DESCRIPTION
Hypothesis tests started failing because `ModelStore` instances where missing the `spec_version` attribute. This was because it was not being set when copying an existing instance.