### PR TITLE
Show effective default values in config reprs

### DIFF
--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -943,11 +943,46 @@ impl PyRepr for PyCachingConfig {
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
         let d = CachingConfig::default();
         vec![
-            ("num_snapshot_nodes", py_option_or_default(&self.num_snapshot_nodes, &d.num_snapshot_nodes().to_string(), mode)),
-            ("num_chunk_refs", py_option_or_default(&self.num_chunk_refs, &d.num_chunk_refs().to_string(), mode)),
-            ("num_transaction_changes", py_option_or_default(&self.num_transaction_changes, &d.num_transaction_changes().to_string(), mode)),
-            ("num_bytes_attributes", py_option_or_default(&self.num_bytes_attributes, &d.num_bytes_attributes().to_string(), mode)),
-            ("num_bytes_chunks", py_option_or_default(&self.num_bytes_chunks, &d.num_bytes_chunks().to_string(), mode)),
+            (
+                "num_snapshot_nodes",
+                py_option_or_default(
+                    &self.num_snapshot_nodes,
+                    &d.num_snapshot_nodes().to_string(),
+                    mode,
+                ),
+            ),
+            (
+                "num_chunk_refs",
+                py_option_or_default(
+                    &self.num_chunk_refs,
+                    &d.num_chunk_refs().to_string(),
+                    mode,
+                ),
+            ),
+            (
+                "num_transaction_changes",
+                py_option_or_default(
+                    &self.num_transaction_changes,
+                    &d.num_transaction_changes().to_string(),
+                    mode,
+                ),
+            ),
+            (
+                "num_bytes_attributes",
+                py_option_or_default(
+                    &self.num_bytes_attributes,
+                    &d.num_bytes_attributes().to_string(),
+                    mode,
+                ),
+            ),
+            (
+                "num_bytes_chunks",
+                py_option_or_default(
+                    &self.num_bytes_chunks,
+                    &d.num_bytes_chunks().to_string(),
+                    mode,
+                ),
+            ),
         ]
     }
 }
@@ -1054,9 +1089,26 @@ impl PyRepr for PyStorageRetriesSettings {
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
         let d = RetriesSettings::default();
         vec![
-            ("max_tries", py_option_or_default(&self.max_tries, &d.max_tries().to_string(), mode)),
-            ("initial_backoff_ms", py_option_or_default(&self.initial_backoff_ms, &d.initial_backoff_ms().to_string(), mode)),
-            ("max_backoff_ms", py_option_or_default(&self.max_backoff_ms, &d.max_backoff_ms().to_string(), mode)),
+            (
+                "max_tries",
+                py_option_or_default(&self.max_tries, &d.max_tries().to_string(), mode),
+            ),
+            (
+                "initial_backoff_ms",
+                py_option_or_default(
+                    &self.initial_backoff_ms,
+                    &d.initial_backoff_ms().to_string(),
+                    mode,
+                ),
+            ),
+            (
+                "max_backoff_ms",
+                py_option_or_default(
+                    &self.max_backoff_ms,
+                    &d.max_backoff_ms().to_string(),
+                    mode,
+                ),
+            ),
         ]
     }
 }
@@ -1207,11 +1259,12 @@ impl PyRepr for PyRepoUpdateRetryConfig {
         "icechunk.config.RepoUpdateRetryConfig"
     }
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
-        vec![("default", py_option_nested_repr_or_default(
-            &self.default,
-            mode,
-            || RepoUpdateRetryConfig::default().retries().clone().into(),
-        ))]
+        vec![(
+            "default",
+            py_option_nested_repr_or_default(&self.default, mode, || {
+                RepoUpdateRetryConfig::default().retries().clone().into()
+            }),
+        )]
     }
 }
 
