### PR TITLE
Harden setup_toxiproxy against stale toxic-laden proxies

### DIFF
--- a/icechunk/tests/test_flaky_connections.rs
+++ b/icechunk/tests/test_flaky_connections.rs
@@ -54,32 +54,37 @@ fn create_proxied_storage(
     Ok(Arc::new(storage))
 }
 
+/// Delete a proxy by name via the toxiproxy REST API, ignoring a 404.
+///
+/// We can't use `noxious_client` for this: its deserializer chokes on any proxy
+/// that has toxics attached (e.g. left behind by a crashed run), which is
+/// exactly the case we need to clean up. The raw REST endpoint doesn't
+/// deserialize toxics, so it always works.
+async fn delete_proxy_via_api(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let url = format!("http://localhost:8474/proxies/{name}");
+    let resp = reqwest::Client::new().delete(&url).send().await?;
+    // 204 = deleted, 404 = wasn't there; both are fine.
+    if !resp.status().is_success() && resp.status() != reqwest::StatusCode::NOT_FOUND {
+        let text = resp.text().await?;
+        return Err(format!("Failed to delete proxy {name}: {text}").into());
+    }
+    Ok(())
+}
+
 /// Set up toxiproxy: create a new proxy on the given port, return (client, `proxy_name`).
-/// If another proxy already holds the port (e.g. from a crashed test), it is
-/// deleted first. Each test deletes its own proxy on cleanup.
+/// Any existing proxy with the same name (e.g. left by a crashed test run) is
+/// deleted first so `create_proxy` can't 409. Each test deletes its own proxy
+/// on cleanup.
 async fn setup_toxiproxy(
     name: &str,
     port: u16,
 ) -> Result<(Client, String), Box<dyn std::error::Error>> {
     let client = Client::new("http://localhost:8474");
 
-    // Delete any proxy already bound to this port.
-    // This handles leftover proxies from crashed/aborted test runs without
-    // wiping unrelated proxies.
-    // Uncomment the block below to nuke all proxies during development:
-    // let proxies = client.proxies().await.unwrap_or_default();
-    // for (name, proxy) in proxies {
-    //     println!("   Deleting old proxy: {}", name);
-    //     proxy.delete().await.ok();
-    // }
-    let port_suffix = format!(":{port}");
-    let proxies = client.proxies().await.unwrap_or_default();
-    for (name, proxy) in proxies {
-        if proxy.config.listen.ends_with(&port_suffix) {
-            println!("Deleting stale proxy on :{port}: {name}");
-            let _ = proxy.delete().await;
-        }
-    }
+    // Delete by name before creating. This survives a crashed run that left a
+    // toxic-laden proxy — unlike scanning `client.proxies()`, whose deserializer
+    // fails on proxies that have toxics attached.
+    delete_proxy_via_api(name).await?;
 
     let listen = format!("0.0.0.0:{port}");
     let name = name.to_string();


### PR DESCRIPTION
Delete the target proxy by name before creating it, instead of scanning client.proxies(). The scan's deserializer fails on any proxy that has toxics attached.