### PR TITLE
Release 2.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-arrow-object-store"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-format"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "base32",
  "bytes",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-macros"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-python"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-s3"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-storage"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-types"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates
-icechunk = { path = "icechunk", version = "2.0.3" }
-icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.0.3", default-features = false }
-icechunk-format = { path = "icechunk-format", version = "2.0.3" }
-icechunk-macros = { path = "icechunk-macros", version = "2.0.3" }
-icechunk-s3 = { path = "icechunk-s3", version = "2.0.3" }
-icechunk-storage = { path = "icechunk-storage", version = "2.0.3" }
-icechunk-types = { path = "icechunk-types", version = "2.0.3" }
+icechunk = { path = "icechunk", version = "2.0.5" }
+icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.0.5", default-features = false }
+icechunk-format = { path = "icechunk-format", version = "2.0.5" }
+icechunk-macros = { path = "icechunk-macros", version = "2.0.5" }
+icechunk-s3 = { path = "icechunk-s3", version = "2.0.5" }
+icechunk-storage = { path = "icechunk-storage", version = "2.0.5" }
+icechunk-types = { path = "icechunk-types", version = "2.0.5" }
 
 # External dependencies
 anyhow = "1.0.102"

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Python Icechunk Library 2.0.5
+
+### Features
+
+- Add `Store.array_chunk_iterator` for batched, per-array enumeration of chunk references (used by the VirtualiZarr parser) ([#2124](https://github.com/earth-mover/icechunk/pull/2124)).
+- Add `checksum_algorithm` option (and `ChecksumAlgorithm` enum) on `S3Options` to override the AWS SDK's default `x-amz-checksum-*` header for S3-compatible providers that reject it ([#2115](https://github.com/earth-mover/icechunk/pull/2115)).
+
+### Fixes
+
+- Reject invalid `session.move` calls (moving a group inside itself, or moving a node under an array) with clearer errors ([#2102](https://github.com/earth-mover/icechunk/pull/2102)).
+- Defer `icechunk.dask` import in `_XarrayDatasetWriter.write_lazy` so it isn't required on early-exit paths ([#2133](https://github.com/earth-mover/icechunk/pull/2133)).
+
 ## Python Icechunk Library 2.0.4
 
 ### Fixes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,12 @@
 
 ## Update version metadata files
 
-All internal crates are versioned in lockstep: bump every workspace crate to the new version even if it had no changes since the last release, and update the matching `version = "..."` pins under `[workspace.dependencies]` in the top-level `Cargo.toml`. The current crates are `icechunk`, `icechunk-python`, `icechunk-types`, `icechunk-format`, `icechunk-storage`, `icechunk-s3`, `icechunk-arrow-object-store`, and `icechunk-macros`.
+All internal crates are versioned in lockstep with the JS package: bump every workspace crate and `icechunk-js/package.json` to the new version even if a given component had no changes since the last release, and update the matching `version = "..."` pins under `[workspace.dependencies]` in the top-level `Cargo.toml`. The current crates are `icechunk`, `icechunk-python`, `icechunk-types`, `icechunk-format`, `icechunk-storage`, `icechunk-s3`, `icechunk-arrow-object-store`, and `icechunk-macros`.
 
 1. (Optional: Iff changes to core icechunk rust crate) Update `icechunk/Cargo.toml` by incrementing the version.
 1. Update `icechunk-python/Cargo.toml` by incrementing the version.
 1. Update the remaining workspace crates (`icechunk-types`, `icechunk-format`, `icechunk-storage`, `icechunk-s3`, `icechunk-arrow-object-store`, `icechunk-macros`) to the same version.
+1. Update `icechunk-js/package.json` to the same version.
 1. Update the version of the dependency on the core Rust Icechunk library in `icechunk-python/Cargo.toml`, ensuring that it is consistent with the latest version of the core icechunk rust crate. Update the other internal crate pins under `[workspace.dependencies]` in the top-level `Cargo.toml` to match.
 1. Update the `Cargo.lock` file, by running `cargo check` from the top-level icechunk directory.
 1. Document changes in `Changelog.md`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,9 +2,12 @@
 
 ## Update version metadata files
 
+All internal crates are versioned in lockstep: bump every workspace crate to the new version even if it had no changes since the last release, and update the matching `version = "..."` pins under `[workspace.dependencies]` in the top-level `Cargo.toml`. The current crates are `icechunk`, `icechunk-python`, `icechunk-types`, `icechunk-format`, `icechunk-storage`, `icechunk-s3`, `icechunk-arrow-object-store`, and `icechunk-macros`.
+
 1. (Optional: Iff changes to core icechunk rust crate) Update `icechunk/Cargo.toml` by incrementing the version.
 1. Update `icechunk-python/Cargo.toml` by incrementing the version.
-1. Update the version of the dependency on the core Rust Icechunk library in `icechunk-python/Cargo.toml`, ensuring that it is consistent with the latest version of the core icechunk rust crate.
+1. Update the remaining workspace crates (`icechunk-types`, `icechunk-format`, `icechunk-storage`, `icechunk-s3`, `icechunk-arrow-object-store`, `icechunk-macros`) to the same version.
+1. Update the version of the dependency on the core Rust Icechunk library in `icechunk-python/Cargo.toml`, ensuring that it is consistent with the latest version of the core icechunk rust crate. Update the other internal crate pins under `[workspace.dependencies]` in the top-level `Cargo.toml` to match.
 1. Update the `Cargo.lock` file, by running `cargo check` from the top-level icechunk directory.
 1. Document changes in `Changelog.md`.
 1. Commit all changes and make a PR.

--- a/icechunk-arrow-object-store/Cargo.toml
+++ b/icechunk-arrow-object-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-arrow-object-store"
-version = "2.0.4"
+version = "2.0.5"
 description = "Apache Arrow object_store storage backend for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-format/Cargo.toml
+++ b/icechunk-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-format"
-version = "2.0.4"
+version = "2.0.5"
 description = "Binary format types and serialization for the Icechunk storage engine"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-js/package.json
+++ b/icechunk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthmover/icechunk",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "description": "JavaScript/TypeScript bindings for Icechunk",
   "main": "index.js",
   "repository": {

--- a/icechunk-macros/Cargo.toml
+++ b/icechunk-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "icechunk-macros"
 description = "Support and helper macros for the Icechunk library"
-version = "2.0.4"
+version = "2.0.5"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"
 homepage = "https://icechunk.io"

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-python"
-version = "2.0.4"
+version = "2.0.5"
 description = "Transactional storage engine for Zarr designed for use on cloud object storage"
 readme = "README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-s3/Cargo.toml
+++ b/icechunk-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-s3"
-version = "2.0.4"
+version = "2.0.5"
 description = "Native AWS S3 storage backend for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-storage/Cargo.toml
+++ b/icechunk-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-storage"
-version = "2.0.4"
+version = "2.0.5"
 description = "Storage trait and shared types for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-types/Cargo.toml
+++ b/icechunk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-types"
-version = "2.0.4"
+version = "2.0.5"
 description = "Shared foundational types for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk"
-version = "2.0.4"
+version = "2.0.5"
 description = "Transactional storage engine for Zarr designed for use on cloud object storage"
 readme = "README.md"
 repository = "https://github.com/earth-mover/icechunk"


### PR DESCRIPTION
## Summary

- Bumps all workspace crates from `2.0.4` to `2.0.5` (in lockstep), and updates the matching `[workspace.dependencies]` pins (which were stale at `2.0.3` after the 2.0.4 release skipped them).
- Adds the `Python Icechunk Library 2.0.5` section to `Changelog.python.md` covering everything user-facing since v2.0.4: `Store.array_chunk_iterator` (#2124), S3 `checksum_algorithm` option (#2115), invalid-move rejections (#2102), and the deferred `icechunk.dask` import in xarray `write_lazy` (#2133).
- Adds a note to `RELEASE.md` documenting the lockstep crate-version convention so future releases don't drop a subcrate again.