### PR TITLE
docs: link both v1 and v2 spec from the docs

### DIFF
--- a/icechunk-python/docs/docs/reference/spec-v1.md
+++ b/icechunk-python/docs/docs/reference/spec-v1.md
@@ -4,7 +4,8 @@ title: Specification
 # Icechunk Specification, version 1
 
 !!! Note
-    See also [spec version 2](./spec.md).
+
+    This is the spec for the original Icechunk on-disk format (spec version 1), used by Icechunk 1.x. The current format is [spec version 2](./spec.md), used by Icechunk 2.x.
 
 !!! Note
 

--- a/icechunk-python/docs/docs/reference/spec.md
+++ b/icechunk-python/docs/docs/reference/spec.md
@@ -1,7 +1,11 @@
 ---
 title: Specification
 ---
-# Icechunk Specification
+# Icechunk Specification, version 2
+
+!!! Note
+
+    This is the current Icechunk specification (spec version 2), used by Icechunk 2.x. For the previous on-disk format, see [spec version 1](./spec-v1.md). See [Changes from spec version 1](#changes-from-spec-version-1) for a summary of what changed.
 
 !!! Note
 

--- a/icechunk-python/docs/docs/reference/version-policy.md
+++ b/icechunk-python/docs/docs/reference/version-policy.md
@@ -2,7 +2,7 @@
 
 ## On-Disk Format
 
-The Icechunk on-disk format is defined by the format specification ("Icechunk Spec"), which is versioned by a single integer. The spec version increments if and only if there is an on-disk incompatible change, as defined by the [spec document](./spec.md).
+The Icechunk on-disk format is defined by the format specification ("Icechunk Spec"), which is versioned by a single integer. The spec version increments if and only if there is an on-disk incompatible change. The current spec is [version 2](./spec.md) (used by Icechunk 2.x); the previous format is documented in [version 1](./spec-v1.md) (used by Icechunk 1.x).
 
 ## Library Versions
 

--- a/icechunk-python/docs/mkdocs.yml
+++ b/icechunk-python/docs/mkdocs.yml
@@ -255,7 +255,9 @@ nav:
   - Related Projects: related-projects.md
   - Blog: blog-posts.md
   - Reference:
-    - Spec: reference/spec.md
+    - Spec:
+      - v2 (current): reference/spec.md
+      - v1: reference/spec-v1.md
     - Version Policy: reference/version-policy.md
     - Python API Reference:
       - reference/index.md


### PR DESCRIPTION
## Summary

- Nest the two spec pages under a `Spec` section in the docs nav (`v2 (current)` and `v1`), so the v1 spec is reachable from the sidebar.
- Add prominent cross-links between `reference/spec.md` (v2) and `reference/spec-v1.md` (v1), and clarify which Icechunk library major version each spec corresponds to.
- Update `reference/version-policy.md` to link both spec versions explicitly.