### PR TITLE
test(strategies): constrain split_manifest dim to 1..=5

### DIFF
--- a/icechunk/src/strategies.rs
+++ b/icechunk/src/strategies.rs
@@ -668,7 +668,9 @@ pub fn large_chunk_indices(dim: usize) -> impl Strategy<Value = ChunkIndices> {
 
 pub fn split_manifest()
 -> impl Strategy<Value = BTreeMap<ChunkIndices, Option<ChunkPayload>>> {
-    any::<u16>().prop_map(usize::from).prop_flat_map(|dim| {
+    // dim must be >= 1: a 0-dim ChunkIndices has only one possible value, so
+    // btree_map cannot reach its min size of 3 unique keys and proptest rejects.
+    (1usize..=5).prop_flat_map(|dim| {
         btree_map(large_chunk_indices(dim), option::of(chunk_payload()), 3..10)
     })
 }


### PR DESCRIPTION
Fixes the macOS-CI flake in `change_set::tests::serialize_and_deserialize_change_sets`, which intermittently aborted with `Too many local rejects` (65527 at "BTreeMap minimum size").

The `split_manifest` proptest generator picked `dim` from `any::<u16>()`, which permits `dim == 0`. With `dim == 0`, `ChunkIndices` is the singleton empty vector, so the surrounding `btree_map(..., 3..10)` could never reach its minimum size of 3 unique keys and proptest rejected until it exhausted its 65,536-reject budget. Probability ~1/65536 per case, hence the flake.

Constraining `dim` to `1..=5` (matching the convention already used in `edit_changes` above) covers the realistic input domain — a 0-dim/scalar array has no meaningful 3–10-chunk split manifest anyway. The change is confined to `#[cfg(test)]` code; no production logic changes.

Verified by reproducing the failure on the pre-fix commit at `PROPTEST_CASES=200000` (same `BTreeMap minimum size` reject fingerprint as CI) and confirming clean passes post-fix across ~20k cases.

Closes #2138