### PR TITLE
remove (re)opens in actor switching

### DIFF
--- a/icechunk-python/python/icechunk/testing/multi_actor.py
+++ b/icechunk-python/python/icechunk/testing/multi_actor.py
@@ -1,0 +1,102 @@
+"""Multi-actor coordinator for stateful tests.
+
+Manages multiple actors sharing a repository. Each actor has its own
+IcechunkModel. The coordinator swaps the active model and computes
+the blocked set (paths other actors have modified).
+
+The test class's self.model is always a plain IcechunkModel — the
+coordinator just tracks which one is active and what's blocked.
+The committed baseline lives on the test (self.committed), not here.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from icechunk.testing.stateful_models import IcechunkModel
+
+
+class MultiActorCoordinator:
+    """Coordinates multiple actors sharing a repository.
+
+    Holds the actor dict. Computes the blocked set from other actors'
+    changes. The test class owns self.model and self.committed directly.
+    """
+
+    @staticmethod
+    def _has_blocked_ancestor(path: str, blocked: set[str]) -> bool:
+        """True if path or any ancestor of path is in the blocked set."""
+        pp = PurePosixPath(path)
+        return any(pp.is_relative_to(p) for p in blocked)
+
+    @staticmethod
+    def _has_blocked_relative(path: str, blocked: set[str]) -> bool:
+        """True if any blocked path is an ancestor, descendant, or equal."""
+        pp = PurePosixPath(path)
+        return any(
+            pp.is_relative_to(p) or PurePosixPath(p).is_relative_to(path) for p in blocked
+        )
+
+    def __init__(self) -> None:
+        self.current_actor: str = ""
+        self._actors: dict[str, IcechunkModel] = {}
+        self.blocked: set[str] = set()
+
+    @property
+    def current(self) -> IcechunkModel:
+        """The current actor's model."""
+        return self._actors[self.current_actor]
+
+    @current.setter
+    def current(self, model: IcechunkModel) -> None:
+        self._actors[self.current_actor] = model
+
+    def recompute_blocked(self, committed: IcechunkModel | None) -> None:
+        """Recompute the blocked set for the current actor.
+
+        The blocked set is:
+        1. Other actors' uncommitted changes (structural + data)
+        2. Main drift: paths that changed on committed since this actor's baseline
+        """
+        actor = self.current_actor
+        result: set[str] = set()
+
+        for name, state in self._actors.items():
+            if name != actor:
+                result |= state.changes()
+
+        current = self._actors.get(actor)
+        if current is not None and committed is not None:
+            committed_nodes = frozenset(committed.all_arrays) | frozenset(
+                committed.all_groups
+            )
+            result |= committed_nodes ^ current.baseline
+
+        self.blocked = result
+
+    # ── Actor management ─────────────────────────────────────────────
+
+    def switch(self, actor: str, committed: IcechunkModel | None) -> None:
+        """Switch to an existing actor and recompute the blocked set."""
+        self.current_actor = actor
+        self.recompute_blocked(committed)
+
+    def init_actor(
+        self, committed: IcechunkModel | None, bootstrap: str = "default"
+    ) -> None:
+        """Promote the bootstrap model to the current actor's model."""
+        self._actors[self.current_actor] = self._actors.pop(bootstrap)
+        if committed is not None:
+            self.current.sync_baseline(committed)
+        self.recompute_blocked(committed)
+
+    def other_actors_clean(self) -> bool:
+        """True if no other actor has uncommitted changes."""
+        return all(
+            not state.changes()
+            for name, state in self._actors.items()
+            if name != self.current_actor
+        )
+
+    def can_add(self, path: str) -> bool:
+        return not self._has_blocked_ancestor(path, self.blocked)

