### PR TITLE
fix zip misalignment in tree strategy

### DIFF
--- a/icechunk-python/python/icechunk/testing/trees.py
+++ b/icechunk-python/python/icechunk/testing/trees.py
@@ -145,7 +145,7 @@ def similar_name(
         )
     if bool(non_siblings):
         strategies.append(st.sampled_from(non_siblings))
-    return st.one_of(*strategies)
+    return st.one_of(*strategies).filter(lambda name: name not in sibling_names)
 
 
 @st.composite


### PR DESCRIPTION
there were some edge cases where we could end up duplicating a name by repeating an affix, or drawing an copied name from a cousin. which was then removed when we put in the set, which is how we ended up with fewer names.

could have done a filter higher up but I think i prefer filtering at as low a level as possible. also means that this function will just work for other use cases down the line.