@@ -1271,11 +1324,19 @@ impl PyRepr for PyStorageConcurrencySettings {
         vec![
             (
                 "max_concurrent_requests_for_object",
-                py_option_or_default(&self.max_concurrent_requests_for_object, &d.max_concurrent_requests_for_object().to_string(), mode),
+                py_option_or_default(
+                    &self.max_concurrent_requests_for_object,
+                    &d.max_concurrent_requests_for_object().to_string(),
+                    mode,
+                ),
             ),
             (
                 "ideal_concurrent_request_size",
-                py_option_or_default(&self.ideal_concurrent_request_size, &d.ideal_concurrent_request_size().to_string(), mode),
+                py_option_or_default(
+                    &self.ideal_concurrent_request_size,
+                    &d.ideal_concurrent_request_size().to_string(),
+                    mode,
+                ),
             ),
         ]
     }
@@ -1395,25 +1456,51 @@ impl PyRepr for PyStorageSettings {
         vec![
             (
                 "unsafe_use_conditional_create",
-                py_option_bool_or_default(&self.unsafe_use_conditional_create, d.unsafe_use_conditional_create(), mode),
+                py_option_bool_or_default(
+                    &self.unsafe_use_conditional_create,
+                    d.unsafe_use_conditional_create(),
+                    mode,
+                ),
             ),
             (
                 "unsafe_use_conditional_update",
-                py_option_bool_or_default(&self.unsafe_use_conditional_update, d.unsafe_use_conditional_update(), mode),
+                py_option_bool_or_default(
+                    &self.unsafe_use_conditional_update,
+                    d.unsafe_use_conditional_update(),
+                    mode,
+                ),
             ),
             (
                 "unsafe_use_metadata",
-                py_option_bool_or_default(&self.unsafe_use_metadata, d.unsafe_use_metadata(), mode),
+                py_option_bool_or_default(
+                    &self.unsafe_use_metadata,
+                    d.unsafe_use_metadata(),
+                    mode,
+                ),
             ),
             ("storage_class", py_option_str(&self.storage_class)),
             ("metadata_storage_class", py_option_str(&self.metadata_storage_class)),
             ("chunks_storage_class", py_option_str(&self.chunks_storage_class)),
             (
                 "minimum_size_for_multipart_upload",
-                py_option_or_default(&self.minimum_size_for_multipart_upload, &d.minimum_size_for_multipart_upload().to_string(), mode),
+                py_option_or_default(
+                    &self.minimum_size_for_multipart_upload,
+                    &d.minimum_size_for_multipart_upload().to_string(),
+                    mode,
+                ),
             ),
-            ("concurrency", py_option_nested_repr_or_default(&self.concurrency, mode, || ConcurrencySettings::default().into())),
-            ("retries", py_option_nested_repr_or_default(&self.retries, mode, || RetriesSettings::default().into())),
+            (
+                "concurrency",
+                py_option_nested_repr_or_default(&self.concurrency, mode, || {
+                    ConcurrencySettings::default().into()
+                }),
+            ),
+            (
+                "retries",
+                py_option_nested_repr_or_default(&self.retries, mode, || {
+                    RetriesSettings::default().into()
+                }),
+            ),
             ("timeouts", py_option_nested_repr(&self.timeouts, mode)),
         ]
     }
@@ -1643,9 +1730,23 @@ impl PyRepr for PyManifestPreloadConfig {
             Some(py_obj) => Python::attach(|py| py_obj.borrow(py).render(mode)),
         };
         vec![
-            ("max_total_refs", py_option_or_default(&self.max_total_refs, &d.max_total_refs().to_string(), mode)),
+            (
+                "max_total_refs",
+                py_option_or_default(
+                    &self.max_total_refs,
+                    &d.max_total_refs().to_string(),
+                    mode,
+                ),
+            ),
             ("preload_if", preload_if),
-            ("max_arrays_to_scan", py_option_or_default(&self.max_arrays_to_scan, &d.max_arrays_to_scan().to_string(), mode)),
+            (
+                "max_arrays_to_scan",
+                py_option_or_default(
+                    &self.max_arrays_to_scan,
+                    &d.max_arrays_to_scan().to_string(),
+                    mode,
+                ),
+            ),
         ]
     }
 }
