### PR TITLE
Remove _upgrade_icechunk_repository from public API

### DIFF
--- a/icechunk-python/python/icechunk/__init__.py
+++ b/icechunk-python/python/icechunk/__init__.py
@@ -174,7 +174,6 @@ __all__ = [
     "VirtualChunkContainer",
     "VirtualChunkSpec",
     "__version__",
-    "_upgrade_icechunk_repository",
     "azure_credentials",
     "azure_from_env_credentials",
     "azure_refreshable_credentials",


### PR DESCRIPTION
## Summary
- Remove `_upgrade_icechunk_repository` from `__all__` in `icechunk/__init__.py`
- The underscore-prefixed private PyO3 function was accidentally exported as part of the public API
- Users should use the public `upgrade_icechunk_repository()` wrapper instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)