### PR TITLE
Comment out `shuttle` usage

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -157,31 +157,31 @@ jobs:
         run: |
           cargo test --profile ci --workspace --all-targets -- --ignored
 
-  shuttle:
-    name: Shuttle concurrency tests
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+  # shuttle:
+  #   name: Shuttle concurrency tests
+  #   timeout-minutes: 30
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v6
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install Rust toolchain
-        run: |
-          rustup update --no-self-update ${{ env.RUST_CHANNEL }}
-          rustup default ${{ env.RUST_CHANNEL }}
+  #     - name: Install Rust toolchain
+  #       run: |
+  #         rustup update --no-self-update ${{ env.RUST_CHANNEL }}
+  #         rustup default ${{ env.RUST_CHANNEL }}
 
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: shuttle-${{ env.RUST_CHANNEL }}
+  #     - name: Cache Dependencies
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         key: shuttle-${{ env.RUST_CHANNEL }}
 
-      - name: Compile shuttle tests
-        run: cargo test -p icechunk --features shuttle --test test_shuttle --no-run
+  #     - name: Compile shuttle tests
+  #       run: cargo test -p icechunk --features shuttle --test test_shuttle --no-run
 
-      - name: Run shuttle tests
-        run: cargo test -p icechunk --features shuttle --test test_shuttle -- --nocapture
+  #     - name: Run shuttle tests
+  #       run: cargo test -p icechunk --features shuttle --test test_shuttle -- --nocapture
 
   wasm-build:
     name: WASM Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,12 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assoc"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
-
-[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,18 +789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,12 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03efed02df0504d71e44bfd51d3329f401b8303a2fd14254acf05c95a0af0153"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,19 +1046,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "corosensei"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c54787b605c7df106ceccf798df23da4f2e09918defad66705d1cedf3bb914f"
-dependencies = [
- "autocfg",
- "cfg-if",
- "libc",
- "scopeguard",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1140,34 +1103,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "tokio",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
@@ -1177,7 +1112,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.8.2",
+ "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -1190,16 +1125,6 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1627,12 +1552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,12 +1874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,7 +2139,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "criterion 0.8.2",
+ "criterion",
  "dialoguer",
  "dirs",
  "err-into",
@@ -2254,8 +2167,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml_ng",
- "shuttle",
- "shuttle-tokio",
  "tempfile",
  "test-log",
  "test-strategy",
@@ -2497,17 +2408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,15 +2418,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2717,7 +2608,7 @@ dependencies = [
  "backtrace-ext",
  "cfg-if",
  "miette-derive",
- "owo-colors 4.3.0",
+ "owo-colors",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
@@ -3009,12 +2900,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "owo-colors"
@@ -3478,12 +3363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,15 +3437,6 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rand_xorshift"
@@ -4248,76 +4118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "shuttle"
-version = "0.8.1"
-source = "git+https://github.com/awslabs/shuttle?branch=main#7b6a0424fb01364c59d9a3bb6ac8c2e59e279b34"
-dependencies = [
- "assoc",
- "bitvec",
- "cfg-if",
- "const-siphasher",
- "corosensei",
- "hex",
- "owo-colors 3.5.0",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rand_pcg",
- "scoped-tls",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "shuttle-tokio"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle?branch=main#7b6a0424fb01364c59d9a3bb6ac8c2e59e279b34"
-dependencies = [
- "cfg-if",
- "shuttle-tokio-impl",
- "tokio",
-]
-
-[[package]]
-name = "shuttle-tokio-impl"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle?branch=main#7b6a0424fb01364c59d9a3bb6ac8c2e59e279b34"
-dependencies = [
- "cfg-if",
- "shuttle-tokio-impl-inner",
- "tokio",
-]
-
-[[package]]
-name = "shuttle-tokio-impl-inner"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle?branch=main#7b6a0424fb01364c59d9a3bb6ac8c2e59e279b34"
-dependencies = [
- "criterion 0.5.1",
- "futures",
- "pin-project",
- "regex",
- "shuttle",
- "shuttle-tokio-macros-impl",
- "smallvec",
- "test-log",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "shuttle-tokio-macros-impl"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle?branch=main#7b6a0424fb01364c59d9a3bb6ac8c2e59e279b34"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "shuttle",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,12 +4336,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -5525,15 +5319,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -5857,15 +5642,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xmlparser"

--- a/icechunk-macros/src/lib.rs
+++ b/icechunk-macros/src/lib.rs
@@ -11,7 +11,7 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let block = &input_fn.block;
 
     let expanded = quote! {
-        #[cfg(not(feature = "shuttle"))]
+        // #[cfg(not(feature = "shuttle"))]
         #[test_log::test(tokio::test)]
         #[test_log(default_log_filter = "warn")]
         #(#attrs)*

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -61,10 +61,10 @@ flexbuffers = "25.12.19"
 flatbuffers = "25.12.19"
 urlencoding = "2.1.3"
 backon = "1.6.0"
-shuttle-tokio = { package = "shuttle-tokio", git = "https://github.com/awslabs/shuttle", branch = "main", features = [
-  "rt-multi-thread",
-  "macros",
-], version = "0.1.0", optional = true }
+# shuttle-tokio = { package = "shuttle-tokio", git = "https://github.com/awslabs/shuttle", branch = "main", features = [
+#   "rt-multi-thread",
+#   "macros",
+# ], version = "0.1.0", optional = true }
 
 # reqwest's default-features enables default-tls which ultimately leads to an openssl dependencies
 # which we are not including as it is not included in manylinux wheels. Instead depend on rustls-tls only
@@ -121,7 +121,7 @@ noxious-client = "1.0"
 reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1.22", features = ["v4"] }
 criterion = { version = "0.8.2", features = ["async_tokio"] }
-shuttle = { git = "https://github.com/awslabs/shuttle", branch = "main" }
+# shuttle = { git = "https://github.com/awslabs/shuttle", branch = "main" }
 tracing-samply = "0.1.5"
 tracing-chrome = "0.7"
 
@@ -154,7 +154,8 @@ object-store-fs = ["object_store/fs"]
 redirect = ["dep:reqwest"]
 logs = ["dep:tracing-subscriber"]
 cli = ["dep:clap", "dep:anyhow", "dep:dialoguer", "dep:dirs"]
-shuttle = ["dep:shuttle-tokio", "shuttle-tokio/shuttle"]
+# shuttle = ["dep:shuttle-tokio", "shuttle-tokio/shuttle"]
+shuttle = []
 
 [[bin]]
 name = "icechunk"

--- a/icechunk/src/lib.rs
+++ b/icechunk/src/lib.rs
@@ -32,8 +32,9 @@
 //!                                   └── Storage (S3, GCS, Azure, local, etc.)
 //! ```
 //!
-#[cfg(feature = "shuttle")]
-extern crate shuttle_tokio as tokio;
+
+// #[cfg(feature = "shuttle")]
+// extern crate shuttle_tokio as tokio;
 
 pub mod asset_manager;
 pub mod change_set;


### PR DESCRIPTION
shuttle-tokio is not released to crates yet, which makes it impossible to release to crates.io