### PR TITLE
Pin xarray child dep for now to unblock ci

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -229,7 +229,7 @@ jobs:
           PYTHON_TAG="cp$(echo ${{ env.PYTHON_VERSION }} | tr -d '.')"
           WHEEL=$(ls dist/*-${PYTHON_TAG}-*.whl)
           uv pip install "$WHEEL" --group test
-          uv pip install pytest-mypy-plugins
+          uv pip install "pytest-mypy-plugins<4"
           # Install specific xarray version based on matrix
           if [ "${{ matrix.xarray-version.version }}" != "latest-release" ]; then
             echo "Installing xarray ${{ matrix.xarray-version.version }}"


### PR DESCRIPTION
This is an xarray dep that is shielded by them using conda

we need to unblock our ci 

See https://github.com/typeddjango/pytest-mypy-plugins/releases/tag/4.0.0 and https://github.com/earth-mover/icechunk/blob/c66cb108cbd795e0a6adb8e9d153f822bf6a8c91/.github/workflows/python-upstream.yaml#L285