### PR TITLE
chore(ci): shard hypothesis tests across 3 parallel runners

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -277,6 +277,9 @@ jobs:
     if: always()
     needs: [test-hypothesis-shard]
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
     steps:
       - name: Verify all shards passed
         run: |


### PR DESCRIPTION
## Summary

Shards the `test-hypothesis` CI job across 3 parallel free runners using `pytest-shard`. The hypothesis test suite (~11-12 min) is the critical path bottleneck for merging PRs — with 3 shards this should drop to ~4 min.

Changes:
- Split `test-hypothesis` into `test-hypothesis-shard` with a 3-way matrix (`--num-shards=3 --shard-id=N`)
- Added `pytest-shard` as a test-time dependency (installed inline via `uv pip install pytest-shard`)
- Per-shard hypothesis cache keys so the hypothesis database doesn't conflict across shards
- Thin `test-hypothesis` aggregation job that gates on all shards passing — preserves the required check name so branch protection rules don't need updating

## Context

Analysis showed the merge-blocking critical path is **~18-19 min**, gated entirely on Python Check:
- `build-wheels`: ~6 min (Rust/maturin compilation)
- `test-hypothesis`: ~12 min (11 min of actual hypothesis property tests after wheels)

All other required checks (Rust CI, Code Quality, Codespell) complete in under 3 min. Sharding the hypothesis tests is the highest-leverage zero-cost optimization — no paid runners needed.

## Risk level

Low. The change only affects CI workflow structure. `pytest-shard` is a lightweight, well-understood plugin that deterministically assigns tests to shards by hashing node IDs. The aggregation job ensures the existing required check name is preserved.

[This is Claude Code on behalf of Samantha Hughes]