### PR TITLE
Don't use snapshot flush time as repo update time

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,10 @@ alias pre := pre-commit
 test *args:
   export DYLD_LIBRARY_PATH="${CONDA_PREFIX:-}/lib" && cargo nextest run --no-fail-fast --cargo-profile {{profile}} --workspace --lib --bins --tests --examples "$@"
 
+[doc("Run all Rust lib tests via cargo-nextest")]
+unit-test *args:
+  export DYLD_LIBRARY_PATH="${CONDA_PREFIX:-}/lib" && cargo nextest run --no-fail-fast --cargo-profile {{profile}} --lib "$@"
+
 [doc("Run Rust doc tests only")]
 doctest *args:
   cargo test --workspace --profile {{profile}} --doc "$@"

--- a/icechunk/src/asset_manager.rs
+++ b/icechunk/src/asset_manager.rs
@@ -1815,6 +1815,7 @@ mod test {
             (&initial).try_into()?,
             100,
             None,
+            None,
         ));
         manager.create_repo_info(repo_info.clone()).await?;
 
@@ -1849,6 +1850,7 @@ mod test {
             SpecVersionBin::current(),
             (&initial).try_into()?,
             100,
+            None,
             None,
         ));
         let new_version = manager.create_repo_info(repo_info.clone()).await?;

--- a/icechunk/src/feature_flags.rs
+++ b/icechunk/src/feature_flags.rs
@@ -194,6 +194,7 @@ mod tests {
             (&initial).try_into().unwrap(),
             100,
             None,
+            None,
         );
         assert!(feature_flag_enabled(&ri, MOVE_NODE_FLAG).unwrap());
         assert!(feature_flag_enabled(&ri, CREATE_TAG_FLAG).unwrap());

--- a/icechunk/src/format/repo_info.rs
+++ b/icechunk/src/format/repo_info.rs
@@ -462,6 +462,7 @@ impl RepoInfo {
         snapshot: SnapshotInfo,
         num_updates_per_file: u16,
         config: Option<&RepositoryConfig>,
+        update_time: Option<DateTime<Utc>>,
     ) -> Self {
         #[allow(clippy::expect_used)]
         let config_bytes =
@@ -477,7 +478,7 @@ impl RepoInfo {
             &Default::default(),
             UpdateInfo {
                 update_type: UpdateType::RepoInitializedUpdate,
-                update_time: Utc::now(),
+                update_time: update_time.unwrap_or(Utc::now()),
                 previous_updates: [],
             },
             None,
@@ -650,12 +651,14 @@ impl RepoInfo {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_snapshot(
         &self,
         spec_version: SpecVersionBin,
         snap: SnapshotInfo,
         branch: Option<&str>,
         update_type: UpdateType,
+        update_time: Option<DateTime<Utc>>, // for testing
         previous_file: &str,
         num_updates_per_file: u16,
     ) -> IcechunkResult<Self> {
@@ -693,7 +696,7 @@ impl RepoInfo {
             &self.metadata()?,
             UpdateInfo {
                 update_type,
-                update_time: Utc::now(),
+                update_time: update_time.unwrap_or(Utc::now()),
                 previous_updates: self.latest_updates()?,
             },
             Some(previous_file),
@@ -1547,7 +1550,8 @@ mod tests {
             message: "snap 1".to_string(),
             metadata: Default::default(),
         };
-        let repo = RepoInfo::initial(SpecVersionBin::current(), snap1.clone(), 100, None);
+        let repo =
+            RepoInfo::initial(SpecVersionBin::current(), snap1.clone(), 100, None, None);
         assert_eq!(repo.all_snapshots()?.next().unwrap().unwrap(), snap1);
 
         let id2 = SnapshotId::random();
@@ -1566,6 +1570,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: snap2.id.clone(),
             },
+            None,
             "foo/bar",
             100,
         )?;
@@ -1599,6 +1604,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: snap3.id.clone(),
             },
+            None,
             "foo",
             100,
         )?;
@@ -1631,7 +1637,8 @@ mod tests {
             message: "snap 1".to_string(),
             metadata: Default::default(),
         };
-        let repo = RepoInfo::initial(SpecVersionBin::current(), snap1.clone(), 100, None);
+        let repo =
+            RepoInfo::initial(SpecVersionBin::current(), snap1.clone(), 100, None, None);
         let repo = repo.add_branch(SpecVersionBin::current(), "foo", &id1, "foo", 100)?;
         let repo = repo.add_branch(SpecVersionBin::current(), "bar", &id1, "bar", 100)?;
         assert!(matches!(
@@ -1677,6 +1684,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: snap2.id.clone(),
             },
+            None,
             "foo",
             100,
         )?;
@@ -1769,6 +1777,7 @@ mod tests {
             snap1,
             num_updates_per_file,
             None,
+            None,
         );
         assert_eq!(repo.latest_updates()?.count(), 1);
         let (last_update, _, file) = repo.latest_updates()?.next().unwrap()?;
@@ -1852,15 +1861,22 @@ mod tests {
     #[test]
     fn test_update_timestamp_ordering_rejected() -> Result<(), Box<dyn std::error::Error>>
     {
+        let flushed_at = DateTime::from_timestamp_micros(1_000_000).unwrap();
         let id1 = SnapshotId::random();
         let snap1 = SnapshotInfo {
             id: id1.clone(),
             parent_id: None,
-            flushed_at: DateTime::from_timestamp_micros(1_000_000).unwrap(),
+            flushed_at,
             message: "snap 1".to_string(),
             metadata: Default::default(),
         };
-        let repo = RepoInfo::initial(SpecVersionBin::current(), snap1, 100, None);
+        let repo = RepoInfo::initial(
+            SpecVersionBin::current(),
+            snap1,
+            100,
+            None,
+            Some(flushed_at),
+        );
 
         // Attempting add_snapshot with a timestamp equal to the top of the ops log
         // should fail
@@ -1880,6 +1896,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: id2.clone(),
             },
+            Some(flushed_at),
             "backup",
             100,
         );
@@ -1893,11 +1910,12 @@ mod tests {
 
         // Attempting add_snapshot with a timestamp older than the top of the ops log
         // should also fail
+        let flushed_at = DateTime::from_timestamp_micros(500_000).unwrap();
         let id3 = SnapshotId::random();
         let snap3 = SnapshotInfo {
             id: id3.clone(),
             parent_id: Some(id1.clone()),
-            flushed_at: DateTime::from_timestamp_micros(500_000).unwrap(),
+            flushed_at,
             message: "snap 3".to_string(),
             metadata: Default::default(),
         };
@@ -1909,6 +1927,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: id3.clone(),
             },
+            Some(flushed_at),
             "backup",
             100,
         );
