### PR TITLE
ci: extend dependabot cooldown to cargo, actions, and tier npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "US/Pacific"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       rust-dependencies:
         patterns:
@@ -18,6 +23,11 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "US/Pacific"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       actions:
         patterns:
@@ -31,6 +41,9 @@ updates:
       timezone: "US/Pacific"
     cooldown:
       default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       js-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

Add tiered `cooldown` to all dependabot ecosystems so version-update PRs only open once a release has soaked. Previously only the `npm /icechunk-js` block had a flat 7-day cooldown; `cargo` and `github-actions` had none, and the npm block didn't differentiate by semver bump.

```
default-days: 7
semver-major-days: 14
semver-minor-days: 7
semver-patch-days: 3
```

## Context

Most recent npm/PyPI/actions supply-chain compromises (TanStack: ~20 min visible window; tj-actions/changed-files: ~2 hr; many worm-style npm incidents: <24 hr) are caught and yanked well inside a 3-day window. With cooldown, Dependabot never proposes a yanked-malicious version in the first place. Security-advisory-driven updates bypass cooldown by design, so genuine CVE fixes still land immediately.

## Risk level

Low. Only affects when Dependabot opens version-update PRs (delays them slightly). Does not change CI, runtime, or any installable artifact. Security updates are unaffected.

## Reviews

No required reviewers.

[This is Claude Code on behalf of Samantha Hughes]