### PR TITLE
Move all dependencies to workspace, use workspace=true in members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,85 @@ resolver = "2"
 rust-version = "1.94.0"
 edition = "2024"
 
+[workspace.dependencies]
+# Internal crates
+icechunk = { path = "icechunk", version = "2.0.0-alpha.4" }
+icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.0.0-alpha.4", default-features = false }
+icechunk-format = { path = "icechunk-format", version = "2.0.0-alpha.4" }
+icechunk-macros = { path = "icechunk-macros", version = "2.0.0-alpha.4" }
+icechunk-s3 = { path = "icechunk-s3", version = "2.0.0-alpha.4" }
+icechunk-storage = { path = "icechunk-storage", version = "2.0.0-alpha.4" }
+icechunk-types = { path = "icechunk-types", version = "2.0.0-alpha.4" }
+
+# External dependencies
+anyhow = "1.0.102"
+assert_fs = "1.1.3"
+async-compression = { version = "0.4.41", features = ["tokio", "zstd"] }
+async-recursion = "1.1.1"
+async-stream = "0.3.6"
+async-trait = "0.1.89"
+aws-config = "1.8.15"
+aws-credential-types = "1.2.14"
+aws-sdk-s3 = "1.127.0"
+aws-smithy-runtime = "1.10.3"
+aws-smithy-types-convert = { version = "0.60.14", features = ["convert-chrono", "convert-streams"] }
+backon = "1.6.0"
+base32 = "0.5.1"
+bytes = { version = "1.11.1", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
+clap = { version = "4.6", features = ["derive"] }
+criterion = { version = "0.8.2", features = ["async_tokio"] }
+dialoguer = "0.12.0"
+dirs = "6.0.0"
+flatbuffers = "25.12.19"
+flexbuffers = "25.12.19"
+fs_extra = "1.3.0"
+futures = "0.3.32"
+itertools = "0.14.0"
+miette = { version = "7.6.0", features = ["fancy"] }
+noxious-client = "1.0"
+object_store = { version = "0.13.1", default-features = false }
+port_check = "0.3.0"
+pretty_assertions = "1.4.1"
+proptest = "1.10.0"
+proptest-state-machine = "0.7.0"
+pyo3 = { version = "0.27.2", features = ["chrono", "experimental-async", "multiple-pymethods"] }
+pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
+pyo3-bytes = "0.5.0"
+quick_cache = "0.6.21"
+quote = "1.0"
+rand = "0.10.0"
+regex = "1.12.3"
+reqwest = "0.13"
+rmp-serde = "1.3.1"
+rstest = "0.26.1"
+rstest_reuse = "0.7.0"
+serde = { version = "1.0.228", features = ["derive", "rc"] }
+serde_bytes = "0.11.19"
+serde_json = "1.0.149"
+serde_with = "3.18.0"
+serde_yaml_ng = "0.10.0"
+strsim = "0.11"
+syn = { version = "2.0", features = ["full"] }
+tempfile = "3.27.0"
+test-log = { version = "0.2.19", default-features = false, features = ["trace", "color", "unstable"] }
+test-strategy = "0.4.5"
+thiserror = "2.0.18"
+tokio = "1.50.0"
+tokio-util = { version = "0.7.18", features = ["io-util"] }
+tracing = "0.1.44"
+tracing-chrome = "0.7"
+tracing-error = "0.2.1"
+tracing-samply = "0.1.5"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+typed-path = "0.12.3"
+typetag = "0.2.21"
+url = { version = "2.5.8", features = ["serde"] }
+urlencoding = "2.1.3"
+uuid = { version = "1.22", features = ["v4"] }
+warp = { version = "0.4.2", features = ["server"] }
+zstd = "0.13.3"
+
 [workspace.lints.rust]
 # Safety
 unsafe_code = "warn"

--- a/icechunk-arrow-object-store/Cargo.toml
+++ b/icechunk-arrow-object-store/Cargo.toml
@@ -14,33 +14,29 @@ publish = true
 rust-version.workspace = true
 
 [dependencies]
-icechunk-storage = { path = "../icechunk-storage", version = "2.0.0-alpha.4" }
-icechunk-types = { path = "../icechunk-types", version = "2.0.0-alpha.4" }
+icechunk-storage.workspace = true
+icechunk-types.workspace = true
 
-async-trait = "0.1.89"
-bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["serde"] }
-futures = "0.3.32"
-object_store = { version = "0.13.1", default-features = false, features = [] }
-rand = "0.10.0"
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-tokio = { version = "1.50.0", features = ["sync"] }
-tokio-util = { version = "0.7.18", features = ["io-util"] }
-tracing = "0.1.44"
-typetag = "0.2.21"
-url = { version = "2.5.8", features = ["serde"] }
+async-trait.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+futures.workspace = true
+object_store.workspace = true
+rand.workspace = true
+serde.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tokio-util.workspace = true
+tracing.workspace = true
+typetag.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-icechunk-macros = { path = "../icechunk-macros", version = "2.0.0-alpha.4" }
+icechunk-macros.workspace = true
 
