### PR TITLE
release: Prepare 2.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-arrow-object-store"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-format"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "base32",
  "bytes",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-macros"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-python"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-s3"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-storage"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-types"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates
-icechunk = { path = "icechunk", version = "2.0.5" }
-icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.0.5", default-features = false }
-icechunk-format = { path = "icechunk-format", version = "2.0.5" }
-icechunk-macros = { path = "icechunk-macros", version = "2.0.5" }
-icechunk-s3 = { path = "icechunk-s3", version = "2.0.5" }
-icechunk-storage = { path = "icechunk-storage", version = "2.0.5" }
-icechunk-types = { path = "icechunk-types", version = "2.0.5" }
+icechunk = { path = "icechunk", version = "2.0.6" }
+icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.0.6", default-features = false }
+icechunk-format = { path = "icechunk-format", version = "2.0.6" }
+icechunk-macros = { path = "icechunk-macros", version = "2.0.6" }
+icechunk-s3 = { path = "icechunk-s3", version = "2.0.6" }
+icechunk-storage = { path = "icechunk-storage", version = "2.0.6" }
+icechunk-types = { path = "icechunk-types", version = "2.0.6" }
 
 # External dependencies
 anyhow = "1.0.102"

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Don't force creation of a directory when opening a repo in local file storage ([#2145](https://github.com/earth-mover/icechunk/pull/2145)).
+- Implement decompression and flatbuffer verification on spawn_blocking tasks ([#2164](https://github.com/earth-mover/icechunk/pull/2164)).
 
 ## Python Icechunk Library 2.0.5
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Don't create a local path when opening (rather than creating) a repository ([#2145](https://github.com/earth-mover/icechunk/pull/2145)).
+- Don't force creation of a directory when opening a repo in local file storage ([#2145](https://github.com/earth-mover/icechunk/pull/2145)).
 
 ## Python Icechunk Library 2.0.5
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Python Icechunk Library 2.0.6
+
+### Features
+
+- Add anonymous credential support for Azure Blob Storage ([#2168](https://github.com/earth-mover/icechunk/pull/2168)).
+
+### Fixes
+
+- Don't create a local path when opening (rather than creating) a repository ([#2145](https://github.com/earth-mover/icechunk/pull/2145)).
+
 ## Python Icechunk Library 2.0.5
 
 ### Features

--- a/icechunk-arrow-object-store/Cargo.toml
+++ b/icechunk-arrow-object-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-arrow-object-store"
-version = "2.0.5"
+version = "2.0.6"
 description = "Apache Arrow object_store storage backend for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-format/Cargo.toml
+++ b/icechunk-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-format"
-version = "2.0.5"
+version = "2.0.6"
 description = "Binary format types and serialization for the Icechunk storage engine"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-js/package.json
+++ b/icechunk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthmover/icechunk",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "JavaScript/TypeScript bindings for Icechunk",
   "main": "index.js",
   "repository": {

--- a/icechunk-macros/Cargo.toml
+++ b/icechunk-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "icechunk-macros"
 description = "Support and helper macros for the Icechunk library"
-version = "2.0.5"
+version = "2.0.6"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"
 homepage = "https://icechunk.io"

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-python"
-version = "2.0.5"
+version = "2.0.6"
 description = "Transactional storage engine for Zarr designed for use on cloud object storage"
 readme = "README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-s3/Cargo.toml
+++ b/icechunk-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-s3"
-version = "2.0.5"
+version = "2.0.6"
 description = "Native AWS S3 storage backend for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-storage/Cargo.toml
+++ b/icechunk-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-storage"
-version = "2.0.5"
+version = "2.0.6"
 description = "Storage trait and shared types for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-types/Cargo.toml
+++ b/icechunk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-types"
-version = "2.0.5"
+version = "2.0.6"
 description = "Shared foundational types for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -143,5 +143,8 @@ path = "tests/test_shuttle.rs"
 name = "main"
 harness = false
 
+[lib]
+bench = false
+
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk"
-version = "2.0.5"
+version = "2.0.6"
 description = "Transactional storage engine for Zarr designed for use on cloud object storage"
 readme = "README.md"
 repository = "https://github.com/earth-mover/icechunk"


### PR DESCRIPTION
### Features

- Add anonymous credential support for Azure Blob Storage ([#2168](https://github.com/earth-mover/icechunk/pull/2168)).

### Fixes

- Don't force creation of a directory when opening a repo in local file storage ([#2145](https://github.com/earth-mover/icechunk/pull/2145)).
- Implement decompression and flatbuffer verification on spawn_blocking tasks ([#2164](https://github.com/earth-mover/icechunk/pull/2164)).