### PR TITLE
Don't run tests that require secrets if they are empty

### DIFF
--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -171,7 +171,9 @@ where
         ("azure_blob_slash", s4slash),
     ];
 
-    if env::var("AWS_BUCKET").is_ok() {
+    if let Ok(e) = env::var("AWS_BUCKET")
+        && !e.is_empty()
+    {
         let prefix = common::get_random_prefix("with_storage");
         let s = common::make_aws_integration_storage(prefix.clone())?;
         storages.push(("AWS", s));
@@ -180,7 +182,9 @@ where
         let s = common::make_aws_integration_storage(prefix.clone())?;
         storages.push(("AWS_slash", s));
     }
-    if env::var("R2_BUCKET").is_ok() {
+    if let Ok(e) = env::var("R2_BUCKET")
+        && !e.is_empty()
+    {
         let prefix = common::get_random_prefix("with_storage");
         let s = common::make_r2_integration_storage(prefix.clone())?;
         storages.push(("R2", s));
@@ -189,7 +193,7 @@ where
         let s = common::make_r2_integration_storage(prefix.clone())?;
         storages.push(("R2_slash", s));
     }
-    // if env::var("TIGRIS_BUCKET").is_ok() {
+    // if let Ok(e) = env::var("TIGRIS_BUCKET") && !e.is_empty() {
     //     let prefix = common::get_random_prefix("with_storage");
     //     let s = common::make_tigris_integration_storage(prefix.clone())?;
     //     storages.push(("Tigris", s));

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -814,7 +814,10 @@ pub async fn test_write_config_can_overwrite_with_unsafe_config(
 
 #[tokio_test]
 pub async fn test_storage_classes() -> Result<(), Box<dyn std::error::Error>> {
-    if env::var("AWS_BUCKET").is_err() {
+    if let Ok(e) = env::var("AWS_BUCKET")
+        && !e.is_empty()
+    {
+    } else {
         return Ok(());
     }
     let prefix = common::get_random_prefix("test_storage_classes");


### PR DESCRIPTION
We frequently have issues when running tests for specific S3-compatible storages that requires GHA secrets because [only users in the org have access to them](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow), and external contributors see failed tests (that they can't fix).

Since "If a secret has not been set, the return value of an expression referencing the secret (such as ${{ secrets.SuperSecret }} in the example) will be an empty string.", this PR checks if the env var both exists and is not empty, instead of just checking for existence.