### PR TITLE
Add docs for named virtual chunk containers and vcc:// URLs

### DIFF
--- a/icechunk-python/docs/docs/virtual.md
+++ b/icechunk-python/docs/docs/virtual.md
@@ -162,7 +162,7 @@ ds.sst.isel(time=26, zlev=0).plot(x='lon', y='lat', vmin=0)
 
 ## Relative Virtual Chunk Containers
 
-By default, every virtual chunk stores a full absolute URL like `s3://bucket/prefix/path/to/chunk.nc`. However, this locks in the location of the chunk - if you move yove your data to a different bucket or cloud provider, you would need to rewrite all the chunk reference URLs.
+By default, every virtual chunk stores a full absolute URL like `s3://bucket/prefix/path/to/chunk.nc`. However, this locks in the location of the chunk - if you move your data to a different bucket or cloud provider, you would need to rewrite all the chunk reference URLs.
 
 To address this, you can give a `VirtualChunkContainer` a **name**. Chunks can then use `vcc://` relative URLs instead of full absolute paths:
 


### PR DESCRIPTION
## Summary
- Adds a new "Relative Virtual Chunk Containers" section to the virtual datasets docs page
- Documents the `name` parameter on `VirtualChunkContainer` and the `vcc://` URL scheme for relative chunk locations
- Explains the portability benefit (update `url_prefix` without rewriting manifests)

Closes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)