@@ -2019,13 +2120,38 @@ impl PyRepr for PyManifestVirtualChunkLocationCompressionConfig {
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
         let d = ManifestVirtualChunkLocationCompressionConfig::default();
         vec![
-            ("min_num_chunks", py_option_or_default(&self.min_num_chunks, &d.min_num_chunks().to_string(), mode)),
+            (
+                "min_num_chunks",
+                py_option_or_default(
+                    &self.min_num_chunks,
+                    &d.min_num_chunks().to_string(),
+                    mode,
+                ),
+            ),
             (
                 "dictionary_max_training_samples",
-                py_option_or_default(&self.dictionary_max_training_samples, &d.dictionary_max_training_samples().to_string(), mode),
+                py_option_or_default(
+                    &self.dictionary_max_training_samples,
+                    &d.dictionary_max_training_samples().to_string(),
+                    mode,
+                ),
             ),
-            ("dictionary_max_size_bytes", py_option_or_default(&self.dictionary_max_size_bytes, &d.dictionary_max_size_bytes().to_string(), mode)),
-            ("compression_level", py_option_or_default(&self.compression_level, &d.compression_level().to_string(), mode)),
+            (
+                "dictionary_max_size_bytes",
+                py_option_or_default(
+                    &self.dictionary_max_size_bytes,
+                    &d.dictionary_max_size_bytes().to_string(),
+                    mode,
+                ),
+            ),
+            (
+                "compression_level",
+                py_option_or_default(
+                    &self.compression_level,
+                    &d.compression_level().to_string(),
+                    mode,
+                ),
+            ),
         ]
     }
 }
@@ -2112,11 +2238,25 @@ impl PyRepr for PyManifestConfig {
     }
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
         vec![
-            ("preload", py_option_nested_repr_or_default(&self.preload, mode, || ManifestPreloadConfig::default().into())),
-            ("splitting", py_option_nested_repr_or_default(&self.splitting, mode, || ManifestSplittingConfig::default().into())),
+            (
+                "preload",
+                py_option_nested_repr_or_default(&self.preload, mode, || {
+                    ManifestPreloadConfig::default().into()
+                }),
+            ),
+            (
+                "splitting",
+                py_option_nested_repr_or_default(&self.splitting, mode, || {
+                    ManifestSplittingConfig::default().into()
+                }),
+            ),
             (
                 "virtual_chunk_location_compression",
-                py_option_nested_repr_or_default(&self.virtual_chunk_location_compression, mode, || ManifestVirtualChunkLocationCompressionConfig::default().into()),
+                py_option_nested_repr_or_default(
+                    &self.virtual_chunk_location_compression,
+                    mode,
+                    || ManifestVirtualChunkLocationCompressionConfig::default().into(),
+                ),
             ),
         ]
     }