-rmp-serde = "1.3.1"
-serde_json = "1.0.149"
-tempfile = "3.27.0"
-test-log = { version = "0.2.19", default-features = false, features = [
-  "trace",
-  "color",
-  "unstable",
-] }
+rmp-serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+test-log.workspace = true
 
 [features]
 default = ["s3", "gcs", "azure", "http", "fs"]

--- a/icechunk-format/Cargo.toml
+++ b/icechunk-format/Cargo.toml
@@ -14,39 +14,35 @@ publish = true
 rust-version.workspace = true
 
 [dependencies]
-icechunk-types = { path = "../icechunk-types", version = "2.0.0-alpha.4" }
+icechunk-types.workspace = true
 
-base32 = "0.5.1"
-bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["serde"] }
-flatbuffers = "25.12.19"
-flexbuffers = "25.12.19"
-futures = "0.3.32"
-itertools = "0.14.0"
-quick_cache = "0.6.21"
-rand = "0.10.0"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_bytes = "0.11.19"
-serde_json = "1.0.149"
-thiserror = "2.0.18"
-tracing = "0.1.44"
-url = { version = "2.5.8", features = ["serde"] }
-zstd = "0.13.3"
+base32.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+flatbuffers.workspace = true
+flexbuffers.workspace = true
+futures.workspace = true
+itertools.workspace = true
+quick_cache.workspace = true
+rand.workspace = true
+rmp-serde.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+url.workspace = true
+zstd.workspace = true
 
 [dev-dependencies]
-icechunk-macros = { path = "../icechunk-macros", version = "2.0.0-alpha.4" }
+icechunk-macros.workspace = true
 
-pretty_assertions = "1.4.1"
-proptest = "1.10.0"
-test-log = { version = "0.2.19", default-features = false, features = [
-  "trace",
-  "color",
-  "unstable",
-] }
-test-strategy = "0.4.5"
-tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"] }
-tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+pretty_assertions.workspace = true
+proptest.workspace = true
+test-log.workspace = true
+test-strategy.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/icechunk-macros/Cargo.toml
+++ b/icechunk-macros/Cargo.toml
@@ -14,8 +14,8 @@ publish = true
 rust-version.workspace = true
 
 [dependencies]
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+quote.workspace = true
+syn.workspace = true
 
 [lints]
 workspace = true

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -19,32 +19,28 @@ name = "_icechunk_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-icechunk = { path = "../icechunk", version = "2.0.0-alpha.4", features = ["logs"] }
+icechunk = { workspace = true, features = ["logs"] }
 
-async-stream = "0.3.6"
-async-trait = "0.1.89"
-chrono = { version = "0.4.44" }
-futures = "0.3.32"
-itertools = "0.14.0"
-miette = { version = "7.6.0", features = ["fancy"] }
-pyo3 = { version = "0.27.2", features = [
-  "chrono",
-  "experimental-async",
-  "multiple-pymethods",
-] }
-pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
-pyo3-bytes = "0.5.0"
-rand = "0.10.0"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-serde_json = "1.0.149"
-strsim = "0.11"
-thiserror = "2.0.18"
-tokio = "1.50"
-typetag = "0.2.21"
+async-stream.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+futures.workspace = true
+itertools.workspace = true
+miette.workspace = true
+pyo3.workspace = true
+pyo3-async-runtimes.workspace = true
+pyo3-bytes.workspace = true
+rand.workspace = true
+rmp-serde.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+strsim.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+typetag.workspace = true
 
 # Optional dependencies
-clap = { version = "4.6", features = ["derive"], optional = true }
+clap = { workspace = true, optional = true }
 
 [features]
 cli = ["clap", "icechunk/cli"]

