### PR TITLE
Use assume in tree generation to prune invalid cases

### DIFF
--- a/icechunk-python/python/icechunk/testing/trees.py
+++ b/icechunk-python/python/icechunk/testing/trees.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 
 import hypothesis.strategies as st
 import numpy as np
+from hypothesis import assume
 
 import zarr
 import zarr.abc.store
@@ -235,7 +236,9 @@ def trees(
         )
         existing_names = existing_names | set(new_names)
         children: dict[str, Node] = {}
-        for name, child in zip(new_names, group.children.values(), strict=False):
+        assume(len(new_names) == len(group.children))
+
+        for name, child in zip(new_names, group.children.values(), strict=True):
             if isinstance(child, GroupNode):
                 child, existing_names = rebuild_with_names(child, existing_names)
             children[name] = child


### PR DESCRIPTION
Pretty sure this is the wrong fix (because we want `children` to be as many as they were before), but need someone with more hypothesis strategy experience to fix it properly :upside_down_face: 