### PR TITLE
test: extract tree model from hypothesis importing file

### DIFF
--- a/icechunk-python/python/icechunk/testing/models.py
+++ b/icechunk-python/python/icechunk/testing/models.py
@@ -1,10 +1,25 @@
-"""Model stores for comparison testing."""
+"""Models for comparison testing.
+
+ModelStore is a superclass of the zarr memory store with added icechunk
+methods shift_array, move, and utility copy.
+
+The tree descriptors (GroupNode / ArrayNode) are pure data structures.
+Materialization writes it into any zarr store, so the same tree can be
+written to MemoryStore, IcechunkStore, etc. for comparison testing.
+"""
 
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterator
+from dataclasses import dataclass, field
 from typing import Any
 
+import numpy as np
+
+import zarr
+import zarr.abc.store
+import zarr.api.asynchronous
 from zarr.core.buffer import default_buffer_prototype
 from zarr.storage import MemoryStore
 
@@ -75,3 +90,137 @@ class ModelStore(MemoryStore):
             if data is not None:
                 await new_store.set(key, data)
         return new_store
+
+
+# ---------------------------------------------------------------------------
+# Tree descriptor
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArrayNode:
+    shape: tuple[int, ...]
+    dtype: np.dtype
+
+
+@dataclass(frozen=True)
+class GroupNode:
+    children: dict[str, ArrayNode | GroupNode] = field(default_factory=dict)
+
+    def walk(self, prefix: str = "") -> Iterator[tuple[str, Node]]:
+        """Yield ``(path, child)`` for every node, depth-first."""
+        for name, child in self.children.items():
+            p = f"{prefix}/{name}" if prefix else name
+            yield p, child
+            if isinstance(child, GroupNode):
+                yield from child.walk(p)
+
+    def nodes(self, prefix: str = "", *, include_root: bool = False) -> list[str]:
+        """Return paths of all nodes, optionally including root."""
+        root = [prefix] if include_root else []
+        return root + [p for p, _ in self.walk(prefix)]
+
+    def groups(self, prefix: str = "", *, include_root: bool = False) -> list[str]:
+        """Return paths of all group nodes, optionally including root."""
+        root = [prefix] if include_root else []
+        return root + [p for p, c in self.walk(prefix) if isinstance(c, GroupNode)]
+
+    def arrays(self, prefix: str = "") -> list[str]:
+        """Return paths of all array nodes."""
+        return [p for p, c in self.walk(prefix) if isinstance(c, ArrayNode)]
+
+    def materialize(self, store: zarr.abc.store.Store) -> zarr.Group:
+        """Write this tree into *store* and return the root group."""
+        root = zarr.open_group(store, mode="w")
+
+        def _write(group: zarr.Group, node: GroupNode) -> None:
+            for name, child in node.children.items():
+                if isinstance(child, ArrayNode):
+                    group.create_array(name, shape=child.shape, dtype=child.dtype)
+                else:
+                    _write(group.create_group(name), child)
+
+        _write(root, self)
+        return root
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> GroupNode:
+        """Convert a nested dict (with ArrayNode leaves) to a GroupNode tree."""
+        children: dict[str, ArrayNode | GroupNode] = {}
+        for name, value in d.items():
+            if isinstance(value, ArrayNode):
+                children[name] = value
+            else:
+                children[name] = cls.from_dict(value)
+        return cls(children=children)
+
+    @classmethod
+    def from_paths(cls, arrays: set[str], groups: set[str]) -> GroupNode:
+        """Build a GroupNode from flat sets of array and group paths.
+
+        Example::
+
+            GroupNode.from_paths(
+                arrays={"a/x", "b"},
+                groups={"a"},
+            )
+        """
+        tree: dict[str, Any] = {}
+        for path in sorted(groups - {""}):
+            current = tree
+            for part in path.split("/"):
+                current = current.setdefault(part, {})
+        for path in sorted(arrays):
+            parts = path.split("/")
+            current = tree
+            for part in parts[:-1]:
+                current = current.setdefault(part, {})
+            current[parts[-1]] = ArrayNode(shape=(1,), dtype=np.dtype("i4"))
+        return cls.from_dict(tree)
+
+    @classmethod
+    async def from_store_async(cls, store: zarr.abc.store.Store) -> GroupNode:
+        """Build a GroupNode by reading a zarr store's structure.
+
+        Example::
+
+            await GroupNode.from_store_async(some_memory_store)
+        """
+        root = await zarr.api.asynchronous.open_group(store, mode="r")
+        tree: dict[str, Any] = {}
+        async for path, obj in root.members(max_depth=None):
+            parts = path.split("/")
+            current = tree
+            if isinstance(obj, zarr.AsyncArray):
+                for part in parts[:-1]:
+                    current = current.setdefault(part, {})
+                current[parts[-1]] = ArrayNode(shape=obj.shape, dtype=obj.dtype)
+            else:
+                for part in parts:
+                    current = current.setdefault(part, {})
+        return cls.from_dict(tree)
+
+    @classmethod
+    def from_store(cls, store: zarr.abc.store.Store) -> GroupNode:
+        """Build a GroupNode by reading a zarr store's structure.
+
+        Example::
+
+            GroupNode.from_store(some_memory_store)
+        """
+        root = zarr.open_group(store, mode="r")
+        tree: dict[str, Any] = {}
+        for path, obj in root.members(max_depth=None):
+            parts = path.split("/")
+            current = tree
+            if isinstance(obj, zarr.Array):
+                for part in parts[:-1]:
+                    current = current.setdefault(part, {})
+                current[parts[-1]] = ArrayNode(shape=obj.shape, dtype=obj.dtype)
+            else:
+                for part in parts:
+                    current = current.setdefault(part, {})
+        return cls.from_dict(tree)
+
+
+Node = ArrayNode | GroupNode

