### PR TITLE
Strip `x-amz-checksum-crc32` header from R2's 304 responses.

### DIFF
--- a/icechunk-s3/src/lib.rs
+++ b/icechunk-s3/src/lib.rs
@@ -19,7 +19,10 @@ use aws_sdk_s3::{
     config::{
         Builder, ConfigBag, IdentityCache, Intercept, ProvideCredentials, Region,
         RuntimeComponents, StalledStreamProtectionConfig,
-        interceptors::BeforeTransmitInterceptorContextMut,
+        interceptors::{
+            BeforeDeserializationInterceptorContextMut,
+            BeforeTransmitInterceptorContextMut,
+        },
     },
     error::{BoxError, SdkError},
     operation::{copy_object::CopyObjectError, put_object::PutObjectError},
@@ -49,7 +52,7 @@ use icechunk_types::ICResultExt as _;
 use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
 use tokio_util::io::StreamReader;
-use tracing::{error, instrument};
+use tracing::{error, instrument, trace};
 use typed_path::Utf8UnixPath;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -107,6 +110,33 @@ impl Intercept for ExtraHeadersInterceptor {
                     request.headers_mut().insert(k.clone(), v.clone());
                 }
             }
+        }
+        Ok(())
+    }
+}
+
+/// Strips `x-amz-checksum-crc32` from HTTP 304 (Not Modified) responses.
+///
+/// R2 includes this header on 304 responses, but because 304 responses have no
+/// body the AWS SDK's checksum validation fails with a mismatch, triggering
+/// transient-error retries with exponential backoff.
+#[derive(Debug)]
+struct StripChecksumOn304Interceptor;
+
+impl Intercept for StripChecksumOn304Interceptor {
+    fn name(&self) -> &'static str {
+        "StripChecksumOn304"
+    }
+
+    fn modify_before_deserialization(
+        &self,
+        context: &mut BeforeDeserializationInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let response = context.response_mut();
+        if response.status().as_u16() == 304 {
+            response.headers_mut().remove("x-amz-checksum-crc32");
         }
         Ok(())
     }
@@ -240,6 +270,17 @@ pub async fn mk_client(
             extra_read_headers,
             extra_write_headers,
         });
+    }
+
+    // R2 includes x-amz-checksum-crc32 on 304 Not Modified responses, but
+    // because 304 has no body the SDK's checksum validation fails and triggers
+    // expensive transient-error retries.
+    if config
+        .endpoint_url
+        .as_ref()
+        .is_some_and(|url| url.contains(".r2.cloudflarestorage.com"))
+    {
+        s3_builder = s3_builder.interceptor(StripChecksumOn304Interceptor);
     }
 
     let config = s3_builder.build();
@@ -873,16 +914,6 @@ impl S3Storage {
                 None => Err(other_error("Object should have an etag".to_string())),
             },
             Err(sdk_err) => {
-                // aws_sdk_s3 on R2 can return a response error (checksum mismatch)
-                // when status 304 (Not Modified) happens, so we need to check
-                // the if it happens here, before other regular checks when
-                // the response is well-formed.
-                if let SdkError::ResponseError(ref e) = sdk_err
-                    && e.raw().status().as_u16() == 304
-                {
-                    return Ok(None);
-                };
-
                 match sdk_err.as_service_error() {
                     Some(e) if e.is_no_such_key() => {
                         obj_not_found_res()
@@ -908,6 +939,7 @@ impl S3Storage {
                             .raw_response()
                             .is_some_and(|x| x.status().as_u16() == 304) =>
                     {
+                        trace!("Received 304 (Not Modified). Treating requested object as up-to-date.");
                         Ok(None)
                     }
                     _ => obj_store_error_res(sdk_err),

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -328,22 +328,31 @@ impl Repository {
     ) -> RepositoryResult<Self> {
         debug!("Opening Repository");
 
+        // Merge user-provided storage settings with backend defaults upfront so
+        // that every code path initializes the shared storage client with the
+        // same settings. The S3 client is lazily built via `OnceCell`, so the
+        // first caller locks in the config permanently.
+        let storage_defaults = storage.default_settings().await.inject()?;
+        let settings = match config.as_ref().and_then(|c| c.storage().cloned()) {
+            Some(user_storage) => storage_defaults.merge(user_storage),
+            None => storage_defaults,
+        };
+
         // Launch spec version detection and an optimistic config.yaml fetch concurrently.
         // For IC1 repos this avoids a sequential round-trip; for V2+ repos the config.yaml
         // result is ignored (config lives in the repo info object instead).
-        let temp_settings = storage.default_settings().await.inject()?;
         let temp_am = AssetManager::new_no_cache(
             Arc::clone(&storage),
-            temp_settings,
+            settings.clone(),
             SpecVersionBin::current(),
             1,
             DEFAULT_MAX_CONCURRENT_REQUESTS,
         );
 
         let storage_c = Arc::clone(&storage);
-        let user_settings = config.as_ref().and_then(|c| c.storage().cloned());
+        let settings_c = settings.clone();
         let fetch_version =
-            tokio::spawn(Self::fetch_spec_version(storage_c, user_settings));
+            tokio::spawn(Self::fetch_spec_version(storage_c, Some(settings_c)));
         let fetch_config_yaml = temp_am.fetch_config();
 
         // Use join! (not try_join!) so that a config.yaml error doesn't fail the
@@ -374,20 +383,21 @@ impl Repository {
         // Merge three layers of config (In order of preference):
         //   - User-provided config (passed to open())
         //   - Persisted repo config (saved alongside the data, if any)
-        //   - Backend storage defaults (e.g. S3 retry/concurrency settings)
-        let storage_defaults = storage.default_settings().await.inject()?;
+        //   - Backend storage defaults (already merged with user settings above)
         let repo_config = match persisted_config {
             Some(c) => RepositoryConfig::default().merge(c),
             None => RepositoryConfig::default(),
         };
         // merge user config on top of persisted config and library defaults
-        // no storage merging happening yet.
         let merged_config = config.map(|c| repo_config.merge(c)).unwrap_or(repo_config);
 
-        // construct the merged storage settings
+        // Re-merge in case persisted config introduced additional storage
+        // settings. Note: the S3 client is already initialized with `settings`
+        // from above, so only Icechunk-level settings (concurrency, etc.) can
+        // change here.
         let storage_settings = match merged_config.storage.clone() {
-            Some(s) => storage_defaults.merge(s),
-            None => storage_defaults,
+            Some(s) => settings.merge(s),
+            None => settings,
         };
         // combine merged config settings + merged storage settings
         let final_config =
@@ -420,8 +430,12 @@ impl Repository {
         create_version: Option<SpecVersionBin>,
         check_clean_root: bool,
     ) -> RepositoryResult<Self> {
-        let user_settings = config.as_ref().and_then(|c| c.storage().cloned());
-        if Self::fetch_spec_version(Arc::clone(&storage), user_settings).await?.is_some()
+        let storage_defaults = storage.default_settings().await.inject()?;
+        let settings = match config.as_ref().and_then(|c| c.storage().cloned()) {
+            Some(user_storage) => storage_defaults.merge(user_storage),
+            None => storage_defaults,
+        };
+        if Self::fetch_spec_version(Arc::clone(&storage), Some(settings)).await?.is_some()
         {
             Self::open(config, storage, authorize_virtual_chunk_access).await
         } else {


### PR DESCRIPTION
This avoids a very expensive retry loop on repo info object update checks.

Closes #1990