### PR TITLE
Fix SVG ancestry graph text invisible on dark backgrounds

### DIFF
--- a/icechunk/src/display/svg.rs
+++ b/icechunk/src/display/svg.rs
@@ -186,7 +186,7 @@ impl AncestryGraph {
 
             let _ = writeln!(
                 svg,
-                "  <text x=\"{text_x}\" y=\"{text_y}\">\
+                "  <text x=\"{text_x}\" y=\"{text_y}\" fill=\"#aaa\">\
                  <tspan fill=\"#888\">{short_id}</tspan>\
                  {labels} {msg}</text>"
             );


### PR DESCRIPTION
Closes #2069
<img width="360" height="157" alt="Screenshot 2026-04-13 at 3 14 28 PM" src="https://github.com/user-attachments/assets/a50d2322-51d3-4df9-8cf1-5cab5f71f6f0" />

Set default `fill="#aaa"` on SVG `<text>` elements so commit messages are visible on both light and dark backgrounds. The message text previously had no fill attribute and defaulted to black.