@@ -2372,24 +2512,60 @@ impl PyRepr for PyRepositoryConfig {
         vec![
             (
                 "inline_chunk_threshold_bytes",
-                py_option_or_default(&self.inline_chunk_threshold_bytes, &d.inline_chunk_threshold_bytes().to_string(), mode),
+                py_option_or_default(
+                    &self.inline_chunk_threshold_bytes,
+                    &d.inline_chunk_threshold_bytes().to_string(),
+                    mode,
+                ),
             ),
             (
                 "get_partial_values_concurrency",
-                py_option_or_default(&self.get_partial_values_concurrency, &d.get_partial_values_concurrency().to_string(), mode),
+                py_option_or_default(
+                    &self.get_partial_values_concurrency,
+                    &d.get_partial_values_concurrency().to_string(),
+                    mode,
+                ),
             ),
-            ("max_concurrent_requests", py_option_or_default(&self.max_concurrent_requests, &d.max_concurrent_requests().to_string(), mode)),
+            (
+                "max_concurrent_requests",
+                py_option_or_default(
+                    &self.max_concurrent_requests,
+                    &d.max_concurrent_requests().to_string(),
+                    mode,
+                ),
+            ),
             (
                 "num_updates_per_repo_info_file",
-                py_option_or_default(&self.num_updates_per_repo_info_file, &d.num_updates_per_repo_info_file().to_string(), mode),
+                py_option_or_default(
+                    &self.num_updates_per_repo_info_file,
+                    &d.num_updates_per_repo_info_file().to_string(),
+                    mode,
+                ),
             ),
-            ("compression", py_option_nested_repr_or_default(&self.compression, mode, || CompressionConfig::default().into())),
-            ("caching", py_option_nested_repr_or_default(&self.caching, mode, || CachingConfig::default().into())),
+            (
+                "compression",
+                py_option_nested_repr_or_default(&self.compression, mode, || {
+                    CompressionConfig::default().into()
+                }),
+            ),
+            (
+                "caching",
+                py_option_nested_repr_or_default(&self.caching, mode, || {
+                    CachingConfig::default().into()
+                }),
+            ),
             ("storage", py_option_nested_repr(&self.storage, mode)),
-            ("manifest", py_option_nested_repr_or_default(&self.manifest, mode, || ManifestConfig::default().into())),
+            (
+                "manifest",
+                py_option_nested_repr_or_default(&self.manifest, mode, || {
+                    ManifestConfig::default().into()
+                }),
+            ),
             (
                 "repo_update_retries",
-                py_option_nested_repr_or_default(&self.repo_update_retries, mode, || RepoUpdateRetryConfig::default().into()),
+                py_option_nested_repr_or_default(&self.repo_update_retries, mode, || {
+                    RepoUpdateRetryConfig::default().into()
+                }),
             ),
             ("virtual_chunk_containers", vccs),
         ]

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1051,11 +1051,12 @@ impl PyRepr for PyStorageRetriesSettings {
     fn cls_name() -> &'static str {
         "icechunk.storage.StorageRetriesSettings"
     }
-    fn fields(&self, _mode: ReprMode) -> Vec<(&str, String)> {
+    fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let d = RetriesSettings::default();
         vec![
-            ("max_tries", py_option(&self.max_tries)),
-            ("initial_backoff_ms", py_option(&self.initial_backoff_ms)),
-            ("max_backoff_ms", py_option(&self.max_backoff_ms)),
+            ("max_tries", py_option_or_default(&self.max_tries, &d.max_tries().to_string(), mode)),
+            ("initial_backoff_ms", py_option_or_default(&self.initial_backoff_ms, &d.initial_backoff_ms().to_string(), mode)),
+            ("max_backoff_ms", py_option_or_default(&self.max_backoff_ms, &d.max_backoff_ms().to_string(), mode)),
         ]
     }
 }
@@ -1261,15 +1262,16 @@ impl PyRepr for PyStorageConcurrencySettings {
     fn cls_name() -> &'static str {
         "icechunk.storage.StorageConcurrencySettings"
     }
-    fn fields(&self, _mode: ReprMode) -> Vec<(&str, String)> {
+    fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let d = ConcurrencySettings::default();
         vec![
             (
                 "max_concurrent_requests_for_object",
-                py_option(&self.max_concurrent_requests_for_object),
+                py_option_or_default(&self.max_concurrent_requests_for_object, &d.max_concurrent_requests_for_object().to_string(), mode),
             ),
             (
                 "ideal_concurrent_request_size",
-                py_option(&self.ideal_concurrent_request_size),
+                py_option_or_default(&self.ideal_concurrent_request_size, &d.ideal_concurrent_request_size().to_string(), mode),
             ),
         ]
     }
