### PR TITLE
Allow optional message and properties with `amend`

### DIFF
--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -2381,13 +2381,13 @@ class PySession:
     ) -> str: ...
     def amend(
         self,
-        message: str,
+        message: str | None = None,
         metadata: dict[str, Any] | None = None,
         allow_empty: bool = False,
     ) -> str: ...
     async def amend_async(
         self,
-        message: str,
+        message: str | None = None,
         metadata: dict[str, Any] | None = None,
         allow_empty: bool = False,
     ) -> str: ...

--- a/icechunk-python/python/icechunk/session.py
+++ b/icechunk-python/python/icechunk/session.py
@@ -507,7 +507,7 @@ class Session:
 
     def amend(
         self,
-        message: str,
+        message: str | None = None,
         metadata: dict[str, Any] | None = None,
         allow_empty: bool = False,
     ) -> str:
@@ -524,10 +524,10 @@ class Session:
 
         Parameters
         ----------
-        message : str
-            The message to write with the commit.
+        message : str | None, optional
+            The message to write with the commit. If None, reuses the message from the previous commit.
         metadata : dict[str, Any] | None, optional
-            Additional metadata to store with the commit snapshot.
+            Additional metadata to store with the commit snapshot. If None, reuses the metadata from the previous commit.
         allow_empty : bool, optional
             If True, allow amending even if no data changes have been made to the session.
             This is useful when you only want to update the commit message. Default is False.
@@ -546,7 +546,7 @@ class Session:
 
     async def amend_async(
         self,
-        message: str,
+        message: str | None = None,
         metadata: dict[str, Any] | None = None,
         allow_empty: bool = False,
     ) -> str:
@@ -563,10 +563,10 @@ class Session:
 
         Parameters
         ----------
-        message : str
-            The message to write with the commit.
+        message : str | None, optional
+            The message to write with the commit. If None, reuses the message from the previous commit.
         metadata : dict[str, Any] | None, optional
-            Additional metadata to store with the commit snapshot.
+            Additional metadata to store with the commit snapshot. If None, reuses the metadata from the previous commit.
         allow_empty : bool, optional
             If True, allow amending even if no data changes have been made to the session.
             This is useful when you only want to update the commit message. Default is False.

--- a/icechunk-python/src/session.rs
+++ b/icechunk-python/src/session.rs
@@ -598,21 +598,21 @@ impl PySession {
         })
     }
 
