### PR TITLE
Update to_icechunk mode docstring to match xarray

### DIFF
--- a/icechunk-python/python/icechunk/xarray.py
+++ b/icechunk-python/python/icechunk/xarray.py
@@ -230,14 +230,22 @@ def to_icechunk(
     session : icechunk.Session
         Writable Icechunk Session
     mode : {"w", "w-", "a", "a-", r+", None}, optional
-        Persistence mode: "w" means create (overwrite if exists);
-        "w-" means create (fail if exists);
-        "a" means override all existing variables including dimension coordinates (create if does not exist);
-        "a-" means only append those variables that have ``append_dim``.
-        "r+" means modify existing array *values* only (raise an error if
-        any metadata or shapes would change).
+        Persistence mode:
+
+        - "w" means create (remove old if exists and write new);
+        - "w-" means create (fail if exists);
+        - "a" means override all existing variables including dimension coordinates (create if does not exist);
+        - "a-" means only append those variables that have ``append_dim``.
+        - "r+" means modify existing array *values* only (raise an error if
+          any metadata or shapes would change).
+
         The default mode is "a" if ``append_dim`` is set. Otherwise, it is
         "r+" if ``region`` is set and ``w-`` otherwise.
+
+        .. note::
+            When modifying an existing Zarr array that is lazily opened, the "w"
+            behavior can be surprising since the underlying file that is being
+            lazily read from might get deleted before the data is computed.
     group : str, optional
         Group path. (a.k.a. `path` in zarr terminology.)
     encoding : dict, optional


### PR DESCRIPTION
@ianhi 's bot was [complaining](https://github.com/earth-mover/icechunk/actions/runs/24366022151/job/71157904552?pr=2049) because xarray [modified](https://github.com/pydata/xarray/pull/11229) their `.to_zarr` docstring slightly - this updates ours to match.