### PR TITLE
ci: pin third-party actions to commit SHAs in js-ci and python-check

### DIFF
--- a/.github/workflows/js-ci.yaml
+++ b/.github/workflows/js-ci.yaml
@@ -71,20 +71,20 @@ jobs:
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: yarn
           cache-dependency-path: icechunk-js/yarn.lock
       - name: Install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: ${{ matrix.settings.rust || 'stable' }}
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -94,12 +94,12 @@ jobs:
             .cargo-cache
             target/
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         if: ${{ contains(matrix.settings.target, 'musl') }}
         with:
           version: 0.14.1
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         if: ${{ contains(matrix.settings.target, 'musl') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -115,7 +115,7 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: |
@@ -145,9 +145,9 @@ jobs:
           - "22"
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -156,7 +156,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ./icechunk-js
@@ -183,9 +183,9 @@ jobs:
           - "22"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -193,7 +193,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bindings-${{ matrix.target }}
           path: ./icechunk-js
@@ -212,9 +212,9 @@ jobs:
       run:
         working-directory: ./icechunk-js
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: yarn
@@ -224,7 +224,7 @@ jobs:
           yarn config set supportedArchitectures.cpu "wasm32"
           yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bindings-wasm32-wasip1-threads
           path: ./icechunk-js
@@ -251,9 +251,9 @@ jobs:
       - test-linux-binding
       - test-wasi
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: yarn
@@ -263,7 +263,7 @@ jobs:
       - name: Create npm dirs
         run: yarn napi create-npm-dirs
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ./icechunk-js/artifacts
       - name: Move artifacts

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -137,13 +137,13 @@ jobs:
   build-wheels-free-threaded:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13t"
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           working-directory: icechunk-python
           args: --release --out dist -i python3.13t
@@ -151,7 +151,7 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-wheels-free-threaded
           path: icechunk-python/dist
@@ -160,19 +160,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-wheels-free-threaded]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Stand up RustFS
         run: |
           docker compose up -d rustfs_init
 
       - name: Download wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: test-wheels-free-threaded
           path: icechunk-python/dist
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           python-version: "3.13t"


### PR DESCRIPTION
## Summary

Replace floating tags (`@v6`, `@stable`, `@v2`, etc.) with commit SHAs in `js-ci.yaml` and `python-check.yaml`. Every other workflow in the repo already SHA-pinned; these two were the holdouts. Each pin keeps a trailing `# <tag>` comment so Dependabot's `github-actions` ecosystem (weekly, with cooldown from #2117) can keep them current.

26 references updated across 11 unique actions:

- `actions/{checkout,setup-node,setup-python,cache,upload-artifact,download-artifact}`
- `dtolnay/rust-toolchain`, `mlugg/setup-zig`, `taiki-e/install-action`
- `PyO3/maturin-action`, `astral-sh/setup-uv`

SHAs match the versions already pinned in `publish-rust-library.yml`, `dependency-check.yaml`, and `python-ci.yaml` for cross-workflow consistency.

## Context

Org-level policy now requires SHA-pinned actions; floating tags will be rejected at run time. Without this, `js-ci.yaml` and `python-check.yaml` would stop running. Beyond the policy, SHA pinning is the standard defense against the tj-actions/changed-files-style action takeover (March 2025).

## Risk level

Low. Pins resolve to the same commits that the floating tags currently point to, so behavior is unchanged today. Dependabot will keep them moving forward.

## Reviews

No required reviewers.

[This is Claude Code on behalf of Samantha Hughes]