### PR TITLE
feat(store): add Store.array_chunk_iterator for the VirtualiZarr parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,7 @@ version = "2.0.4"
 dependencies = [
  "async-stream",
  "async-trait",
+ "bytes",
  "chrono",
  "clap",
  "futures",

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -23,6 +23,7 @@ icechunk = { workspace = true, features = ["logs"] }
 
 async-stream.workspace = true
 async-trait.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 futures.workspace = true
 itertools.workspace = true

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -2546,6 +2546,20 @@ class PyStore:
         checksum: str | datetime.datetime | None,
         validate_container: bool,
     ) -> None: ...
+    def array_chunk_iterator(
+        self,
+        array_path: str,
+        batch_size: int,
+    ) -> AsyncIterator[
+        tuple[
+            np.ndarray[Any, np.dtype[np.uint32]],
+            np.ndarray[Any, np.dtype[np.uint8]],
+            list[str],
+            np.ndarray[Any, np.dtype[np.uint64]],
+            np.ndarray[Any, np.dtype[np.uint64]],
+            dict[int, bytes],
+        ]
+    ]: ...
     async def set_virtual_ref_async(
         self,
         key: str,

--- a/icechunk-python/python/icechunk/store.py
+++ b/icechunk-python/python/icechunk/store.py
@@ -274,6 +274,47 @@ class IcechunkStore(Store, SyncMixin):
             key, location, offset, length, checksum, validate_container
         )
 
