### PR TITLE
docs: render changelog in the docs site

### DIFF
--- a/icechunk-python/docs/docs/reference/changelog.md
+++ b/icechunk-python/docs/docs/reference/changelog.md
@@ -1,0 +1,1 @@
+../../../../Changelog.python.md

--- a/icechunk-python/docs/mkdocs.yml
+++ b/icechunk-python/docs/mkdocs.yml
@@ -273,6 +273,7 @@ nav:
       - icechunk.dask: reference/dask.md
     - Icechunk JavaScript / TypeScript: reference/icechunk-js.md
     - Icechunk Rust: reference/icechunk-rust.md
+    - Changelog: reference/changelog.md
     - Contributing: reference/contributing.md
     - AI Usage Policy: reference/ai-policy.md
     - Migrate to 1.0: reference/migration.md


### PR DESCRIPTION
## Summary

The changelog (`Changelog.python.md`, with `Changelog.md` symlinked to it) lives at the repo root but was never referenced by the MkDocs nav, so the docs site never rendered it. Readers had to go find it in the GitHub repo.

This adds a **Changelog** page under the **Reference** section.

## Approach

The new `reference/changelog.md` is a symlink to the repo-root `Changelog.python.md`, mirroring the existing `Changelog.md -> Changelog.python.md` symlink already in the repo. This keeps the rendered docs automatically in sync with the changelog — no plugin directive or duplicated content to maintain.

## Notes

- Symlinks require `core.symlinks=true` on checkout (the default on macOS/Linux). This is consistent with the repo's existing root-level changelog symlink.
- Verified locally with `mkdocs build`: the page renders the changelog content under `reference/changelog/`.