--- a/icechunk-python/python/icechunk/testing/stateful_models.py
+++ b/icechunk-python/python/icechunk/testing/stateful_models.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from zarr.core.buffer import default_buffer_prototype
+from zarr.storage import MemoryStore
+
+PROTOTYPE = default_buffer_prototype()
+
+
+class IcechunkModel(MemoryStore):
+    """MemoryStore with move, copy, and lifecycle methods for testing.
+
+    Tracks all_arrays/all_groups alongside store data so that copy()
+    preserves them.
+    """
+
+    spec_version: int
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.all_arrays: set[str] = set()
+        self.all_groups: set[str] = set()
+        self.baseline: frozenset[str] = frozenset()
+        self.claims: set[str] = set()
+
+    @classmethod
+    def from_store(cls, store: MemoryStore) -> IcechunkModel:
+        """Promote a plain MemoryStore to an IcechunkModel."""
+        model = cls()
+        model._store_dict = store._store_dict
+        return model
+
+    def _claim_node(self, key: str) -> None:
+        """Record which array or group a key belongs to."""
+        for array in self.all_arrays:
+            if key.startswith(array + "/"):
+                self.claims.add(array)
+                return
+        for group in self.all_groups:
+            if key.startswith(group + "/"):
+                self.claims.add(group)
+                return
+
+    async def set(
+        self, key: str, value: object, byte_range: tuple[int, int] | None = None
+    ) -> None:
+        self._claim_node(key)
+        await super().set(key, value, byte_range)
+
+    async def delete(self, key: str) -> None:
+        self._claim_node(key)
+        await super().delete(key)
+
+    async def move(self, source: str, dest: str) -> None:
+        """Move all keys from source to dest.
+
+        Store keys always have form "node/zarr.json" or "node/c/...", never bare "node".
+        """
+        all_keys = [k async for k in self.list_prefix("")]
+        keys_to_move = [k for k in all_keys if k.startswith(source + "/")]
+        for old_key in keys_to_move:
+            new_key = dest + old_key[len(source) :]
+            data = await self.get(old_key, prototype=PROTOTYPE)
+            if data is not None:
+                await self.set(new_key, data)
+                await self.delete(old_key)
+
+    async def copy(self) -> IcechunkModel:
+        """Create a copy of this store (data + arrays + groups)."""
+        new_store = IcechunkModel()
+        new_store.spec_version = self.spec_version
+        new_store.all_arrays = self.all_arrays.copy()
+        new_store.all_groups = self.all_groups.copy()
+        async for key in self.list_prefix(""):
+            data = await self.get(key, prototype=PROTOTYPE)
+            if data is not None:
+                await new_store.set(key, data)
+        return new_store
+
+    # things for tracking changes relative to committed baseline
+    @property
+    def nodes(self) -> frozenset[str]:
+        """Current set of all node paths in this model."""
+        return frozenset(self.all_arrays) | frozenset(self.all_groups)
+
+    def changes(self) -> set[str]:
+        """Paths modified since last sync: structural diff + data claims."""
+        return set(self.claims) | (self.nodes ^ self.baseline)
+
+    def sync_baseline(self, committed) -> None:
+        """Record committed state as this actor's baseline."""
+        self.baseline = frozenset(committed.all_arrays) | frozenset(committed.all_groups)
+
+    # ── Lifecycle methods ─────────────────────────────────────────────
+
+    async def commit(self) -> IcechunkModel:
+        """Snapshot this model as the new committed baseline.
+
+        Returns the committed copy; caller stores it as shared state.
+        """
+        committed = await self.copy()
+        self.claims.clear()
+        self.sync_baseline(committed)
+        return committed
+
+    async def rebase(self, committed: IcechunkModel) -> IcechunkModel:
+        """Merge committed baseline with local changes.
+
+        Returns a new model with the merge result; caller swaps it in.
+        """
+        merged = await committed.copy()
+        my_changes = self.changes()
+
+        merged.all_arrays = (committed.all_arrays - my_changes) | (
+            my_changes & self.all_arrays
+        )
+        merged.all_groups = (committed.all_groups - my_changes) | (
+            my_changes & self.all_groups
+        )
+
+        for path in my_changes:
+            keys_to_delete = [k async for k in merged.list_prefix(path + "/")]
+            for key in keys_to_delete:
+                await merged.delete(key)
+            async for key in self.list_prefix(path + "/"):
+                data = await self.get(key, prototype=PROTOTYPE)
+                if data is not None:
+                    await merged.set(key, data)
+
+        merged.sync_baseline(committed)
+        return merged
+
+    async def new_session(self, committed: IcechunkModel) -> IcechunkModel:
+        """Reset to the committed baseline, discarding local changes."""
+        fresh = await committed.copy()
+        fresh.claims.clear()
+        fresh.sync_baseline(committed)
+        return fresh
+
+    async def rewrite_manifests(self, committed: IcechunkModel) -> IcechunkModel:
+        """Reset to committed baseline (rewrite_manifests doesn't change data)."""
+        fresh = await committed.copy()
+        fresh.claims.clear()
+        fresh.sync_baseline(committed)
+        return fresh