+    def array_chunk_iterator(
+        self,
+        array_path: str,
+        batch_size: int = 100_000,
+    ) -> AsyncIterator[
+        tuple[
+            "np.ndarray[Any, np.dtype[np.uint32]]",
+            "np.ndarray[Any, np.dtype[np.uint8]]",
+            list[str],
+            "np.ndarray[Any, np.dtype[np.uint64]]",
+            "np.ndarray[Any, np.dtype[np.uint64]]",
+            dict[int, bytes],
+        ]
+    ]:
+        """Async generator of columnar chunk-reference batches for one array.
+
+        Each yielded batch is a 6-tuple::
+
+            (coords, kinds, paths, offsets, lengths, inlined)
+
+            coords:   np.ndarray[uint32, (n, ndim)]  — chunk grid coordinates
+            kinds:    np.ndarray[uint8]              — 1=virtual, 2=native, 3=inline
+            paths:    list[str]                      — URL (virtual) | bare chunk_id (native) | "" (inline)
+            offsets:  np.ndarray[uint64]
+            lengths:  np.ndarray[uint64]
+            inlined:  dict[int, bytes]               — keyed by index within this batch
+
+        ``vcc://`` virtual locations are resolved against the session's
+        registered containers before yielding. Native chunk ids are returned
+        bare — the caller chooses how to render them (e.g. by prepending an
+        S3 prefix). Missing chunks are not yielded.
+
+        Parameters
+        ----------
+        array_path : str
+            Zarr path to the array (e.g. ``"a"`` or ``"/group/var"``).
+        batch_size : int
+            Maximum number of chunks per yielded batch.
+        """
+        return self._store.array_chunk_iterator(array_path, batch_size)
+
     async def set_virtual_ref_async(
         self,
         key: str,

--- a/icechunk-python/src/store.rs
+++ b/icechunk-python/src/store.rs
@@ -1,23 +1,29 @@
 use std::{borrow::Cow, sync::Arc};
 
+use async_stream::try_stream;
+use bytes::Bytes;
 use chrono::Utc;
 use futures::{StreamExt as _, TryStreamExt as _};
 use icechunk::{
     Store,
     format::{
         ChunkIndices, ChunkLength, ChunkOffset, Path,
-        manifest::{Checksum, SecondsSinceEpoch, VirtualChunkLocation, VirtualChunkRef},
+        manifest::{
+            Checksum, ChunkPayload, ChunkRef, SecondsSinceEpoch, VirtualChunkLocation,
+            VirtualChunkRef,
+        },
     },
+    session::{SessionError, SessionErrorKind},
     storage::ETag,
     store::{SetVirtualRefsResult, StoreError, StoreErrorKind},
 };
 use itertools::Itertools as _;
-use numpy::PyReadonlyArray1;
+use numpy::{IntoPyArray as _, PyArrayMethods as _, PyReadonlyArray1};
 use pyo3::{
     conversion::IntoPyObjectExt as _,
     exceptions::{PyKeyError, PyValueError},
     prelude::*,
-    types::{PyList, PyTuple, PyType},
+    types::{PyBytes as PyBytesType, PyDict, PyList, PyTuple, PyType},
 };
 use pyo3_bytes::PyBytes;
 use serde::{Deserialize, Serialize};
@@ -33,6 +39,12 @@ use crate::{
 };
 
 type KeyRanges = Vec<(String, (Option<ChunkOffset>, Option<ChunkOffset>))>;
+
+/// Per-slot tag values for [`PyStore::array_chunk_iterator`] batches.
+/// Kept in sync with the docstring on that method.
+const KIND_VIRTUAL: u8 = 1;
+const KIND_NATIVE: u8 = 2;
+const KIND_INLINE: u8 = 3;
 
 #[derive(FromPyObject, Clone, Debug)]
 enum ChecksumArgument {
@@ -604,6 +616,136 @@ impl PyStore {
                 vrefs_result_to_py(res)
             },
         )
+    }
+
+    /// Per-array async generator of columnar chunk-reference batches.
+    ///
+    /// Each yielded item is a 6-tuple:
+    ///
+    /// ```text
+    /// (coords, kinds, paths, offsets, lengths, inlined)
+    ///   coords   : np.ndarray[uint32, (n, ndim)]  — chunk grid coordinates
+    ///   kinds    : np.ndarray[uint8]              — 1=virtual, 2=native, 3=inline
+    ///   paths    : list[str]                      — URL (virtual) | bare chunk_id (native) | "" (inline)
+    ///   offsets  : np.ndarray[uint64]
+    ///   lengths  : np.ndarray[uint64]
+    ///   inlined  : dict[int, bytes]               — keyed by index within this batch
+    /// ```
+    ///
+    /// `vcc://` virtual locations are expanded against the session's
+    /// resolver. Native chunk ids are returned bare — the caller renders the
+    /// full URL however suits them. Missing chunks are not yielded.
+    fn array_chunk_iterator(
+        &self,
+        array_path: String,
+        batch_size: u32,
+    ) -> PyResult<PyAsyncGenerator> {
+        let store = Arc::clone(&self.0);
+        let res = try_stream! {
+            let session_lock = store.session();
+            let session = session_lock.read_owned().await;
+            let array_path = if array_path.starts_with('/') {
+                array_path
+            } else {
+                format!("/{array_path}")
+            };
+            let path: Path = array_path.try_into().map_err(|e| {
+                PyIcechunkStoreError::PyValueError(format!("Invalid path: {e}"))
+            })?;
+            let stream = session
+                .array_chunk_iterator(&path)
+                .await
+                .map_err(PyIcechunkStoreError::SessionError)
+                .chunks(batch_size as usize);
+
+            for await infos in stream {
+                let n = infos.len();
+                let mut coords_flat: Vec<u32> = Vec::new();
+                let mut kinds: Vec<u8> = Vec::with_capacity(n);
+                let mut paths: Vec<String> = Vec::with_capacity(n);
+                let mut offsets: Vec<u64> = Vec::with_capacity(n);
+                let mut lengths: Vec<u64> = Vec::with_capacity(n);
+                let mut inlined: Vec<(usize, Bytes)> = Vec::new();
+                let mut ndim: usize = 0;
+
+                for (i, ci_res) in infos.into_iter().enumerate() {
+                    let ci = ci_res?;
+                    ndim = ci.coord.0.len();
+                    coords_flat.extend_from_slice(&ci.coord.0);
+                    match ci.payload {
+                        ChunkPayload::Virtual(VirtualChunkRef {
+                            location, offset, length, ..
+                        }) => {
+                            let url = session
+                                .resolve_virtual_location(&location)
+                                .map_err(|e| {
+                                    PyIcechunkStoreError::SessionError(
+                                        SessionError::capture(
+                                            SessionErrorKind::VirtualReferenceError(e.kind),
+                                        ),
+                                    )
+                                })?;
+                            kinds.push(KIND_VIRTUAL);
+                            paths.push(url);
+                            offsets.push(offset);
+                            lengths.push(length);
+                        }
+                        ChunkPayload::Ref(ChunkRef { id, offset, length }) => {
+                            kinds.push(KIND_NATIVE);
+                            paths.push(format!("{id}"));
+                            offsets.push(offset);
+                            lengths.push(length);
+                        }
+                        ChunkPayload::Inline(bytes) => {
+                            kinds.push(KIND_INLINE);
+                            paths.push(String::new());
+                            offsets.push(0);
+                            lengths.push(bytes.len() as u64);
+                            inlined.push((i, bytes));
+                        }
+                        other => {
+                            Err(PyIcechunkStoreError::PyValueError(format!(
+                                "array_chunk_iterator encountered an unsupported ChunkPayload variant: {other:?}"
+                            )))?
+                        }
+                    }
+                }
+
+                let batch = Python::attach(|py| -> PyResult<Py<PyAny>> {
+                    let coords_arr = coords_flat
+                        .into_pyarray(py)
+                        .reshape((n, ndim))?
+                        .into_any()
+                        .unbind();
+                    let kinds_arr = kinds.into_pyarray(py).into_any().unbind();
+                    let offsets_arr = offsets.into_pyarray(py).into_any().unbind();
+                    let lengths_arr = lengths.into_pyarray(py).into_any().unbind();
+                    let paths_list: Py<PyAny> =
+                        PyList::new(py, paths)?.into_any().unbind();
+                    let inlined_dict = PyDict::new(py);
+                    for (i, b) in inlined {
+                        let slice: &[u8] = b.as_ref();
+                        inlined_dict.set_item(i, PyBytesType::new(py, slice))?;
+                    }
+                    let tup = PyTuple::new(
+                        py,
+                        [
+                            coords_arr,
+                            kinds_arr,
+                            paths_list,
+                            offsets_arr,
+                            lengths_arr,
+                            inlined_dict.into_any().unbind(),
+                        ],
+                    )?;
+                    Ok(tup.into_any().unbind())
+                })?;
+
+                yield batch;
+            }
+        };
+        let prepared = Arc::new(Mutex::new(res.boxed()));
+        Ok(PyAsyncGenerator::new(prepared))
     }
 
     fn delete<'py>(

