### PR TITLE
fix: skip empty paths in set_virtual_refs_arr

### DIFF
--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -392,7 +392,8 @@ class IcechunkStore(Store, SyncMixin):
             The product must equal the length of the arrays.
             Arrays are assumed to be flattened in C (row-major) order.
         locations : list[str]
-            URLs to external files containing chunk data.
+            URLs to external files containing chunk data. Empty strings
+            represent missing chunks and are silently skipped.
             Example: ["s3://bucket/file1.nc", "s3://bucket/file2.nc"]
         offsets : np.ndarray
             1-D uint64 array of byte offsets within each file.
@@ -457,7 +458,8 @@ class IcechunkStore(Store, SyncMixin):
             The product must equal the length of the arrays.
             Arrays are assumed to be flattened in C (row-major) order.
         locations : list[str]
-            URLs to external files containing chunk data.
+            URLs to external files containing chunk data. Empty strings
+            represent missing chunks and are silently skipped.
             Example: ["s3://bucket/file1.nc", "s3://bucket/file2.nc"]
         offsets : np.ndarray
             1-D uint64 array of byte offsets within each file.

--- a/icechunk-python/src/virtualrefs.rs
+++ b/icechunk-python/src/virtualrefs.rs
@@ -57,6 +57,14 @@ pub(crate) fn build_vrefs_from_arrays(
         .map(|i| {
             let loc_item = locations.get_item(i)?;
             let loc_str: &str = loc_item.extract()?;
+            // Empty paths represent missing chunks — skip them.
+            // We use empty strings rather than Option/None because callers
+            // (e.g. VirtualiZarr) store paths in numpy StringDType arrays,
+            // which can be passed via `.tolist()` directly. Using None would
+            // require a Python loop to convert empty strings to None first.
+            if loc_str.is_empty() {
+                return Ok(None);
+            }
             let location = VirtualChunkLocation::from_url(loc_str)
                 .map_err(PyIcechunkStoreError::from)?;
             let indices = flat_to_nd_indices(i, chunk_grid_shape, arr_offset);
@@ -66,8 +74,9 @@ pub(crate) fn build_vrefs_from_arrays(
                 length: lengths[i],
                 checksum: checksum.clone(),
             };
-            Ok((indices, vref))
+            Ok(Some((indices, vref)))
         })
+        .filter_map(|r| r.transpose())
         .collect()
 }
 

--- a/icechunk-python/tests/test_virtual_ref.py
+++ b/icechunk-python/tests/test_virtual_ref.py
@@ -492,6 +492,33 @@ def test_cannot_write_invalid_urls(any_spec_version: int | None) -> None:
         )
 
 
+def test_set_virtual_refs_arr_skips_empty_paths() -> None:
+    """Empty paths represent missing chunks and should be silently skipped."""
+    repo = Repository.create(storage=in_memory_storage())
+    session = repo.writable_session("main")
+    store = session.store
+
+    zarr.create_array(store, shape=(3,), chunks=(1,), dtype="i4", compressors=None)
+    session.commit("init")
+
+    session = repo.writable_session("main")
+    store = session.store
+
+    # locations[1] is empty — should be skipped, not raise an error
+    store.set_virtual_refs_arr(
+        array_path="/",
+        chunk_grid_shape=(3,),
+        locations=["s3://bucket/a.nc", "", "s3://bucket/c.nc"],
+        offsets=np.array([0, 0, 0], dtype=np.uint64),
+        lengths=np.array([4, 0, 4], dtype=np.uint64),
+        validate_containers=False,
+    )
+
+    # Only the two non-empty chunks should have been written
+    locations = session.all_virtual_chunk_locations()
+    assert sorted(locations) == ["s3://bucket/a.nc", "s3://bucket/c.nc"]
+
+
 @pytest.mark.filterwarnings("ignore:datetime.datetime.utcnow")
 async def test_write_minio_virtual_refs_with_vcc_urls(
     any_spec_version: int | None,


### PR DESCRIPTION
## Summary

This basically moves a python `for...if` in virtualizarr ([here](https://github.com/zarr-developers/VirtualiZarr/blob/3065bcd7b35079d70daf2e7ba969d3c54f843b46/virtualizarr/manifests/manifest.py#L463), called from [here](https://github.com/zarr-developers/VirtualiZarr/blob/3065bcd7b35079d70daf2e7ba969d3c54f843b46/virtualizarr/writers/icechunk.py#L578)) into `icechunk-python` rust.

- Skip empty location strings in `set_virtual_refs_arr` instead of raising a URL parse error
- Empty paths represent missing chunks in VirtualiZarr manifests — they should not be written as virtual refs
- Adds a test verifying that only non-empty chunks are written

Found while testing zarr-developers/VirtualiZarr#967.