@@ -1921,11 +1940,12 @@ mod tests {
         ));
 
         // Attempting add_snapshot with a strictly newer timestamp should succeed
+        let flushed_at = DateTime::from_timestamp_micros(2_000_000).unwrap();
         let id4 = SnapshotId::random();
         let snap4 = SnapshotInfo {
             id: id4.clone(),
             parent_id: Some(id1.clone()),
-            flushed_at: DateTime::from_timestamp_micros(2_000_000).unwrap(),
+            flushed_at,
             message: "snap 4".to_string(),
             metadata: Default::default(),
         };
@@ -1937,6 +1957,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: id4.clone(),
             },
+            Some(flushed_at),
             "backup",
             100,
         );

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -277,6 +277,7 @@ impl Repository {
                     snap_info,
                     num_updates,
                     config_to_store,
+                    None,
                 ));
 
                 // Write snapshot and transaction log concurrently first

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -1182,6 +1182,7 @@ impl Session {
                 new_snapshot_info,
                 None,
                 update_type.clone(),
+                None,
                 backup_path,
                 num_updates,
             )?))
@@ -2820,6 +2821,7 @@ async fn do_commit_v2(
             new_snapshot_info,
             Some(branch_name),
             update_type,
+            None,
             backup_path,
             num_updates_per_repo_info_file,
         )?))
@@ -3468,6 +3470,7 @@ mod tests {
             (&initial).try_into()?,
             100,
             None,
+            None,
         )
         .add_snapshot(
             SpecVersionBin::current(),
@@ -3477,6 +3480,7 @@ mod tests {
                 branch: "main".to_string(),
                 new_snap_id: snapshot.id().clone(),
             },
+            None,
             "backup_path",
             100,
         )?;


### PR DESCRIPTION
Some change may have happened since the commit started, and we have a rule that disalows going back in time in the ops-log

<!-- Please review our AI & contribution guidelines: https://icechunk.io/en/latest/ai-policy/ -->

## Description

<!-- Describe your changes and the reasoning behind them. -->
