### PR TITLE
fix(xarray): defer icechunk.dask import in write_lazy

### DIFF
--- a/icechunk-python/python/icechunk/xarray.py
+++ b/icechunk-python/python/icechunk/xarray.py
@@ -184,8 +184,6 @@ class _XarrayDatasetWriter:
         """
         Write lazy arrays (e.g. dask) to store.
         """
-        from icechunk.dask import session_merge_reduction
-
         if not self._initialized:
             raise ValueError("Please call `write_metadata` first.")
 
@@ -193,6 +191,8 @@ class _XarrayDatasetWriter:
             raise TypeError(
                 "Attempting to execute a write with dask but no dask arrays were detected."
             )
+
+        from icechunk.dask import session_merge_reduction
 
         chunkmanager_store_kwargs = chunkmanager_store_kwargs or {}
         chunkmanager_store_kwargs["load_stored"] = False


### PR DESCRIPTION
## Summary

`_XarrayDatasetWriter.write_lazy` imported `icechunk.dask` (which imports `dask`) as its very first statement, before the guards that short-circuit when there is no lazy work. Move the import past both guards so it only fires when we're actually about to call `session_merge_reduction`.

This is the trivial reorder discussed in #2128 — `write_lazy` should not require `dask` to be importable on the early-exit paths.

## Test plan

- [x] Reorder confirmed via local diff (3 lines moved, no logic change).
- [x] Verified `write_lazy` still imports `session_merge_reduction` immediately before the only call site, so the dask path is unchanged.

Closes #2128