--- a/icechunk-s3/Cargo.toml
+++ b/icechunk-s3/Cargo.toml
@@ -14,37 +14,30 @@ publish = true
 rust-version.workspace = true
 
 [dependencies]
-icechunk-storage = { path = "../icechunk-storage", version = "2.0.0-alpha.4" }
-icechunk-types = { path = "../icechunk-types", version = "2.0.0-alpha.4" }
+icechunk-storage.workspace = true
+icechunk-types.workspace = true
 
-async-trait = "0.1.89"
-aws-config = "1.8.15"
-aws-credential-types = "1.2.14"
-aws-sdk-s3 = "1.127.0"
-aws-smithy-runtime = "1.10.3"
-aws-smithy-types-convert = { version = "0.60.14", features = [
-  "convert-chrono",
-  "convert-streams",
-] }
-bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["serde"] }
-futures = "0.3.32"
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-tokio = { version = "1.50.0", features = ["sync"] }
-tokio-util = { version = "0.7.18", features = ["io-util"] }
-tracing = "0.1.44"
-typed-path = "0.12.3"
-typetag = "0.2.21"
+async-trait.workspace = true
+aws-config.workspace = true
+aws-credential-types.workspace = true
+aws-sdk-s3.workspace = true
+aws-smithy-runtime.workspace = true
+aws-smithy-types-convert.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+futures.workspace = true
+serde.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tokio-util.workspace = true
+tracing.workspace = true
+typed-path.workspace = true
+typetag.workspace = true
 
 [dev-dependencies]
-icechunk-macros = { path = "../icechunk-macros", version = "2.0.0-alpha.4" }
+icechunk-macros.workspace = true
 
-serde_json = "1.0.149"
-test-log = { version = "0.2.19", default-features = false, features = [
-  "trace",
-  "color",
-  "unstable",
-] }
+serde_json.workspace = true
+test-log.workspace = true
 
 [lints]
 workspace = true

--- a/icechunk-storage/Cargo.toml
+++ b/icechunk-storage/Cargo.toml
@@ -14,20 +14,20 @@ publish = true
 rust-version.workspace = true
 
 [dependencies]
-icechunk-types = { path = "../icechunk-types", version = "2.0.0-alpha.4" }
+icechunk-types.workspace = true
 
-async-trait = "0.1.89"
-bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["serde"] }
-futures = "0.3.32"
-itertools = "0.14.0"
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["io-util", "macros"] }
-tokio-util = { version = "0.7.18", features = ["io-util"] }
-tracing = "0.1.44"
-typetag = "0.2.21"
-url = { version = "2.5.8", features = ["serde"] }
+async-trait.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+futures.workspace = true
+itertools.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros"] }
+tokio-util.workspace = true
+tracing.workspace = true
+typetag.workspace = true
+url.workspace = true
 
 [lints]
 workspace = true

--- a/icechunk-types/Cargo.toml
+++ b/icechunk-types/Cargo.toml
@@ -14,11 +14,11 @@ publish = true
 rust-version.workspace = true
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_with = { version = "3.18.0" }
-thiserror = "2.0.18"
-tracing-error = "0.2.1"
-typed-path = "0.12.3"
+serde.workspace = true
+serde_with.workspace = true
+thiserror.workspace = true
+tracing-error.workspace = true
+typed-path.workspace = true
 
 [lints]
 workspace = true

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -16,55 +16,53 @@ autobenches = false
 autotests = false
 
 [dependencies]
-icechunk-arrow-object-store = { path = "../icechunk-arrow-object-store", version = "2.0.0-alpha.4", default-features = false }
-icechunk-format = { path = "../icechunk-format", version = "2.0.0-alpha.4" }
-icechunk-storage = { path = "../icechunk-storage", version = "2.0.0-alpha.4" }
-icechunk-types = { path = "../icechunk-types", version = "2.0.0-alpha.4" }
-icechunk-s3 = { path = "../icechunk-s3", version = "2.0.0-alpha.4", optional = true }
+icechunk-arrow-object-store.workspace = true
+icechunk-format.workspace = true
+icechunk-storage.workspace = true
+icechunk-types.workspace = true
+icechunk-s3 = { workspace = true, optional = true }
 