--- a/icechunk-python/tests/test_array_chunk_iterator.py
+++ b/icechunk-python/tests/test_array_chunk_iterator.py
@@ -1,0 +1,190 @@
+"""Tests for IcechunkStore.array_chunk_iterator — the parser-facing batched
+columnar iterator consumed by VirtualiZarr's IcechunkParser.
+
+Per-array async generator. Each batch is a 6-tuple:
+
+    (coords, kinds, paths, offsets, lengths, inlined)
+
+where:
+    coords:   np.ndarray[uint32, (n, ndim)]  — chunk grid coordinates
+    kinds:    np.ndarray[uint8]              — 1=virtual, 2=native, 3=inline
+    paths:    list[str]                      — URL (virtual) | chunk_id (native) | "" (inline)
+    offsets:  np.ndarray[uint64]
+    lengths:  np.ndarray[uint64]
+    inlined:  dict[int, bytes]               — keyed by index within this batch
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+import icechunk
+
+
+KIND_VIRTUAL = 1
+KIND_NATIVE = 2
+KIND_INLINE = 3
+
+
+def _drain(async_iter) -> list:
+    """Synchronously drain an async generator into a list of batches."""
+
+    async def _collect():
+        out = []
+        async for b in async_iter:
+            out.append(b)
+        return out
+
+    return asyncio.run(_collect())
+
+
+def _mixed_repo() -> icechunk.Repository:
+    """A repo with virtual, inline, and (forced) native chunks on /a (shape=2x2x2)."""
+    config = icechunk.RepositoryConfig.default()
+    repo = icechunk.Repository.create(
+        storage=icechunk.in_memory_storage(),
+        config=config,
+    )
+    session = repo.writable_session("main")
+    store = session.store
+    import zarr
+
+    group = zarr.group(store=store, overwrite=True)
+    arr = group.create_array(
+        "a", shape=(2, 2, 2), chunks=(1, 1, 1), dtype="i4", compressors=None
+    )
+
+    # inline (small)
+    arr[0, 0, 0] = 1
+
+    # virtual
+    store.set_virtual_ref(
+        "a/c/0/0/1",
+        "s3://bucket/data.nc",
+        offset=100,
+        length=50,
+        validate_container=False,
+    )
+    # (0,1,0) — missing (won't appear in iterator)
+    # other slots — missing
+
+    session.commit("init")
+    return repo
+
+
+def test_iterator_columnar_shape_and_dtypes() -> None:
+    repo = _mixed_repo()
+    session = repo.readonly_session(branch="main")
+    batches = _drain(session.store.array_chunk_iterator("a", batch_size=100))
+    # All present chunks fit in one batch.
+    assert len(batches) == 1
+    coords, kinds, paths, offsets, lengths, inlined = batches[0]
+
+    # Two present chunks: one inline + one virtual
+    n = coords.shape[0]
+    assert n == 2
+    assert coords.shape == (2, 3)
+    assert coords.dtype == np.uint32
+
+    assert kinds.shape == (2,)
+    assert kinds.dtype == np.uint8
+
+    assert isinstance(paths, list)
+    assert len(paths) == 2
+
+    assert offsets.shape == (2,)
+    assert offsets.dtype == np.uint64
+    assert lengths.shape == (2,)
+    assert lengths.dtype == np.uint64
+
+    assert isinstance(inlined, dict)
+
+
+def test_iterator_yields_correct_kinds_and_paths() -> None:
+    repo = _mixed_repo()
+    session = repo.readonly_session(branch="main")
+    (batch,) = _drain(session.store.array_chunk_iterator("a", batch_size=100))
+    coords, kinds, paths, offsets, lengths, inlined = batch
+
+    # Build a coord-keyed lookup so test isn't sensitive to iteration order.
+    by_coord = {tuple(c.tolist()): i for i, c in enumerate(coords)}
+    assert set(by_coord) == {(0, 0, 0), (0, 0, 1)}
+
+    inline_i = by_coord[(0, 0, 0)]
+    virt_i = by_coord[(0, 0, 1)]
+
+    assert kinds[inline_i] == KIND_INLINE
+    assert paths[inline_i] == ""
+    assert offsets[inline_i] == 0
+    assert lengths[inline_i] == 4
+    assert inline_i in inlined
+    assert len(inlined[inline_i]) == 4
+
+    assert kinds[virt_i] == KIND_VIRTUAL
+    assert paths[virt_i] == "s3://bucket/data.nc"
+    assert offsets[virt_i] == 100
+    assert lengths[virt_i] == 50
+    assert virt_i not in inlined
+
+
+def test_iterator_native_chunk_returns_bare_id() -> None:
+    """Native (managed) chunk paths come back as bare chunk_ids — no prefix."""
+    config = icechunk.RepositoryConfig.default()
+    config.inline_chunk_threshold_bytes = 0  # force native
+    repo = icechunk.Repository.create(
+        storage=icechunk.in_memory_storage(),
+        config=config,
+    )
+    session = repo.writable_session("main")
+    import zarr
+
+    group = zarr.group(store=session.store, overwrite=True)
+    arr = group.create_array(
+        "v", shape=(2,), chunks=(1,), dtype="i4", compressors=None
+    )
+    arr[0] = 9
+    arr[1] = 10
+    session.commit("c")
+
+    session = repo.readonly_session(branch="main")
+    batches = _drain(session.store.array_chunk_iterator("v", batch_size=100))
+    assert len(batches) == 1
+    coords, kinds, paths, offsets, lengths, inlined = batches[0]
+    assert kinds.tolist() == [KIND_NATIVE, KIND_NATIVE]
+    # Bare chunk_id strings — no URL scheme, no '/' separator
+    for p in paths:
+        assert "://" not in p
+        assert "/" not in p
+    assert lengths.tolist() == [4, 4]
+    assert inlined == {}
+
+
+def test_iterator_batches_split_at_batch_size() -> None:
+    """Many chunks crossing batch_size boundary are split across yields."""
+    config = icechunk.RepositoryConfig.default()
+    repo = icechunk.Repository.create(
+        storage=icechunk.in_memory_storage(),
+        config=config,
+    )
+    session = repo.writable_session("main")
+    import zarr
+
+    group = zarr.group(store=session.store, overwrite=True)
+    arr = group.create_array(
+        "b", shape=(7,), chunks=(1,), dtype="i4", compressors=None
+    )
+    # Start from 1 — writing 0 (the default fill value) into an int chunk
+    # is treated as a fill-value write and won't materialize a chunk.
+    for i in range(7):
+        arr[i] = i + 1
+    session.commit("c")
+
+    session = repo.readonly_session(branch="main")
+    batches = _drain(session.store.array_chunk_iterator("b", batch_size=3))
+    # 7 chunks at batch_size 3 = 3 + 3 + 1
+    total = sum(b[0].shape[0] for b in batches)
+    assert total == 7
+    assert len(batches) == 3

--- a/icechunk-python/tests/test_array_chunk_iterator.py
+++ b/icechunk-python/tests/test_array_chunk_iterator.py
@@ -75,54 +75,35 @@ def _mixed_repo() -> icechunk.Repository:
     return repo
 
 
-def test_iterator_columnar_shape_and_dtypes() -> None:
-    repo = _mixed_repo()
-    session = repo.readonly_session(branch="main")
-    batches = _drain(session.store.array_chunk_iterator("a", batch_size=100))
-    # All present chunks fit in one batch.
-    assert len(batches) == 1
-    coords, kinds, paths, offsets, lengths, inlined = batches[0]
-
-    # Two present chunks: one inline + one virtual
-    n = coords.shape[0]
-    assert n == 2
-    assert coords.shape == (2, 3)
-    assert coords.dtype == np.uint32
-
-    assert kinds.shape == (2,)
-    assert kinds.dtype == np.uint8
-
-    assert isinstance(paths, list)
-    assert len(paths) == 2
-
-    assert offsets.shape == (2,)
-    assert offsets.dtype == np.uint64
-    assert lengths.shape == (2,)
-    assert lengths.dtype == np.uint64
-
-    assert isinstance(inlined, dict)
-
-
-def test_iterator_yields_correct_kinds_and_paths() -> None:
+def test_iterator_yields_columnar_batch_for_mixed_payloads() -> None:
+    """Shape/dtype contract + per-row values for a virtual+inline mix."""
     repo = _mixed_repo()
     session = repo.readonly_session(branch="main")
     (batch,) = _drain(session.store.array_chunk_iterator("a", batch_size=100))
     coords, kinds, paths, offsets, lengths, inlined = batch
 
-    # Build a coord-keyed lookup so test isn't sensitive to iteration order.
+    # Columnar contract: aligned uint{32,8,64} numpy arrays + list[str] + dict.
+    n = coords.shape[0]
+    assert n == 2
+    assert coords.shape == (2, 3) and coords.dtype == np.uint32
+    assert kinds.shape == (2,) and kinds.dtype == np.uint8
+    assert offsets.shape == (2,) and offsets.dtype == np.uint64
+    assert lengths.shape == (2,) and lengths.dtype == np.uint64
+    assert isinstance(paths, list) and len(paths) == 2
+    assert isinstance(inlined, dict)
+
+    # Coord-keyed lookup so the test isn't sensitive to iteration order.
     by_coord = {tuple(c.tolist()): i for i, c in enumerate(coords)}
     assert set(by_coord) == {(0, 0, 0), (0, 0, 1)}
 
     inline_i = by_coord[(0, 0, 0)]
-    virt_i = by_coord[(0, 0, 1)]
-
     assert kinds[inline_i] == KIND_INLINE
     assert paths[inline_i] == ""
     assert offsets[inline_i] == 0
     assert lengths[inline_i] == 4
-    assert inline_i in inlined
     assert len(inlined[inline_i]) == 4
 
+    virt_i = by_coord[(0, 0, 1)]
     assert kinds[virt_i] == KIND_VIRTUAL
     assert paths[virt_i] == "s3://bucket/data.nc"
     assert offsets[virt_i] == 100

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -1392,6 +1392,19 @@ impl Session {
     }
 
     #[instrument(skip(self))]
+    /// Resolve a possibly-relative virtual chunk location to its absolute URL.
+    ///
+    /// `vcc://name/path` URLs are expanded against the session's registered
+    /// virtual chunk containers. Absolute URLs (`s3://`, `gs://`, `file://`, …)
+    /// are returned as-is.
+    pub fn resolve_virtual_location(
+        &self,
+        location: &VirtualChunkLocation,
+    ) -> Result<String, icechunk_format::manifest::VirtualReferenceError> {
+        self.virtual_resolver.expand_location(location.url())
+    }
+
+    #[instrument(skip(self))]
     pub async fn all_virtual_chunk_locations(
         &self,
     ) -> SessionResult<impl Stream<Item = SessionResult<String>> + '_> {


### PR DESCRIPTION
## Summary

Adds `IcechunkStore.array_chunk_iterator(array_path, batch_size)` — a per-array async generator yielding **columnar batches** of chunk references, designed for the new `IcechunkParser` in VirtualiZarr (companion PR: zarr-developers/VirtualiZarr#991).

Each yielded batch is a 6-tuple:

```
(coords, kinds, paths, offsets, lengths, inlined)

  coords   : np.ndarray[uint32, (n, ndim)]   — chunk grid coordinates
  kinds    : np.ndarray[uint8]               — 1=virtual, 2=native, 3=inline
  paths    : list[str]                        — URL (virtual) | bare chunk_id (native) | "" (inline)
  offsets  : np.ndarray[uint64]
  lengths  : np.ndarray[uint64]
  inlined  : dict[int, bytes]                 — keyed by index within this batch
```

`vcc://` virtual locations are resolved against the session's registered containers before the batch crosses FFI. Missing chunks are not yielded (the iterator is sparse).

## Design notes

This API was designed to **keep icechunk free of VirtualiZarr vocabulary**. The earlier sketch (a `Store.array_chunk_refs` method returning a dense `ArrayChunkRefs` struct sized to the chunk grid, with a `__inlined__` sentinel string in the path column and a `native_chunks_prefix` parameter) leaked VZ's manifest shape into icechunk's API. The iterator form:

- Doesn't know the array's chunk grid shape — the caller derives that from zarr metadata.
- Doesn't render native chunk URLs — returns bare `chunk_id` strings, caller decides the prefix.
- Doesn't emit any VZ sentinels — inline chunks live in a separate `dict` keyed by index, and `kinds` tells callers what each row is.
- Memory-bounded by `batch_size`, not by total chunk count.

The rust core is unchanged. The pyo3 binding wraps the existing `Session::array_chunk_iterator` (which already yields `Stream<Item = SessionResult<ChunkInfo>>`) with a `.chunks(batch_size)` adapter and per-batch columnar conversion. One minor addition on `Session`: a public `resolve_virtual_location` accessor so the binding can expand `vcc://` URLs without exposing the internal resolver Arc.

Adds `bytes` as a direct dep of `icechunk-python` (already a workspace dep).

## Test plan

- [x] 4 new Python tests in `icechunk-python/tests/test_array_chunk_iterator.py`:
  - columnar shapes + dtypes
  - kind tags + path values for virtual/inline mix
  - bare `chunk_id` (no URL scheme) for native chunks
  - batch splitting at `batch_size`
- [x] Existing rust test suite (210 tests) still passes.
- [x] stubtest clean for the new method.
- [ ] Bench at scale (preliminary local run: ~1 μs/chunk parse, ~64 B/chunk of Python-side memory; extrapolates to ~16 min and ~62 GiB peak for 1B chunks).

## Companion PR

VirtualiZarr-side parser: zarr-developers/VirtualiZarr#991.