@@ -1384,35 +1386,30 @@ impl PyRepr for PyStorageSettings {
         "icechunk.storage.StorageSettings"
     }
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let d = storage::Settings::default();
         // Scalar fields first, then nested objects
         vec![
             (
                 "unsafe_use_conditional_create",
-                self.unsafe_use_conditional_create
-                    .map(py_bool)
-                    .unwrap_or_else(|| "None".to_string()),
+                py_option_bool_or_default(&self.unsafe_use_conditional_create, d.unsafe_use_conditional_create(), mode),
             ),
             (
                 "unsafe_use_conditional_update",
-                self.unsafe_use_conditional_update
-                    .map(py_bool)
-                    .unwrap_or_else(|| "None".to_string()),
+                py_option_bool_or_default(&self.unsafe_use_conditional_update, d.unsafe_use_conditional_update(), mode),
             ),
             (
                 "unsafe_use_metadata",
-                self.unsafe_use_metadata
-                    .map(py_bool)
-                    .unwrap_or_else(|| "None".to_string()),
+                py_option_bool_or_default(&self.unsafe_use_metadata, d.unsafe_use_metadata(), mode),
             ),
             ("storage_class", py_option_str(&self.storage_class)),
             ("metadata_storage_class", py_option_str(&self.metadata_storage_class)),
             ("chunks_storage_class", py_option_str(&self.chunks_storage_class)),
             (
                 "minimum_size_for_multipart_upload",
-                py_option(&self.minimum_size_for_multipart_upload),
+                py_option_or_default(&self.minimum_size_for_multipart_upload, &d.minimum_size_for_multipart_upload().to_string(), mode),
             ),
-            ("concurrency", py_option_nested_repr(&self.concurrency, mode)),
-            ("retries", py_option_nested_repr(&self.retries, mode)),
+            ("concurrency", py_option_nested_repr_or_default(&self.concurrency, mode, || ConcurrencySettings::default().into())),
+            ("retries", py_option_nested_repr_or_default(&self.retries, mode, || RetriesSettings::default().into())),
             ("timeouts", py_option_nested_repr(&self.timeouts, mode)),
         ]
     }

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1633,14 +1633,15 @@ impl PyRepr for PyManifestPreloadConfig {
         "icechunk.config.ManifestPreloadConfig"
     }
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let d = ManifestPreloadConfig::default();
         let preload_if = match &self.preload_if {
             None => "None".to_string(),
             Some(py_obj) => Python::attach(|py| py_obj.borrow(py).render(mode)),
         };
         vec![
-            ("max_total_refs", py_option(&self.max_total_refs)),
+            ("max_total_refs", py_option_or_default(&self.max_total_refs, &d.max_total_refs().to_string(), mode)),
             ("preload_if", preload_if),
-            ("max_arrays_to_scan", py_option(&self.max_arrays_to_scan)),
+            ("max_arrays_to_scan", py_option_or_default(&self.max_arrays_to_scan, &d.max_arrays_to_scan().to_string(), mode)),
         ]
     }
 }
@@ -2011,15 +2012,16 @@ impl PyRepr for PyManifestVirtualChunkLocationCompressionConfig {
     fn cls_name() -> &'static str {
         "icechunk.config.ManifestVirtualChunkLocationCompressionConfig"
     }
-    fn fields(&self, _mode: ReprMode) -> Vec<(&str, String)> {
+    fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let d = ManifestVirtualChunkLocationCompressionConfig::default();
         vec![
-            ("min_num_chunks", py_option(&self.min_num_chunks)),
+            ("min_num_chunks", py_option_or_default(&self.min_num_chunks, &d.min_num_chunks().to_string(), mode)),
             (
                 "dictionary_max_training_samples",
-                py_option(&self.dictionary_max_training_samples),
+                py_option_or_default(&self.dictionary_max_training_samples, &d.dictionary_max_training_samples().to_string(), mode),
             ),
-            ("dictionary_max_size_bytes", py_option(&self.dictionary_max_size_bytes)),
-            ("compression_level", py_option(&self.compression_level)),
+            ("dictionary_max_size_bytes", py_option_or_default(&self.dictionary_max_size_bytes, &d.dictionary_max_size_bytes().to_string(), mode)),
+            ("compression_level", py_option_or_default(&self.compression_level, &d.compression_level().to_string(), mode)),
         ]
     }
 }
@@ -2106,11 +2108,11 @@ impl PyRepr for PyManifestConfig {
     }
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
         vec![
-            ("preload", py_option_nested_repr(&self.preload, mode)),
-            ("splitting", py_option_nested_repr(&self.splitting, mode)),
+            ("preload", py_option_nested_repr_or_default(&self.preload, mode, || ManifestPreloadConfig::default().into())),
+            ("splitting", py_option_nested_repr_or_default(&self.splitting, mode, || ManifestSplittingConfig::default().into())),
             (
                 "virtual_chunk_location_compression",
-                py_option_nested_repr(&self.virtual_chunk_location_compression, mode),
+                py_option_nested_repr_or_default(&self.virtual_chunk_location_compression, mode, || ManifestVirtualChunkLocationCompressionConfig::default().into()),
             ),
         ]
     }

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -856,16 +856,24 @@ impl PyRepr for PyCompressionConfig {
     fn cls_name() -> &'static str {
         "icechunk.config.CompressionConfig"
     }
