### PR TITLE
Add summary table of top-level API to reference docs

### DIFF
--- a/icechunk-python/docs/docs/reference/index.md
+++ b/icechunk-python/docs/docs/reference/index.md
@@ -28,6 +28,23 @@ solver = ic.conflicts.BasicConflictSolver(...)
 | [`icechunk.xarray`](xarray.md) | Xarray integration |
 | [`icechunk.dask`](dask.md) | Dask integration |
 
+## Top-level API
+
+The following classes, exceptions, and utilities are available directly in the `icechunk` namespace and are not part of any submodule.
+
+| Name | Kind | Description |
+|------|------|-------------|
+| [`Repository`](#icechunkrepository) | class | Main entry point for creating and opening repositories |
+| [`IcechunkStore`](#icechunkicechunkstore) | class | Zarr-compatible store backed by an Icechunk session |
+| [`IcechunkError`](#icechunkerror) | exception | Base exception for Icechunk errors |
+| [`ConflictError`](#conflicterror) | exception | Raised on conflicting concurrent writes |
+| [`RebaseFailedError`](#rebasefailederror) | exception | Raised when a rebase cannot be completed |
+| [`print_debug_info`](#print_debug_info) | function | Print versions of icechunk and related packages |
+| [`upgrade_icechunk_repository`](#upgrade_icechunk_repository) | function | Migrate a repository to the latest spec version |
+| [`supported_spec_versions`](#supported_spec_versions) | function | List supported spec versions |
+
+---
+
 ## `icechunk.Repository`
 
 ::: icechunk.Repository


### PR DESCRIPTION
## Summary
- Adds a quick-reference table to the top of the Python API reference page listing the classes, exceptions, and utilities that live directly in the `icechunk` namespace (not re-exports from submodules)
- Each entry links to its full documentation section lower on the same page

🤖 Generated with [Claude Code](https://claude.com/claude-code)