### PR TITLE
[fix] ancestry was using two different versions of the repo info

### DIFF
--- a/icechunk/src/asset_manager.rs
+++ b/icechunk/src/asset_manager.rs
@@ -503,12 +503,9 @@ impl AssetManager {
         .await
         {
             Ok(Some((repo_info, version_info))) => {
-                if repo_cache.is_some() {
-                    trace!("Cached repo info wasn't latest");
-                }
                 if self.use_repo_info_cache {
                     trace!(
-                        "Updating repo info cache from {} to {}",
+                        "Repo info cache wasn't latest, updating from {} to {}",
                         repo_cache
                             .map(|(_, old)| old.to_string())
                             .unwrap_or_else(|| "none".to_string()),

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -1134,8 +1134,20 @@ impl Repository {
     }
 
     #[instrument(skip(self))]
-    async fn lookup_branch_v2(&self, branch: &str) -> RepositoryResult<SnapshotId> {
-        let (ri, _) = self.get_repo_info().await?;
+    async fn lookup_branch_v2(
+        &self,
+        branch: &str,
+        repo_info: Option<&RepoInfo>,
+    ) -> RepositoryResult<SnapshotId> {
+        let fetched; // used to hold the temp ref
+        let ri = match repo_info {
+            Some(ri) => ri,
+            None => {
+                fetched = self.get_repo_info().await?.0;
+                &fetched
+            }
+        };
+
         match ri.resolve_branch(branch) {
             Ok(snap) => Ok(snap),
             Err(IcechunkFormatError {
@@ -1152,7 +1164,7 @@ impl Repository {
     pub async fn lookup_branch(&self, branch: &str) -> RepositoryResult<SnapshotId> {
         match self.spec_version {
             SpecVersionBin::V1dot0 => self.lookup_branch_v1(branch).await,
-            SpecVersionBin::V2dot0 => self.lookup_branch_v2(branch).await,
+            SpecVersionBin::V2dot0 => self.lookup_branch_v2(branch, None).await,
         }
     }
 
@@ -1498,8 +1510,19 @@ impl Repository {
     }
 
     #[instrument(skip(self))]
-    async fn lookup_tag_v2(&self, tag: &str) -> RepositoryResult<SnapshotId> {
-        let (ri, _) = self.get_repo_info().await?;
+    async fn lookup_tag_v2(
+        &self,
+        tag: &str,
+        repo_info: Option<&RepoInfo>,
+    ) -> RepositoryResult<SnapshotId> {
+        let fetched; // used to hold the temp ref
+        let ri = match repo_info {
+            Some(ri) => ri,
+            None => {
+                fetched = self.get_repo_info().await?.0;
+                &fetched
+            }
+        };
         match ri.resolve_tag(tag) {
             Ok(snap) => Ok(snap),
             Err(IcechunkFormatError {
@@ -1516,7 +1539,7 @@ impl Repository {
     pub async fn lookup_tag(&self, tag: &str) -> RepositoryResult<SnapshotId> {
         match self.spec_version {
             SpecVersionBin::V1dot0 => self.lookup_tag_v1(tag).await,
-            SpecVersionBin::V2dot0 => self.lookup_tag_v2(tag).await,
+            SpecVersionBin::V2dot0 => self.lookup_tag_v2(tag, None).await,
         }
     }
 
@@ -1560,8 +1583,10 @@ impl Repository {
                 raise_if_invalid_snapshot_id_v2(repo_info, sid)?;
                 Ok(sid.clone())
             }
-            RefVersionInfo::TagRef(tag) => self.lookup_tag(tag).await,
-            RefVersionInfo::BranchTipRef(branch) => self.lookup_branch(branch).await,
+            RefVersionInfo::TagRef(tag) => self.lookup_tag_v2(tag, Some(repo_info)).await,
+            RefVersionInfo::BranchTipRef(branch) => {
+                self.lookup_branch_v2(branch, Some(repo_info)).await
+            }
         }
     }
 
@@ -2562,7 +2587,7 @@ mod tests {
             "main",
             "rewrite_manifests with split-size=12",
             None,
-            commit_method.clone(),
+            commit_method,
         )
         .await?;
         total_manifests += 1;
@@ -2595,7 +2620,7 @@ mod tests {
             "main",
             "rewrite_manifests with split-size=4",
             None,
-            commit_method.clone(),
+            commit_method,
         )
         .await?;
         total_manifests += 3;


### PR DESCRIPTION

<!-- Please review our AI & contribution guidelines: https://icechunk.io/en/latest/ai-policy/ -->

## Description
This is also a problem for `diff` and `rearrange_session`. Creating tickets for those.

<!-- Describe your changes and the reasoning behind them. -->