-    fn fields(&self, _mode: ReprMode) -> Vec<(&str, String)> {
+    fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let defaults = CompressionConfig::default();
         vec![
             (
                 "algorithm",
-                self.algorithm
-                    .as_ref()
-                    .map(|a| format!("{a:?}"))
-                    .unwrap_or_else(|| "None".to_string()),
+                match (&self.algorithm, mode) {
+                    (Some(a), _) => format!("{a:?}"),
+                    (None, ReprMode::Repr) => "None".to_string(),
+                    (None, _) => {
+                        let alg: PyCompressionAlgorithm = defaults.algorithm().into();
+                        format!("{alg:?} (default)")
+                    }
+                },
             ),
-            ("level", py_option(&self.level)),
+            (
+                "level",
+                py_option_or_default(&self.level, &defaults.level().to_string(), mode),
+            ),
         ]
     }
 }
@@ -932,13 +940,14 @@ impl PyRepr for PyCachingConfig {
         "icechunk.config.CachingConfig"
     }
 
-    fn fields(&self, _mode: ReprMode) -> Vec<(&str, String)> {
+    fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
+        let d = CachingConfig::default();
         vec![
-            ("num_snapshot_nodes", py_option(&self.num_snapshot_nodes)),
-            ("num_chunk_refs", py_option(&self.num_chunk_refs)),
-            ("num_transaction_changes", py_option(&self.num_transaction_changes)),
-            ("num_bytes_attributes", py_option(&self.num_bytes_attributes)),
-            ("num_bytes_chunks", py_option(&self.num_bytes_chunks)),
+            ("num_snapshot_nodes", py_option_or_default(&self.num_snapshot_nodes, &d.num_snapshot_nodes().to_string(), mode)),
+            ("num_chunk_refs", py_option_or_default(&self.num_chunk_refs, &d.num_chunk_refs().to_string(), mode)),
+            ("num_transaction_changes", py_option_or_default(&self.num_transaction_changes, &d.num_transaction_changes().to_string(), mode)),
+            ("num_bytes_attributes", py_option_or_default(&self.num_bytes_attributes, &d.num_bytes_attributes().to_string(), mode)),
+            ("num_bytes_chunks", py_option_or_default(&self.num_bytes_chunks, &d.num_bytes_chunks().to_string(), mode)),
         ]
     }
 }

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1262,7 +1262,7 @@ impl PyRepr for PyRepoUpdateRetryConfig {
         vec![(
             "default",
             py_option_nested_repr_or_default(&self.default, mode, || {
-                RepoUpdateRetryConfig::default().retries().clone().into()
+                (*RepoUpdateRetryConfig::default().retries()).into()
             }),
         )]
     }

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -1207,7 +1207,11 @@ impl PyRepr for PyRepoUpdateRetryConfig {
         "icechunk.config.RepoUpdateRetryConfig"
     }
     fn fields(&self, mode: ReprMode) -> Vec<(&str, String)> {
-        vec![("default", py_option_nested_repr(&self.default, mode))]
+        vec![("default", py_option_nested_repr_or_default(
+            &self.default,
+            mode,
+            || RepoUpdateRetryConfig::default().retries().clone().into(),
+        ))]
     }
 }
 
@@ -2364,27 +2368,28 @@ impl PyRepr for PyRepositoryConfig {
                 out
             }
         };