--- a/icechunk-python/tests/test_stateful_compat.py
+++ b/icechunk-python/tests/test_stateful_compat.py
@@ -12,9 +12,11 @@ Skipped entirely if icechunk_v1 is not installed.
 """
 
 import tempfile
+import types
+from dataclasses import dataclass
+from typing import Any
 
 import pytest
-from packaging.version import Version
 
 import icechunk as ic
 
@@ -34,16 +36,55 @@ import tests.test_stateful_repo_ops as repo_ops_mod
 repo_ops_mod.IcechunkError = (ic.IcechunkError, ic_v1.IcechunkError)  # type: ignore[assignment,attr-defined]
 
 
+from collections.abc import Iterable
+
 import hypothesis.strategies as st
 from hypothesis import note, settings
 from hypothesis.stateful import initialize, precondition, rule, run_state_machine_as_test
 
+from icechunk.testing.multi_actor import MultiActorCoordinator
+from icechunk.testing.stateful_models import IcechunkModel
 from tests.test_stateful_repo_ops import (
     VersionControlStateMachine,
 )
 from tests.test_zarr.test_stateful import (
     ModifiedZarrHierarchyStateMachine,
 )
+
+
+class _ProxySet(set[str]):
+    """Narrowed view that delegates mutations to a backing set.
+
+    Iterates/contains only narrowed items. Mutations (add/remove/etc.)
+    are forwarded to the backing set so the model stays in sync.
+    """
+
+    def __init__(self, backing: set[str], narrowed: Iterable[str]):
+        super().__init__(narrowed)
+        self._backing = backing
+
+    def add(self, item: str) -> None:
+        super().add(item)
+        self._backing.add(item)
+
+    def remove(self, item: str) -> None:
+        super().remove(item)
+        self._backing.remove(item)
+
+    def discard(self, item: str) -> None:
+        if item in self:
+            super().discard(item)
+        self._backing.discard(item)
+
+
+@dataclass
+class Actor:
+    """Per-actor state for cross-version tests."""
+
+    module: types.ModuleType  # ic or ic_v1
+    store: Any = None  # ic.IcechunkStore | ic_v1.IcechunkStore
+    repo: Any = None  # ic.Repository | ic_v1.Repository
+    storage: Any = None  # ic.Storage | ic_v1.Storage
 
 
 class CrossVersionVersionControlStateMachine(VersionControlStateMachine):
@@ -53,10 +94,10 @@ class CrossVersionVersionControlStateMachine(VersionControlStateMachine):
     """
 
     def __init__(self) -> None:
-        self.actors = {"v2": ic.Repository, "v1": ic_v1.Repository}
-        self.actor_modules = {"v2": ic, "v1": ic_v1}
+        self._actors = {"v2": Actor(module=ic), "v1": Actor(module=ic_v1)}
         self._storage_path = tempfile.mkdtemp()
-        super().__init__(actor=None)
+        self.actor_name: str = ""
+        super().__init__()
 
     # Disabled: v1 actor doesn't support spec version upgrade.
     @rule()
@@ -72,21 +113,30 @@ class CrossVersionVersionControlStateMachine(VersionControlStateMachine):
         target=VersionControlStateMachine.branches,
     )
     def initialize(self, data: st.DataObject) -> str:
-        choice = data.draw(st.sampled_from(list(self.actors.keys())))
+        choice = data.draw(st.sampled_from(list(self._actors.keys())))
         note(f"initializing with actor {choice!r}")
-        self.actor = self.actors[choice]
-        self.ic = self.actor_modules[choice]
-        return super().initialize(data, spec_version=1)  # type: ignore[return-value]
+        self.actor_name = choice
+        self.ic = self._actors[choice].module
+        result = super().initialize(data, spec_version=1)
+        self._actors[choice].repo = self.repo
+        return result  # type: ignore[return-value]
 
     @rule(data=st.data())
     def switch_actor(self, data: st.DataObject) -> None:
         """Switch to a randomly chosen actor and reopen the repository."""
-        choice = data.draw(st.sampled_from(tuple(self.actors)))
+        choice = data.draw(st.sampled_from(tuple(self._actors)))
+        if choice == self.actor_name:
+            return
+
         note(f"switching to actor {choice!r}")
-        self.actor = self.actors[choice]
-        self.ic = self.actor_modules[choice]
+        self.actor_name = choice
+        actor = self._actors[choice]
+        self.ic = actor.module
         self.storage = self._make_storage()
-        super().reopen_repository(data)
+
+        if actor.repo is None:
+            actor.repo = self.ic.Repository.open(self.storage)
+        self.repo = actor.repo
 
 
 def test_two_actors_cross_version() -> None:
@@ -99,63 +149,176 @@ class CrossVersionTwoActorZarrHierarchyStateMachine(ModifiedZarrHierarchyStateMa
     """Two-actor Zarr hierarchy test: one actor is v2, the other is v1.
 
     Uses filesystem storage since v1 and v2 packages can't share storage objects.
+    Allows overlapping uncommitted sessions — actors hold uncommitted writes
+    simultaneously with array-level claim tracking to ensure disjoint modifications.
+
+    self.model is always a plain IcechunkModel (the current actor's).
+    The coordinator just swaps which model is active and computes blocked sets.
     """
 
     def __init__(self, tmpdir: str) -> None:
-        # Pass v2 storage to parent
+        self._actors = {"v2": Actor(module=ic), "v1": Actor(module=ic_v1)}
+        self._tmpdir = tmpdir
+        self.actor_name: str = "default"
+        self._committed_baseline = None
+        self._coordinator = MultiActorCoordinator()
+        self._coordinator.current_actor = self.actor_name
+
+        # Pass v2 storage to parent — model/committed properties auto-sync coordinator
         storage = ic.local_filesystem_storage(tmpdir)
         super().__init__(storage)
 
-        # Set up per-actor storage/module objects for cross-version testing
-        self.actors = {"v2": ic.Repository, "v1": ic_v1.Repository}
-        self._tmpdir = tmpdir
-        self.actor_storage_objects = {
-            "v2": ic.local_filesystem_storage(tmpdir),
-            "v1": ic_v1.local_filesystem_storage(tmpdir),
+    def _make_storage(self) -> Any:
+        """Create a fresh storage object for the current actor's module."""
+        return self.ic.local_filesystem_storage(self._tmpdir)
+
+    # ── model/committed properties: auto-sync coordinator ──────────────
+
+    @property
+    def model(self) -> Any:
+        return self._coordinator.current
+
+    @model.setter
+    def model(self, value: Any) -> None:
+        if not isinstance(value, IcechunkModel):
+            value = IcechunkModel.from_store(value)
+        self._coordinator.current = value
+
+    @property
+    def committed(self) -> Any:
+        return self._committed_baseline
+
+    @committed.setter
+    def committed(self, value: Any) -> None:
+        self._committed_baseline = value
+        self._coordinator.recompute_blocked(value)
+
+    # ── narrowed properties ──────────────────────────────────────────────
+
+    @property
+    def all_arrays(self) -> set[str]:
+        blocked = self._coordinator.blocked
+        backing = self.model.all_arrays
+        narrowed = {
+            a
+            for a in backing
+            if not MultiActorCoordinator._has_blocked_ancestor(a, blocked)
         }
-        self.actor_modules = {"v2": ic, "v1": ic_v1}
+        return _ProxySet(backing, narrowed)
+
+    @all_arrays.setter
+    def all_arrays(self, value: set[str]) -> None:
+        hidden = self.model.all_arrays - self.all_arrays
+        self.model.all_arrays = set(value) | hidden
+
+    @property
+    def all_groups(self) -> set[str]:
+        blocked = self._coordinator.blocked
+        backing = self.model.all_groups
+        narrowed = {
+            g
+            for g in backing - {"", "/"}
+            if not MultiActorCoordinator._has_blocked_relative(g, blocked)
+        }
+        return _ProxySet(backing, narrowed)
+
+    @all_groups.setter
+    def all_groups(self, value: set[str]) -> None:
+        hidden = self.model.all_groups - self.all_groups
+        self.model.all_groups = set(value) | hidden
+
+    # ── can_add override ─────────────────────────────────────────────────
+
+    def can_add(self, path: str) -> bool:
+        return self._coordinator.can_add(path) and super().can_add(path)
+
+    # ── init / switch ────────────────────────────────────────────────────
+
+    @initialize(spec_version=st.just(1), data=st.data())
+    def init_store(self, spec_version: int, data: st.DataObject) -> None:
+        """Override to draw actor and create with v1 compatibility."""
+        actor_name = data.draw(st.sampled_from(list(self._actors.keys())))
+        actor = self._actors[actor_name]
+        self.ic = actor.module
+        self.storage = self._make_storage()
+        super().init_store(spec_version=spec_version)
+
+        # Promote bootstrap model to the drawn actor
+        self.actor_name = actor_name
+        self._coordinator.current_actor = actor_name
+        self._coordinator.init_actor(self.committed, bootstrap="default")
+        actor.store = self.store
+        actor.repo = self.repo
+        actor.storage = self.storage
+
+        # Commit root group so both actors see it
+        self.commit_with_check(data)
+
+    @rule(data=st.data())
+    def switch_actor(self, data: st.DataObject) -> None:
+        """Switch to another actor, preserving uncommitted state."""
+        actor_name = data.draw(
+            st.sampled_from([a for a in self._actors if a != self.actor_name])
+        )
+
+        note(f"switching to actor {actor_name!r}")
+
+        # Stash current state
+        prev = self._actors[self.actor_name]
+        prev.store = self.store
+        prev.repo = self.repo
+        prev.storage = self.storage
+
+        # Switch identity
+        self.actor_name = actor_name
+        actor = self._actors[actor_name]
+        self.ic = actor.module
+        self._coordinator.switch(actor_name, self.committed)
+
+        if actor.store is None:
+            # New actor: create from committed baseline
+            self.storage = self._make_storage()
+            self.repo = self.ic.Repository.open(self.storage)
+            self.store = self.repo.writable_session("main").store
+            assert self.committed is not None
+            new_model = self._sync(self.committed.copy())
+            new_model.sync_baseline(self.committed)
+            self._coordinator.current = new_model
+            actor.store = self.store
+            actor.repo = self.repo
+            actor.storage = self.storage
+            self._coordinator.recompute_blocked(self.committed)
+        else:
+            self.store = actor.store
+            self.repo = actor.repo
+            self.storage = actor.storage
+
+    # ── precondition overrides ─────────────────────────────────────────
+
+    # rewrite_manifests creates a commit on the branch. If another actor has
+    # uncommitted changes, their next commit will conflict — ConflictDetector
+    # can't resolve rewrite_manifests conflicts since it touched the same
+    # manifests, even though no data changed.
+    @precondition(lambda self: not self.store.session.has_uncommitted_changes)
+    @precondition(lambda self: self._coordinator.other_actors_clean())
+    @rule(data=st.data())
+    def rewrite_manifests(self, data: st.DataObject) -> None:
+        super().rewrite_manifests(data)
+
+    # ── disabled rules ───────────────────────────────────────────────────
+
+    # Disabled: clear() wipes the entire store, which isn't a realistic multi-actor
+    # operation. Single-actor test_zarr_hierarchy still covers store.clear().
+    @precondition(lambda self: False)
+    @rule()
+    def clear(self) -> None:
+        pass
 
     # Disabled: v1 actor doesn't support spec version upgrade.
     @rule()
     @precondition(lambda self: False)
     def upgrade_spec_version(self) -> None:
         pass
-
-    @initialize(spec_version=st.just(1), data=st.data())
-    def init_store(self, spec_version: int, data: st.DataObject) -> None:
-        """Override to draw actor and create with v1 compatibility."""
-
-        # Draw an actor and set self.actor / self.ic / self.storage
-        actor_name = data.draw(st.sampled_from(list(self.actors.keys())))
-        self.actor = self.actors[actor_name]
-        self.ic = self.actor_modules[actor_name]
-        self.storage = self.actor_storage_objects[actor_name]
-        super().init_store(spec_version=spec_version)
-
-    @rule(data=st.data())
-    def switch_actor(self, data: st.DataObject) -> None:
-        if self.store.session.has_uncommitted_changes:
-            self.commit_with_check(data)
-
-        # Draw an actor and use their storage object
-        actor_name = data.draw(st.sampled_from(list(self.actors.keys())))
-        self.actor = self.actors[actor_name]
-        self.ic = self.actor_modules[actor_name]
-        self.storage = self.actor_storage_objects[actor_name]
-
-        self.repo = self.actor.open(self.storage)
-        self.store = self.repo.writable_session("main").store
-
-    # v1 doesn't support empty commits, so only allow them when the actor is v2
-    @rule(data=st.data())
-    @precondition(
-        lambda self: (
-            self.store.session.has_uncommitted_changes
-            or Version(self.ic.__version__).major >= 2
-        )
-    )
-    def commit_with_check(self, data: st.DataObject) -> None:
-        return super().commit_with_check(data)
 
 
 def test_two_actors_zarr_cross_version() -> None:

--- a/icechunk-python/tests/test_stateful_repo_ops.py
+++ b/icechunk-python/tests/test_stateful_repo_ops.py
@@ -42,7 +42,6 @@ from hypothesis.stateful import (
 import zarr.testing.strategies as zrst
 from icechunk import (
     IcechunkError,
-    Repository,
     RepositoryConfig,
     SnapshotInfo,
     Storage,
@@ -493,13 +492,12 @@ class VersionControlStateMachine(RuleBasedStateMachine):
     tags = Bundle("tags")
     branches = Bundle("branches")
 
-    def __init__(self, actor: Any = None, ic_module: Any = None) -> None:
+    def __init__(self, ic_module: Any = None) -> None:
         super().__init__()
 
         note("----------")
         self.model = Model()
         self.storage: Storage | None = None
-        self.actor = actor or Repository
         self.ic = ic_module or icechunk
 
     def _initialize_model_and_data(self, data: st.DataObject) -> None:
@@ -528,13 +526,13 @@ class VersionControlStateMachine(RuleBasedStateMachine):
         self.model.spec_version = spec_version
 
         if Version(self.ic.__version__).major >= 2:
-            self.repo = self.actor.create(
+            self.repo = self.ic.Repository.create(
                 self.storage,
                 spec_version=spec_version,
                 config=config,
             )
         else:
-            self.repo = self.actor.create(
+            self.repo = self.ic.Repository.create(
                 self.storage,
                 config=config,
             )
@@ -631,7 +629,7 @@ class VersionControlStateMachine(RuleBasedStateMachine):
         This discards any uncommitted changes.
         """
         assert self.storage is not None, "storage must be initialized"
-        self.repo = self.actor.open(self.storage, config=config)
+        self.repo = self.ic.Repository.open(self.storage, config=config)
         note(f"Reopened repository (spec_version={self.model.spec_version})")
 
         # Reopening discards uncommitted changes - reset model to last committed state

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -21,8 +21,8 @@ import zarr
 from icechunk import Repository, Storage, in_memory_storage
 from icechunk.testing import strategies as icst
 from zarr import Array
+from zarr.abc.store import Store
 from zarr.core.buffer import default_buffer_prototype
-from zarr.storage import MemoryStore
 from zarr.testing.stateful import ZarrHierarchyStateMachine, split_prefix_name
 from zarr.testing.strategies import (
     node_names,
@@ -32,69 +32,7 @@ from zarr.testing.strategies import (
 PROTOTYPE = default_buffer_prototype()
 
 
-class ModelStore(MemoryStore):
-    """MemoryStore with move, copy, and shift_array methods for testing."""
-
-    async def shift_array(
-        self,
-        array_path: str,
-        offset: tuple[int, ...],
-        num_chunks: tuple[int, ...],
-    ) -> None:
-        """Shift chunk indices for an array.
-
-        This simulates what shift_array does to the chunk store keys.
-        Out-of-bounds chunks are dropped, vacated positions retain stale data.
-        """
-        prefix = f"{array_path}/c/"
-
-        # Read all chunks keyed by their new indices, discarding out-of-bounds
-        chunk_data: dict[tuple[int, ...], Any] = {}
-        async for key in self.list_prefix(prefix):
-            parts = key.split("/")
-            idx_start = parts.index("c") + 1
-            old_idx = tuple(int(p) for p in parts[idx_start:])
-            new_idx = tuple(idx + off for idx, off in zip(old_idx, offset, strict=True))
-            if any(
-                idx < 0 or idx >= nchunks
-                for idx, nchunks in zip(new_idx, num_chunks, strict=True)
-            ):
-                continue
-            data = await self.get(key, prototype=PROTOTYPE)
-            if data:
-                chunk_data[new_idx] = data
-
-        # Write chunks at new positions
-        for new_idx, data in chunk_data.items():
-            new_key = f"{prefix}{'/'.join(str(idx) for idx in new_idx)}"
-            await self.set(new_key, data)
-
-    spec_version: int
-
-    async def move(self, source: str, dest: str) -> None:
-        """Move all keys from source to dest.
-
-        Store keys always have form "node/zarr.json" or "node/c/...", never bare "node".
-        """
-        all_keys = [k async for k in self.list_prefix("")]
-        keys_to_move = [k for k in all_keys if k.startswith(source + "/")]
-        for old_key in keys_to_move:
-            new_key = dest + old_key[len(source) :]
-            data = await self.get(old_key, prototype=PROTOTYPE)
-            if data is not None:
-                await self.set(new_key, data)
-                await self.delete(old_key)
-
-    async def copy(self) -> "ModelStore":
-        """Create a copy of this store."""
-        new_store = ModelStore()
-        new_store.spec_version = self.spec_version
-        async for key in self.list_prefix(""):
-            data = await self.get(key, prototype=PROTOTYPE)
-            if data is not None:
-                await new_store.set(key, data)
-        return new_store
-
+from icechunk.testing.stateful_models import IcechunkModel
 
 Frequency = TypeVar("Frequency", bound=Callable[..., Any])
 
@@ -109,12 +47,11 @@ Frequency = TypeVar("Frequency", bound=Callable[..., Any])
 # TODO: add "/" to self.all_groups, deleting "/" seems to be problematic
 class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
     store: ic.IcechunkStore  # Override parent class type annotation
-    model: ModelStore  # Override to add move() method
+    model: IcechunkModel  # Override to add move() method
     storage: ic.Storage
 
     def __init__(self, storage: Storage) -> None:
         self.storage = storage
-        self.actor: type[Repository] = Repository
         # keep a version of icechunk module
         # this is necessary for subclasses that use multiple versions of icechunk
         # to do things like construct config types correctly
@@ -127,23 +64,32 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         temp_repo = Repository.create(in_memory_storage(), spec_version=1)
         temp_store = temp_repo.writable_session("main").store
         super().__init__(temp_store)
-        # Replace parent's MemoryStore with our ModelStore that has move()
-        self.model = ModelStore()
         self.model.spec_version = 1
-        zarr.group(store=self.model)
+
+    # properties in order to handle super class setting our
+    @property
+    def model(self) -> IcechunkModel:
+        return self._model
+
+    @model.setter
+    def model(self, store: Store):
+        if not isinstance(store, IcechunkModel):
+            self._model = IcechunkModel.from_store(store)
+        else:
+            self._model = store
 
     @initialize(spec_version=st.sampled_from([1, 2]))
     def init_store(self, spec_version: int) -> None:
         """Override parent's init_store to sample spec_version and create repository."""
         # necessary to control the order of calling. if multiple intiliazes they will be
         # called by hypothesis in a random order
-        note(f"Creating repository with spec_version={spec_version}, actor={self.actor}")
+        note(f"Creating repository with spec_version={spec_version}")
 
         # Create repository with the drawn spec version
         if Version(self.ic.__version__).major >= 2:
-            self.repo = self.actor.create(self.storage, spec_version=spec_version)
+            self.repo = self.ic.Repository.create(self.storage, spec_version=spec_version)
         else:
-            self.repo = self.actor.create(self.storage)
+            self.repo = self.ic.Repository.create(self.storage)
         self.store = self.repo.writable_session("main").store
         self.model.spec_version = spec_version
 
@@ -169,10 +115,11 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
             )
         )
         note(f"reopening with config {config!r}")
-        self.repo = self.actor.open(self.storage, config=config)
+        self.repo = self.ic.Repository.open(self.storage, config=config)
         if data.draw(st.booleans()):
             self.repo.save_config()
         self.store = self.repo.writable_session("main").store
+        self.model = self._sync(self.model.new_session(self.committed))
 
     @precondition(lambda self: not self.store.session.has_uncommitted_changes)
     @rule(data=st.data())
@@ -192,17 +139,22 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
             manifest=self.ic.ManifestConfig(splitting=sconfig),
         )
         note(f"rewriting manifests with config {sconfig=!r}")
-        self.repo = self.actor.open(self.storage, config=config)
+        self.repo = self.ic.Repository.open(self.storage, config=config)
         self.repo.rewrite_manifests(
             f"rewriting manifests with {sconfig!s}", branch="main"
         )
         if data.draw(st.booleans()):
             self.repo.save_config()
         self.store = self.repo.writable_session("main").store
+        self.model = self._sync(self.model.rewrite_manifests(self.committed))
 
     @rule(data=st.data())
+    @precondition(
+        lambda self: self.store.session.has_uncommitted_changes
+        or Version(self.ic.__version__).major >= 2
+    )
     def commit_with_check(self, data: st.DataObject) -> None:
-        note("committing and checking list_prefix")
+        note("committing")
 
         lsbefore = sorted(self._sync_iter(self.store.list_prefix("")))
         path = data.draw(st.sampled_from(lsbefore))
@@ -210,12 +162,20 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         assert get_before
 
         allow_empty = not self.store.session.has_uncommitted_changes
-        if Version(self.ic.__version__).major >= 2:
-            self.store.session.commit("foo", allow_empty=allow_empty)
-        else:
-            self.store.session.commit("foo")
+        try:
+            self._do_commit(allow_empty)
+        except self.ic.ConflictError:
+            self.store.session.rebase(self.ic.ConflictDetector())
+            self._do_commit(allow_empty)
+            self.model = self._sync(self.model.rebase(self.committed))
+            self.committed = self._sync(self.model.commit())
+            self.store = self.repo.writable_session("main").store
+            self.model = self._sync(self.model.new_session(self.committed))
+            return
 
+        self.committed = self._sync(self.model.commit())
         self.store = self.repo.writable_session("main").store
+        self.model = self._sync(self.model.new_session(self.committed))
 
         lsafter = sorted(self._sync_iter(self.store.list_prefix("")))
         get_after = self._sync(self.store.get(path, prototype=PROTOTYPE))
@@ -248,6 +208,24 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
                 f"Expected: {get_expect.to_bytes()!r}"
             )
 
+    def _do_commit(self, allow_empty: bool) -> None:
+        if Version(self.ic.__version__).major >= 2:
+            self.store.session.commit("foo", allow_empty=allow_empty)
+        else:
+            self.store.session.commit("foo")
+
+    @rule()
+    def clear(self) -> None:
+        """Clear the store and model, then commit and reopen session."""
+        # Reopen at branch tip so the commit doesn't conflict
+        self.repo = self.ic.Repository.open(self.storage)
+        self.store = self.repo.writable_session("main").store
+        super().clear()
+        self.store.session.commit("clear")
+        self.committed = self._sync(self.model.commit())
+        self.store = self.repo.writable_session("main").store
+        self.model = self._sync(self.model.new_session(self.committed))
+
     @rule(dry_run=st.booleans(), delete_unused_v1_files=st.booleans())
     @precondition(lambda self: self.model.spec_version == 1)
     @precondition(lambda self: not self.store.session.has_uncommitted_changes)
@@ -256,10 +234,14 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         self.repo = self.ic.upgrade_icechunk_repository(
             self.repo, dry_run=dry_run, delete_unused_v1_files=delete_unused_v1_files
         )
+        # Reopen to pick up the upgraded spec version
+        self.repo = self.ic.Repository.open(self.storage)
         self.store = self.repo.writable_session("main").store
         if not dry_run:
             assert self.repo.spec_version == 2
             self.model.spec_version = 2
+        self.committed = self._sync(self.model.commit())
+        self.model = self._sync(self.model.new_session(self.committed))
 
     @rule(data=st.data(), num_moves=st.integers(min_value=1, max_value=5))
     @precondition(lambda self: self.model.spec_version >= 2)
@@ -338,6 +320,7 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         else:
             note("discarding moves")
             self.store = self.repo.writable_session("main").store
+            self.model = self._sync(self.model.new_session(self.committed))
 
     @rule(data=st.data())
     @precondition(
@@ -395,7 +378,7 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         super().add_array(data, name, array_and_chunks)
 
     def _compare_list_dir(
-        self, model: ModelStore, store: ic.IcechunkStore, paths: set[str]
+        self, model: IcechunkModel, store: ic.IcechunkStore, paths: set[str]
     ) -> None:
         """Compare list_dir results between model and store for given paths."""
         for path in paths:
@@ -456,8 +439,9 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         if self.store.session.has_uncommitted_changes:
             self.commit_with_check(data)
 
-        self.repo = self.actor.open(self.storage)
+        self.repo = self.ic.Repository.open(self.storage)
         self.store = self.repo.writable_session("main").store
+        self.model = self._sync(self.model.new_session(self.committed))
 
     @rule()
     def pickle_objects(self) -> None:

--- a/icechunk/src/conflicts/detector.rs
+++ b/icechunk/src/conflicts/detector.rs
@@ -52,8 +52,18 @@ impl ConflictSolver for ConflictDetector {
         )
         .try_filter_map(|(path, _)| async {
             match previous_repo.get_node(path).await {
-                Ok(_) => {
-                    Ok(Some(Conflict::NewNodeConflictsWithExistingNode(path.clone())))
+                Ok(existing_node) => {
+                    /*
+                    If the current changeset deletes then recreates a node
+                    at this path then that is ok, not a conflict
+                    unless they also modify the content. But that is detected
+                    lower down in this function
+                    */
+                    if current_changes.is_deleted(path, &existing_node.id) {
+                        Ok(None)
+                    } else {
+                        Ok(Some(Conflict::NewNodeConflictsWithExistingNode(path.clone())))
+                    }
                 }
                 Err(SessionError {
                     kind: SessionErrorKind::NodeNotFound { .. }, ..

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -5154,7 +5154,8 @@ mod tests {
         let repository = create_memory_store_repository(SpecVersionBin::current()).await;
         let mut ds = repository.writable_session("main").await?;
 
-        ds.add_group("/foo/bar".try_into().unwrap(), Bytes::new()).await?;
+        ds.add_group("/foo/bar".try_into().unwrap(), Bytes::from("group-metadata"))
+            .await?;
         ds.add_array(
             "/foo/bar/some-array".try_into().unwrap(),
             basic_shape(),


### PR DESCRIPTION
We already have reopening logic on the super classes. I wanted to remove the (re)open in the actor switch as that potentially does some re-init which might mask a subtle bug. This way its a bit more like two concurrent actors who have both opened the repo and are doing operations to it.