### PR TITLE
TEST: fix failing tests

### DIFF
--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -292,12 +292,10 @@ jobs:
     needs: xarray-backends
     permissions:
       issues: write # needed to create/update issues on nightly failures
-    # TODO(ci): revert to `github.event_name == 'schedule'` after validating
-    # the report step from a labeled PR run.
     if: |
       always()
       && needs.xarray-backends.outputs.pytest-outcome == 'failure'
-      && (github.event_name == 'schedule' || github.event_name == 'pull_request')
+      && github.event_name == 'schedule'
       && github.repository_owner == 'earth-mover'
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -292,15 +292,18 @@ jobs:
     needs: xarray-backends
     permissions:
       issues: write # needed to create/update issues on nightly failures
+    # TODO(ci): revert to `github.event_name == 'schedule'` after validating
+    # the report step from a labeled PR run.
     if: |
       always()
       && needs.xarray-backends.outputs.pytest-outcome == 'failure'
-      && github.event_name == 'schedule'
+      && (github.event_name == 'schedule' || github.event_name == 'pull_request')
       && github.repository_owner == 'earth-mover'
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: xarray-backends-logs
+          path: xarray-backends-logs
 
       - name: Generate and publish the xarray backends report
         uses: xarray-contrib/issue-from-pytest-log@8e905db353437cda1d6a773de245343fbfc940dd # v1

--- a/icechunk-python/tests/test_stateful_repo_ops.py
+++ b/icechunk-python/tests/test_stateful_repo_ops.py
@@ -17,6 +17,7 @@ from packaging.version import Version
 
 import icechunk
 import icechunk as ic
+import zarr
 from zarr.core.buffer import Buffer, default_buffer_prototype
 
 pytest.importorskip("hypothesis")
@@ -653,6 +654,12 @@ class VersionControlStateMachine(RuleBasedStateMachine):
         config = data.draw(repository_configs(ic_module=self.ic))
         self.model.initial_spec_version = spec_version
         self.model.spec_version = spec_version
+
+        # spec_version=1 rejects rectilinear chunk grids. The package conftest
+        # globally enables `array.rectilinear_chunks`; turn it off for v1
+        # examples so v3_array_metadata doesn't draw rectilinear grids.
+        if "array.rectilinear_chunks" in zarr.config:
+            zarr.config.set({"array.rectilinear_chunks": spec_version != 1})
 
         if Version(self.ic.__version__).major >= 2:
             self.repo = self.actor.create(

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -284,6 +284,8 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
                 read_sizes = tuple(
                     (c,) * n for c, n in zip(arr_model.chunks, num_chunks, strict=True)
                 )
+            # Shifting right by offset[i] pushes the last offset[i] chunks
+            # past the original extent; grow by their sizes so they fit.
             new_shape = tuple(
                 arr_model.shape[i]
                 + (sum(read_sizes[i][-offset[i] :]) if offset[i] > 0 else 0)

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -75,6 +75,12 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         # called by hypothesis in a random order
         note(f"Creating repository with spec_version={spec_version}, actor={self.actor}")
 
+        # spec_version=1 rejects rectilinear chunk grids. The package conftest
+        # globally enables `array.rectilinear_chunks`; turn it off for v1
+        # examples so zarr's strategies don't draw them here.
+        if "array.rectilinear_chunks" in zarr.config:
+            zarr.config.set({"array.rectilinear_chunks": spec_version != 1})
+
         # Create repository with the drawn spec version
         if Version(self.ic.__version__).major >= 2:
             self.repo = self.actor.create(self.storage, spec_version=spec_version)
@@ -196,6 +202,8 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         if not dry_run:
             assert self.repo.spec_version == 2
             self.model.spec_version = 2
+            if "array.rectilinear_chunks" in zarr.config:
+                zarr.config.set({"array.rectilinear_chunks": True})
 
     @rule(data=st.data(), num_moves=st.integers(min_value=1, max_value=5))
     @precondition(lambda self: self.model.spec_version >= 2)
@@ -256,7 +264,6 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         arr_model = zarr.open_array(self.model, path=array_path)
         arr_store = zarr.open_array(self.store, path=array_path)
         num_chunks = arr_model.cdata_shape
-        chunks = arr_model.chunks
 
         # Draw offset: negative shifts left, positive shifts right
         offset = data.draw(
@@ -268,9 +275,19 @@ class ModifiedZarrHierarchyStateMachine(ZarrHierarchyStateMachine):
         # - Without resize: data shifting beyond bounds is lost
         should_resize = data.draw(st.booleans())
         if should_resize and any(o > 0 for o in offset):
+            # read_chunk_sizes was added alongside rectilinear support; on older
+            # zarr it doesn't exist but grids are always regular, so synthesize
+            # the same tuple-of-tuples shape from the declared chunk size.
+            if hasattr(arr_model, "read_chunk_sizes"):
+                read_sizes = arr_model.read_chunk_sizes
+            else:
+                read_sizes = tuple(
+                    (c,) * n for c, n in zip(arr_model.chunks, num_chunks, strict=True)
+                )
             new_shape = tuple(
-                arr_model.shape[i] + max(0, offset[i]) * chunks[i]
-                for i in range(len(chunks))
+                arr_model.shape[i]
+                + (sum(read_sizes[i][-offset[i] :]) if offset[i] > 0 else 0)
+                for i in range(len(read_sizes))
             )
             note(f"resizing array '{array_path}' from {arr_model.shape} to {new_shape}")
             arr_model.resize(new_shape)


### PR DESCRIPTION
1. Take more care in not generating rectilinear chunk grids on spec version 1
2. update our model for shift-array with rectilinear chunks
3. fix the xarray-upstream-backend-tests issue creation

this gets us almost all the way to green. the remaining failures are actualyl xarray failures and are fixed there: https://github.com/pydata/xarray/pull/11340