+        let d = RepositoryConfig::default();
         vec![
             (
                 "inline_chunk_threshold_bytes",
-                py_option(&self.inline_chunk_threshold_bytes),
+                py_option_or_default(&self.inline_chunk_threshold_bytes, &d.inline_chunk_threshold_bytes().to_string(), mode),
             ),
             (
                 "get_partial_values_concurrency",
-                py_option(&self.get_partial_values_concurrency),
+                py_option_or_default(&self.get_partial_values_concurrency, &d.get_partial_values_concurrency().to_string(), mode),
             ),
-            ("max_concurrent_requests", py_option(&self.max_concurrent_requests)),
+            ("max_concurrent_requests", py_option_or_default(&self.max_concurrent_requests, &d.max_concurrent_requests().to_string(), mode)),
             (
                 "num_updates_per_repo_info_file",
-                py_option(&self.num_updates_per_repo_info_file),
+                py_option_or_default(&self.num_updates_per_repo_info_file, &d.num_updates_per_repo_info_file().to_string(), mode),
             ),
-            ("compression", py_option_nested_repr(&self.compression, mode)),
-            ("caching", py_option_nested_repr(&self.caching, mode)),
+            ("compression", py_option_nested_repr_or_default(&self.compression, mode, || CompressionConfig::default().into())),
+            ("caching", py_option_nested_repr_or_default(&self.caching, mode, || CachingConfig::default().into())),
             ("storage", py_option_nested_repr(&self.storage, mode)),
-            ("manifest", py_option_nested_repr(&self.manifest, mode)),
+            ("manifest", py_option_nested_repr_or_default(&self.manifest, mode, || ManifestConfig::default().into())),
             (
                 "repo_update_retries",
-                py_option_nested_repr(&self.repo_update_retries, mode),
+                py_option_nested_repr_or_default(&self.repo_update_retries, mode, || RepoUpdateRetryConfig::default().into()),
             ),
             ("virtual_chunk_containers", vccs),
         ]

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -36,7 +36,8 @@ use pyo3::{
 
 use crate::display::{
     PyRepr, ReprMode, dataclass_html_repr, dataclass_str, py_bool, py_option,
-    py_option_nested_repr, py_option_str,
+    py_option_bool_or_default, py_option_nested_repr, py_option_nested_repr_or_default,
+    py_option_or_default, py_option_str,
 };
 use crate::errors::PyIcechunkStoreError;
 

--- a/icechunk-python/src/display.rs
+++ b/icechunk-python/src/display.rs
@@ -37,9 +37,44 @@ pub(crate) fn py_option_str(o: &Option<String>) -> String {
     }
 }
 
+/// Format an `Option<T>` showing the effective default in human-readable modes.
+///
+/// - `Repr` mode: `"None"` (preserves round-trip fidelity for `eval(repr(x))`)
+/// - `Str` / `Html` mode: `"<default> (default)"` when `None`, or the value when `Some`
+pub(crate) fn py_option_or_default<T: Display>(
+    o: &Option<T>,
+    default: &str,
+    mode: ReprMode,
+) -> String {
+    match o {
+        Some(v) => v.to_string(),
+        None => match mode {
+            ReprMode::Repr => "None".to_string(),
+            ReprMode::Str | ReprMode::Html => format!("{default} (default)"),
+        },
+    }
+}
+
 /// Format a bool as a Python literal (`True` / `False`).
 pub(crate) fn py_bool(b: bool) -> String {
     if b { "True" } else { "False" }.to_string()
+}
+
+/// Format an `Option<bool>` showing the effective default in human-readable modes.
+pub(crate) fn py_option_bool_or_default(
+    o: &Option<bool>,
+    default: bool,
+    mode: ReprMode,
+) -> String {
+    match o {
+        Some(b) => py_bool(*b),
+        None => match mode {
+            ReprMode::Repr => "None".to_string(),
+            ReprMode::Str | ReprMode::Html => {
+                format!("{} (default)", py_bool(default))
+            }
+        },
+    }
 }
 
 /// Trait for Python repr/str/html methods on icechunk classes.
@@ -119,6 +154,28 @@ pub(crate) fn py_option_nested_repr<T: PyRepr + PyClass>(
     match opt {
         None => "None".to_string(),
         Some(py_obj) => Python::attach(|py| py_obj.borrow(py).render(mode)),
+    }
+}
+
+/// Like [`py_option_nested_repr`], but when the value is `None`, renders the
+/// effective default in human-readable modes (`Str` / `Html`).
+///
+/// The `make_default` closure constructs a default instance of the Python wrapper
+/// type (typically via `RustConfig::default().into()`). The default instance's own
+/// `fields()` method then shows per-field defaults recursively.
+///
+/// `Repr` mode still returns `"None"` to preserve `eval(repr(x))` round-trips.
+pub(crate) fn py_option_nested_repr_or_default<T: PyRepr + PyClass>(
+    opt: &Option<Py<T>>,
+    mode: ReprMode,
+    make_default: impl FnOnce() -> T,
+) -> String {
+    match opt {
+        Some(py_obj) => Python::attach(|py| py_obj.borrow(py).render(mode)),
+        None => match mode {
+            ReprMode::Repr => "None".to_string(),
+            _ => make_default().render(mode),
+        },
     }
 }
 