--- a/icechunk-python/python/icechunk/testing/trees.py
+++ b/icechunk-python/python/icechunk/testing/trees.py
@@ -1,8 +1,5 @@
 """Zarr tree descriptors, materialization, and Hypothesis strategies.
 
-The tree descriptor (GroupNode / ArrayNode) is a pure data structure.
-Materialization writes it into any zarr store, so the same tree can be
-written to MemoryStore, IcechunkStore, etc. for comparison testing.
 
 The ``trees`` strategy uses st.recursive for tree structure (good
 structural shrinking) and @composite for pool-based name assignment
@@ -11,152 +8,12 @@ that produces realistic prefix collisions (e.g. ``EC-Earth3`` / ``EC-Earth3-Veg`
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from dataclasses import dataclass, field
-from typing import Any
-
 import hypothesis.strategies as st
 import numpy as np
 
-import zarr
-import zarr.abc.store
-import zarr.api.asynchronous
 import zarr.testing.strategies as zrst
+from icechunk.testing.models import ArrayNode, GroupNode, Node
 from zarr.testing.strategies import node_names
-
-# ---------------------------------------------------------------------------
-# Tree descriptor
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ArrayNode:
-    shape: tuple[int, ...]
-    dtype: np.dtype
-
-
-@dataclass(frozen=True)
-class GroupNode:
-    children: dict[str, ArrayNode | GroupNode] = field(default_factory=dict)
-
-    def walk(self, prefix: str = "") -> Iterator[tuple[str, Node]]:
-        """Yield ``(path, child)`` for every node, depth-first."""
-        for name, child in self.children.items():
-            p = f"{prefix}/{name}" if prefix else name
-            yield p, child
-            if isinstance(child, GroupNode):
-                yield from child.walk(p)
-
-    def nodes(self, prefix: str = "", *, include_root: bool = False) -> list[str]:
-        """Return paths of all nodes, optionally including root."""
-        root = [prefix] if include_root else []
-        return root + [p for p, _ in self.walk(prefix)]
-
-    def groups(self, prefix: str = "", *, include_root: bool = False) -> list[str]:
-        """Return paths of all group nodes, optionally including root."""
-        root = [prefix] if include_root else []
-        return root + [p for p, c in self.walk(prefix) if isinstance(c, GroupNode)]
-
-    def arrays(self, prefix: str = "") -> list[str]:
-        """Return paths of all array nodes."""
-        return [p for p, c in self.walk(prefix) if isinstance(c, ArrayNode)]
-
-    def materialize(self, store: zarr.abc.store.Store) -> zarr.Group:
-        """Write this tree into *store* and return the root group."""
-        root = zarr.open_group(store, mode="w")
-
-        def _write(group: zarr.Group, node: GroupNode) -> None:
-            for name, child in node.children.items():
-                if isinstance(child, ArrayNode):
-                    group.create_array(name, shape=child.shape, dtype=child.dtype)
-                else:
-                    _write(group.create_group(name), child)
-
-        _write(root, self)
-        return root
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> GroupNode:
-        """Convert a nested dict (with ArrayNode leaves) to a GroupNode tree."""
-        children: dict[str, ArrayNode | GroupNode] = {}
-        for name, value in d.items():
-            if isinstance(value, ArrayNode):
-                children[name] = value
-            else:
-                children[name] = cls.from_dict(value)
-        return cls(children=children)
-
-    @classmethod
-    def from_paths(cls, arrays: set[str], groups: set[str]) -> GroupNode:
-        """Build a GroupNode from flat sets of array and group paths.
-
-        Example::
-
-            GroupNode.from_paths(
-                arrays={"a/x", "b"},
-                groups={"a"},
-            )
-        """
-        tree: dict[str, Any] = {}
-        for path in sorted(groups - {""}):
-            current = tree
-            for part in path.split("/"):
-                current = current.setdefault(part, {})
-        for path in sorted(arrays):
-            parts = path.split("/")
-            current = tree
-            for part in parts[:-1]:
-                current = current.setdefault(part, {})
-            current[parts[-1]] = ArrayNode(shape=(1,), dtype=np.dtype("i4"))
-        return cls.from_dict(tree)
-
-    @classmethod
-    async def from_store_async(cls, store: zarr.abc.store.Store) -> GroupNode:
-        """Build a GroupNode by reading a zarr store's structure.
-
-        Example::
-
-            await GroupNode.from_store_async(some_memory_store)
-        """
-        root = await zarr.api.asynchronous.open_group(store, mode="r")
-        tree: dict[str, Any] = {}
-        async for path, obj in root.members(max_depth=None):
-            parts = path.split("/")
-            current = tree
-            if isinstance(obj, zarr.AsyncArray):
-                for part in parts[:-1]:
-                    current = current.setdefault(part, {})
-                current[parts[-1]] = ArrayNode(shape=obj.shape, dtype=obj.dtype)
-            else:
-                for part in parts:
-                    current = current.setdefault(part, {})
-        return cls.from_dict(tree)
-
-    @classmethod
-    def from_store(cls, store: zarr.abc.store.Store) -> GroupNode:
-        """Build a GroupNode by reading a zarr store's structure.
-
-        Example::
-
-            GroupNode.from_store(some_memory_store)
-        """
-        root = zarr.open_group(store, mode="r")
-        tree: dict[str, Any] = {}
-        for path, obj in root.members(max_depth=None):
-            parts = path.split("/")
-            current = tree
-            if isinstance(obj, zarr.Array):
-                for part in parts[:-1]:
-                    current = current.setdefault(part, {})
-                current[parts[-1]] = ArrayNode(shape=obj.shape, dtype=obj.dtype)
-            else:
-                for part in parts:
-                    current = current.setdefault(part, {})
-        return cls.from_dict(tree)
-
-
-Node = ArrayNode | GroupNode
-
 
 # ---------------------------------------------------------------------------
 # Name strategies — pool-based derivation for prefix collisions

--- a/icechunk-python/python/icechunk/testing/utils.py
+++ b/icechunk-python/python/icechunk/testing/utils.py
@@ -7,8 +7,7 @@ from collections.abc import Generator
 from icechunk import Repository, in_memory_storage
 from icechunk.session import Session
 from icechunk.store import IcechunkStore
-from icechunk.testing.models import ModelStore
-from icechunk.testing.trees import GroupNode
+from icechunk.testing.models import GroupNode, ModelStore
 
 
 def tree_to_model_and_icechunk(

--- a/icechunk-python/tests/test_move.py
+++ b/icechunk-python/tests/test_move.py
@@ -8,7 +8,8 @@ from hypothesis import strategies as st
 import icechunk as ic
 import zarr
 from icechunk.testing.invariants import assert_moves_sorted_by_final_path
-from icechunk.testing.trees import GroupNode, tree_and_moves
+from icechunk.testing.models import GroupNode
+from icechunk.testing.trees import tree_and_moves
 from icechunk.testing.utils import (
     precommit_postcommit_readonly,
     tree_to_model_and_icechunk,

--- a/icechunk-python/tests/test_store_properties.py
+++ b/icechunk-python/tests/test_store_properties.py
@@ -8,7 +8,8 @@ import pytest
 from hypothesis import given
 
 import zarr
-from icechunk.testing.trees import GroupNode, trees
+from icechunk.testing.models import GroupNode
+from icechunk.testing.trees import trees
 from icechunk.testing.utils import (
     precommit_postcommit_readonly,
     tree_to_model_and_icechunk,

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -24,8 +24,8 @@ from icechunk.testing.invariants import (
     assert_list_dir_equal,
     assert_moves_sorted_by_final_path,
 )
-from icechunk.testing.models import ModelStore
-from icechunk.testing.trees import GroupNode, valid_moves
+from icechunk.testing.models import GroupNode, ModelStore
+from icechunk.testing.trees import valid_moves
 from icechunk.testing.utils import update_paths_after_move
 from zarr import Array
 from zarr.core.buffer import default_buffer_prototype


### PR DESCRIPTION
This allows you to import the surprisingly useful tree model without having hypothesis installed. This is helpful for example in subsync verification withoutu needing hypothesis.

We could go even further and have the trees strategies live inside strategies.py so it's super clear which import paths require hypothesis.