-    #[pyo3(signature = (message, metadata=None, allow_empty=false))]
+    #[pyo3(signature = (message=None, *, metadata=None, allow_empty=false))]
     pub fn amend(
         &self,
         py: Python<'_>,
-        message: &str,
+        message: Option<&str>,
         metadata: Option<PySnapshotProperties>,
         allow_empty: bool,
     ) -> PyResult<String> {
         let metadata = metadata.map(|m| m.into());
+        let message = message.map(|m| m.to_string());
         // This is blocking function, we need to release the Gil
         py.detach(move || {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let mut session = self.0.write().await;
-                let mut builder =
-                    session.commit(message).amend().allow_empty(allow_empty);
+                let mut builder = session.amend(message).allow_empty(allow_empty);
                 if let Some(props) = metadata {
                     builder = builder.properties(props);
                 }
@@ -625,21 +625,21 @@ impl PySession {
         })
     }
 
-    #[pyo3(signature = (message, metadata=None, allow_empty=false))]
+    #[pyo3(signature = (message=None, *, metadata=None, allow_empty=false))]
     pub fn amend_async<'py>(
         &'py self,
         py: Python<'py>,
-        message: &str,
+        message: Option<&str>,
         metadata: Option<PySnapshotProperties>,
         allow_empty: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let session = Arc::clone(&self.0);
-        let message = message.to_owned();
+        let message = message.map(|m| m.to_string());
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let metadata = metadata.map(|m| m.into());
             let mut session = session.write().await;
-            let mut builder = session.commit(&message).amend().allow_empty(allow_empty);
+            let mut builder = session.amend(message).allow_empty(allow_empty);
             if let Some(props) = metadata {
                 builder = builder.properties(props);
             }

--- a/icechunk/benches/manifest.rs
+++ b/icechunk/benches/manifest.rs
@@ -171,10 +171,9 @@ fn benchmark_get_chunks(c: &mut Criterion) {
                                     let mut session =
                                         repo.writable_session("main").await.unwrap();
                                     session
-                                        .commit("rewrite")
+                                        .amend(Some("rewrite".to_string()))
                                         .max_concurrent_nodes(8)
                                         .rewrite_manifests()
-                                        .amend()
                                         .execute()
                                         .await
                                         .unwrap();

--- a/icechunk/src/ops/manifests.rs
+++ b/icechunk/src/ops/manifests.rs
@@ -39,13 +39,13 @@ pub async fn rewrite_manifests(
         .await
         .map_err(|e| ManifestOpsError::ManifestRewriteError(Box::new(e.inject())))?;
 
-    let mut builder = session
-        .commit(message)
-        .max_concurrent_nodes(max_concurrent_manifests)
-        .rewrite_manifests();
-    if commit_method == CommitMethod::Amend {
-        builder = builder.amend();
+    let mut builder = if commit_method == CommitMethod::Amend {
+        session.amend(Some(message.to_string()))
+    } else {
+        session.commit(message)
     }
+    .max_concurrent_nodes(max_concurrent_manifests)
+    .rewrite_manifests();
     if let Some(props) = properties {
         builder = builder.properties(props);
     }

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -4308,8 +4308,10 @@ mod tests {
         session
             .move_node("/dest".try_into().unwrap(), "/another_dest".try_into().unwrap())
             .await?;
-        let first_amend_snap_id =
-            session.commit("moved dest to another_dest").amend().execute().await?;
+        let first_amend_snap_id = session
+            .amend(Some("moved dest to another_dest".to_string()))
+            .execute()
+            .await?;
 
         // Check if moved group still shows up properly after commit
         let session = repo
@@ -4329,8 +4331,10 @@ mod tests {
         session
             .move_node("/another_dest".try_into().unwrap(), "/src".try_into().unwrap())
             .await?;
-        let second_amend_snap_id =
-            session.commit("moved another_dest to src").amend().execute().await?;
+        let second_amend_snap_id = session
+            .amend(Some("moved another_dest to src".to_string()))
+            .execute()
+            .await?;
 
         // Check if moved group still shows up properly after commit
         let session = repo
@@ -4442,8 +4446,11 @@ mod tests {
         // Rearrange session: move a node
         let mut session = repo.rearrange_session("main").await?;
         session.move_node("/f".try_into().unwrap(), "/foo".try_into().unwrap()).await?;
-        let amend_snap_id =
-            session.commit("f to foo").max_concurrent_nodes(8).amend().execute().await?;
+        let amend_snap_id = session
+            .amend(Some("f to foo".to_string()))
+            .max_concurrent_nodes(8)
+            .execute()
+            .await?;
 
         // Check if moved (and nested) groups still show up properly after commit
         let session = repo
@@ -4531,7 +4538,7 @@ mod tests {
             .move_node("/f/bar".try_into().unwrap(), "/foo".try_into().unwrap())
             .await?;
         let first_amend_snap_id =
-            session.commit("f/bar to foo").amend().execute().await?;
+            session.amend(Some("f/bar to foo".to_string())).execute().await?;
 
         // Check if moved (and nested) groups still show up properly after commit
         let session = repo
@@ -4629,7 +4636,8 @@ mod tests {
         // Rearrange session: move another node, amend this time
         let mut session = repo.rearrange_session("main").await?;
         session.move_node("/b".try_into().unwrap(), "/d".try_into().unwrap()).await?;
-        let second_amend_snap_id = session.commit("b to d").amend().execute().await?;
+        let second_amend_snap_id =
+            session.amend(Some("b to d".to_string())).execute().await?;
 
         // Check if moved (and nested) groups still show up properly after commit
         let session = repo
@@ -4651,7 +4659,8 @@ mod tests {
         // Rearrange session: move child from one top-level node to another
         let mut session = repo.rearrange_session("main").await?;
         session.move_node("/d/a".try_into().unwrap(), "/c/e".try_into().unwrap()).await?;
-        let third_amend_snap_id = session.commit("d/a to c/e").amend().execute().await?;
+        let third_amend_snap_id =
+            session.amend(Some("d/a to c/e".to_string())).execute().await?;
 
         // Check if moved (and nested) groups still show up properly after commit
         let session = repo

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -240,7 +240,7 @@ enum CommitKind {
 
 pub struct CommitBuilder<'a> {
     session: &'a mut Session,
-    message: String,
+    message: Option<String>,
     properties: Option<SnapshotProperties>,
     max_concurrent_nodes: usize,
     allow_empty: bool,
@@ -262,14 +262,30 @@ impl std::fmt::Debug for CommitBuilder<'_> {
 }
 
 impl<'a> CommitBuilder<'a> {
-    fn new(session: &'a mut Session, message: String) -> Self {
+    fn for_commit(session: &'a mut Session, message: String) -> Self {
+        Self {
+            session,
+            message: Some(message),
+            properties: None,
+            max_concurrent_nodes: 1,
+            allow_empty: false,
+            amend: false,
+            kind: CommitKind::NewCommit,
+            rebase_solver: None,
+            rebase_attempts: 0,
+            before_rebase: None,
+            after_rebase: None,
+        }
+    }
+
+    fn for_amend(session: &'a mut Session, message: Option<String>) -> Self {
         Self {
             session,
             message,
             properties: None,
             max_concurrent_nodes: 1,
             allow_empty: false,
-            amend: false,
+            amend: true,
             kind: CommitKind::NewCommit,
             rebase_solver: None,
             rebase_attempts: 0,
@@ -290,11 +306,6 @@ impl<'a> CommitBuilder<'a> {
 
     pub fn allow_empty(mut self, allow_empty: bool) -> Self {
         self.allow_empty = allow_empty;
-        self
-    }
-
-    pub fn amend(mut self) -> Self {
-        self.amend = true;
         self
     }
 
@@ -361,12 +372,38 @@ impl<'a> CommitBuilder<'a> {
             ));
         }
 
-        if self.amend {
+        if self.message.is_none() && !self.amend {
+            return Err(SessionError::capture(
+                SessionErrorKind::InvalidCommitConfiguration {
+                    reason: "message can be None only if amending",
+                },
+            ));
+        }
+
+        let (properties, message) = if self.amend {
             self.session
                 .asset_manager
                 .fail_unless_spec_at_least(SpecVersionBin::V2)
                 .inject()?;
-        }
+            let snapshot = self
+                .session
+                .asset_manager
+                .fetch_snapshot(&self.session.snapshot_id)
+                .await
+                .inject()?;
+            let properties = match self.properties {
+                Some(p) => Some(p),
+                None => Some(snapshot.metadata().inject()?),
+            };
+            let message = self.message.unwrap_or_else(|| snapshot.message());
+            (properties, message)
+        } else {
+            #[allow(clippy::expect_used)]
+            (
+                self.properties,
+                self.message.expect("message cannot be None if not amending."),
+            )
+        };
 
         let commit_method =
             if self.amend { CommitMethod::Amend } else { CommitMethod::NewCommit };
@@ -374,15 +411,15 @@ impl<'a> CommitBuilder<'a> {
         match self.kind {
             CommitKind::Flush => {
                 self.session
-                    .do_flush(&self.message, self.max_concurrent_nodes, self.properties)
+                    .do_flush(&message, self.max_concurrent_nodes, properties)
                     .await
             }
             CommitKind::RewriteManifests => {
                 self.session
                     .do_rewrite_manifests(
-                        &self.message,
+                        &message,
                         self.max_concurrent_nodes,
-                        self.properties,
+                        properties,
                         commit_method,
                     )
                     .await
@@ -393,9 +430,9 @@ impl<'a> CommitBuilder<'a> {
                         .do_commit_rebasing(
                             solver,
                             self.rebase_attempts,
-                            &self.message,
+                            &message,
                             self.max_concurrent_nodes,
-                            self.properties,
+                            properties,
                             self.allow_empty,
                             self.before_rebase,
                             self.after_rebase,
@@ -404,9 +441,9 @@ impl<'a> CommitBuilder<'a> {
                 } else {
                     self.session
                         .commit_inner(
-                            &self.message,
+                            &message,
                             self.max_concurrent_nodes,
-                            self.properties,
+                            properties,
                             false,
                             commit_method,
                             self.allow_empty,
@@ -1435,7 +1472,11 @@ impl Session {
     }
 
     pub fn commit(&mut self, message: impl Into<String>) -> CommitBuilder<'_> {
-        CommitBuilder::new(self, message.into())
+        CommitBuilder::for_commit(self, message.into())
+    }
+
+    pub fn amend(&mut self, message: Option<String>) -> CommitBuilder<'_> {
+        CommitBuilder::for_amend(self, message)
     }
 
     async fn flush_v2(&mut self, new_snap: Arc<Snapshot>) -> SessionResult<()> {
@@ -4933,9 +4974,8 @@ mod tests {
         let mut session = repo.writable_session("main").await?;
         session.add_group(Path::root(), Bytes::copy_from_slice(b"")).await?;
         let amend_result = session
-            .commit("cannot amend initial commit")
+            .amend(Some("cannot amend initial commit".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .execute()
             .await;
         assert!(amend_result.is_err());
@@ -4943,9 +4983,8 @@ mod tests {
 
         let mut session = repo.writable_session("main").await?;
         let amend_result = session
-            .commit("cannot amend initial commit")
+            .amend(Some("cannot amend initial commit".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .allow_empty(true)
             .execute()
             .await;
@@ -4964,9 +5003,8 @@ mod tests {
         let mut session = repo.writable_session("main").await?;
         session.add_group("/b".try_into().unwrap(), Bytes::copy_from_slice(b"")).await?;
         let before_amend2 = session
-            .commit("first amend")
+            .amend(Some("first amend".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .execute()
             .await?;
 
@@ -4997,9 +5035,8 @@ mod tests {
             .add_group("/error".try_into().unwrap(), Bytes::copy_from_slice(b""))
             .await?;
         let after_amend2 = session
-            .commit("second amend")
+            .amend(Some("second amend".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .execute()
             .await?;
 
@@ -5060,6 +5097,84 @@ mod tests {
     }
 
     #[tokio_test]
+    async fn test_amend_reuses_message_and_metadata() -> Result<(), Box<dyn Error>> {
+        let repo = create_memory_store_repository(SpecVersionBin::current()).await;
+
+        // Create initial commit
+        let mut session = repo.writable_session("main").await?;
+        session.add_group(Path::root(), Bytes::copy_from_slice(b"")).await?;
+        session.commit("make root").max_concurrent_nodes(8).execute().await?;
+
+        // Commit with message and metadata
+        let mut session = repo.writable_session("main").await?;
+        session.add_group("/a".try_into().unwrap(), Bytes::copy_from_slice(b"")).await?;
+        let mut props = SnapshotProperties::default();
+        props.insert("key".to_string(), serde_json::Value::String("value".to_string()));
+        session
+            .commit("original message")
+            .max_concurrent_nodes(8)
+            .properties(props)
+            .execute()
+            .await?;
+
+        let asset_manager = repo.asset_manager();
+
+        // Amend with None message and None metadata — should reuse both
+        let mut session = repo.writable_session("main").await?;
+        session.add_group("/b".try_into().unwrap(), Bytes::copy_from_slice(b"")).await?;
+        let snap_id = session.amend(None).max_concurrent_nodes(8).execute().await?;
+
+        let info = asset_manager.fetch_snapshot_info(&snap_id).await?;
+        assert_eq!(info.message, "original message");
+        assert_eq!(
+            info.metadata.get("key"),
+            Some(&serde_json::Value::String("value".to_string()))
+        );
+
+        // Amend with new message but None metadata — should override message, keep metadata
+        let mut session = repo.writable_session("main").await?;
+        session.add_group("/c".try_into().unwrap(), Bytes::copy_from_slice(b"")).await?;
+        let snap_id = session
+            .amend(Some("new message".to_string()))
+            .max_concurrent_nodes(8)
+            .execute()
+            .await?;
+
+        let info = asset_manager.fetch_snapshot_info(&snap_id).await?;
+        assert_eq!(info.message, "new message");
+        assert_eq!(
+            info.metadata.get("key"),
+            Some(&serde_json::Value::String("value".to_string()))
+        );
+
+        // Amend with new properties but None message — should keep message, override metadata
+        let mut session = repo.writable_session("main").await?;
+        session.add_group("/d".try_into().unwrap(), Bytes::copy_from_slice(b"")).await?;
+        let mut new_props = SnapshotProperties::default();
+        new_props.insert(
+            "new_key".to_string(),
+            serde_json::Value::String("new_value".to_string()),
+        );
+        let snap_id = session
+            .amend(None)
+            .max_concurrent_nodes(8)
+            .properties(new_props)
+            .execute()
+            .await?;
+
+        let info = asset_manager.fetch_snapshot_info(&snap_id).await?;
+        assert_eq!(info.message, "new message");
+        assert_eq!(
+            info.metadata.get("new_key"),
+            Some(&serde_json::Value::String("new_value".to_string()))
+        );
+        // Old key should be gone since we provided explicit properties
+        assert!(info.metadata.get("key").is_none());
+
+        Ok(())
+    }
+
+    #[tokio_test]
     async fn implicit_group_creation_in_move() -> Result<(), Box<dyn Error>> {
         let repo = create_memory_store_repository(SpecVersionBin::current()).await;
 
@@ -5108,9 +5223,8 @@ mod tests {
             .add_group("/fail".try_into().unwrap(), Bytes::copy_from_slice(b""))
             .await?;
         let result = session
-            .commit("amend after move")
+            .amend(Some("amend after move".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .execute()
             .await;
         assert!(result.is_err());
@@ -5123,9 +5237,8 @@ mod tests {
             .move_node("/dest".try_into().unwrap(), "/another_dest".try_into().unwrap())
             .await?;
         let result = session
-            .commit("amend after move, only new moves")
+            .amend(Some("amend after move, only new moves".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .execute()
             .await;
         assert!(result.is_ok());
@@ -5190,9 +5303,8 @@ mod tests {
             )
             .await?;
         let snapshot_id = session
-            .commit("amend nested groups move ")
+            .amend(Some("amend nested groups move ".to_string()))
             .max_concurrent_nodes(8)
-            .amend()
             .execute()
             .await?;
 


### PR DESCRIPTION
Closes #2002

One issue is that `properties=None` means no properties but that meaning is now discarded for amend. So a user cannot amend and only unset properties. I guess they can just make a new commit for that case?