--- a/icechunk-python/tests/test_display.py
+++ b/icechunk-python/tests/test_display.py
@@ -252,6 +252,10 @@ class TestStr:
         str_str = str(config)
         assert "<icechunk.config.CachingConfig>" in str_str
         assert "num_snapshot_nodes: 100" in str_str
+        # Explicitly set value should not show (default)
+        assert "(default)" not in str_str.split("num_snapshot_nodes")[1].split("\n")[0]
+        # Unset fields should show their effective defaults
+        assert "15000000 (default)" in str_str  # num_chunk_refs
 
     def test_storage_settings(self) -> None:
         ss = StorageSettings(retries=StorageRetriesSettings(max_tries=5))
@@ -259,6 +263,8 @@ class TestStr:
         assert "<icechunk.storage.StorageSettings>" in str_str
         assert "retries:" in str_str
         assert "max_tries: 5" in str_str
+        # Bool defaults should show effective values
+        assert "True (default)" in str_str  # unsafe_use_conditional_create etc.
 
     def test_manifest_preload_condition(self) -> None:
         cond = ManifestPreloadCondition.name_matches("foo")
@@ -299,6 +305,8 @@ class TestReprHtml:
         assert '<div class="icechunk-repr">' in html
         assert "num_snapshot_nodes" in html
         assert "100" in html
+        # Unset fields should show defaults in HTML too
+        assert "15000000 (default)" in html
 
     def test_nested_html_uses_details(self) -> None:
         """Nested HTML reprs should use collapsible <details> elements."""
@@ -361,6 +369,17 @@ class TestReprStructural:
         assert "icechunk.config.CompressionConfig(" in repr_str
         assert "Zstd" in repr_str
         assert "level=3" in repr_str
+
+    def test_compression_config_defaults_in_str(self) -> None:
+        """Default CompressionConfig str should show effective defaults."""
+        config = CompressionConfig()
+        str_str = str(config)
+        assert "Zstd (default)" in str_str
+        assert "3 (default)" in str_str
+        # repr should still show None (round-trip fidelity)
+        repr_str = repr(config)
+        assert "algorithm=None" in repr_str
+        assert "(default)" not in repr_str
 
     def test_s3_options_shows_all_fields(self) -> None:
         opts = S3Options(region="us-east-1", allow_http=True, requester_pays=True)
@@ -450,6 +469,13 @@ class TestReprStructural:
         assert "repo_update_retries" in repr_str
         assert "num_updates_per_repo_info_file" in repr_str
         assert "virtual_chunk_containers" in repr_str
+        # str should show scalar defaults and expand nested default configs
+        str_str = str(config)
+        assert "512 (default)" in str_str  # inline_chunk_threshold_bytes
+        assert "256 (default)" in str_str  # max_concurrent_requests
+        # Nested defaults should be expanded
+        assert "Zstd (default)" in str_str  # from CompressionConfig
+        assert "500000 (default)" in str_str  # from CachingConfig
 
     def test_repository_config_shows_virtual_chunk_containers(self) -> None:
         config = RepositoryConfig()


### PR DESCRIPTION
## Summary

- `__str__` and `_repr_html_` now show the effective default value with a `(default)` annotation for unset config fields, instead of `None`
- `__repr__` remains unchanged (`None`) so `eval(repr(x))` round-trips still work
- Nested default configs (compression, caching, manifest, etc.) are fully expanded showing their per-field defaults recursively
- Default values are derived at runtime from the Rust accessor methods (e.g. `CachingConfig::default().num_snapshot_nodes()`), so they can never drift from the actual defaults
- Truly optional fields with no defaults (timeouts, storage_class, etc.) still show `None`

Closes #1980