-async-compression = { version = "0.4.41", features = ["tokio", "zstd"] }
-async-recursion = "1.1.1"
-async-stream = "0.3.6"
-async-trait = "0.1.89"
-backon = "1.6.0"
-bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["serde"] }
-flexbuffers = "25.12.19"
-futures = "0.3.32"
-itertools = "0.14.0"
-quick_cache = "0.6.21"
-rand = "0.10.0"
-regex = "1.12.3"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-serde_bytes = "0.11.19"
-serde_json = "1.0.149"
-serde_with = { version = "3.18.0", features = ["hex"] }
-serde_yaml_ng = "0.10.0"
-thiserror = "2.0.18"
-tracing = "0.1.44"
-tracing-error = "0.2.1"
-typetag = "0.2.21"
-url = { version = "2.5.8", features = ["serde"] }
-urlencoding = "2.1.3"
-zstd = "0.13.3"
+async-compression.workspace = true
+async-recursion.workspace = true
+async-stream.workspace = true
+async-trait.workspace = true
+backon.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+flexbuffers.workspace = true
+futures.workspace = true
+itertools.workspace = true
+quick_cache.workspace = true
+rand.workspace = true
+regex.workspace = true
+rmp-serde.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+serde_json.workspace = true
+serde_with = { workspace = true, features = ["hex"] }
+serde_yaml_ng.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-error.workspace = true
+typetag.workspace = true
+url.workspace = true
+urlencoding.workspace = true
+zstd.workspace = true
 
 # Optional dependencies
-anyhow = { version = "1.0.102", optional = true }
-clap = { version = "4.6", features = ["derive"], optional = true }
-dialoguer = { version = "0.12.0", optional = true }
-dirs = { version = "6.0.0", optional = true }
-reqwest = { version = "0.13", optional = true }
-tracing-subscriber = { version = "0.3.23", features = [
-  "env-filter",
-], optional = true }
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+dialoguer = { workspace = true, optional = true }
+dirs = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 # shuttle-tokio = { package = "shuttle-tokio", git = "https://github.com/awslabs/shuttle", branch = "main", features = [
 #   "rt-multi-thread",
 #   "macros",
 # ], version = "0.1.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { version = "1.50.0", features = [
+tokio = { workspace = true, features = [
   "rt-multi-thread",
   "macros",
   "sync",
@@ -74,7 +72,7 @@ tokio = { version = "1.50.0", features = [
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-tokio = { version = "1.50.0", features = [
+tokio = { workspace = true, features = [
   "rt",
   "macros",
   "sync",
@@ -83,31 +81,27 @@ tokio = { version = "1.50.0", features = [
 ] }
 
 [dev-dependencies]
-icechunk-macros = { path = "../icechunk-macros", version = "2.0.0-alpha.4" }
+icechunk-macros.workspace = true
 
-assert_fs = "1.1.3"
-clap = { version = "4.6", features = ["derive"] }
-criterion = { version = "0.8.2", features = ["async_tokio"] }
-fs_extra = "1.3.0"
-noxious-client = "1.0"
-port_check = "0.3.0"
-pretty_assertions = "1.4.1"
-proptest = "1.10.0"
-proptest-state-machine = "0.7.0"
-reqwest = { version = "0.13", features = ["json"] }
-rstest = "0.26.1"
-rstest_reuse = "0.7.0"
-tempfile = "3.27.0"
-test-log = { version = "0.2.19", default-features = false, features = [
-  "trace",
-  "color",
-  "unstable",
-] }
-test-strategy = "0.4.5"
-tracing-chrome = "0.7"
-tracing-samply = "0.1.5"
-uuid = { version = "1.22", features = ["v4"] }
-warp = { version = "0.4.2", features = ["server"] }
+assert_fs.workspace = true
+clap.workspace = true
+criterion.workspace = true
+fs_extra.workspace = true
+noxious-client.workspace = true
+port_check.workspace = true
+pretty_assertions.workspace = true
+proptest.workspace = true
+proptest-state-machine.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+rstest.workspace = true
+rstest_reuse.workspace = true
+tempfile.workspace = true
+test-log.workspace = true
+test-strategy.workspace = true
+tracing-chrome.workspace = true
+tracing-samply.workspace = true
+uuid.workspace = true
+warp.workspace = true
 # shuttle = { git = "https://github.com/awslabs/shuttle", branch = "main" }
 
 [lints]


### PR DESCRIPTION
With the new internal crates it is becoming more complicated to track dependency versions. This PR moves all the dependencies to the workspace Cargo.toml, and use `dep.workspace = true` in the member's Cargo.toml.