### PR TITLE
Copy object race condition

### DIFF
--- a/icechunk/src/storage/object_store.rs
+++ b/icechunk/src/storage/object_store.rs
@@ -402,10 +402,10 @@ impl Storage for ObjectStorage {
             let result = self.get_client(settings).await.get_opts(&from, opts).await;
             match result {
                 Ok(result) => {
-                    let bytes =
-                        result.bytes().await.map_err(|e| -> StorageError {
-                            Box::new(e).into()
-                        })?;
+                    let bytes = result
+                        .bytes()
+                        .await
+                        .map_err(|e| -> StorageError { Box::new(e).into() })?;
                     self.get_client(settings)
                         .await
                         .put(&to, bytes.into())


### PR DESCRIPTION
We use copy_object to backup repo_info. It needs to be consistent, and reject the copy if source has changed. object_store doesn't support it, so we do get+put instead of copy 🤷.

Created a ticket in object_store https://github.com/apache/arrow-rs-object-store/issues/667