### PR TITLE
Move icechunk-js release LTO to .cargo/config

### DIFF
--- a/icechunk-js/.cargo/config.toml
+++ b/icechunk-js/.cargo/config.toml
@@ -1,2 +1,10 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+# Release-profile tuning for the napi cdylib. Lives here rather than in
+# Cargo.toml because workspace members can't set profiles (Cargo ignores them
+# and warns); a config-file profile is discovered when `napi build` runs from
+# this directory and merges over the workspace-root release profile.
+[profile.release]
+lto = "fat"
+strip = "symbols"

--- a/icechunk-js/Cargo.toml
+++ b/icechunk-js/Cargo.toml
@@ -36,7 +36,3 @@ icechunk = { path = "../icechunk", default-features = false, features = ["napi-s
 
 [build-dependencies]
 napi-build = "2"
-
-[profile.release]
-lto = true
-strip = "symbols"


### PR DESCRIPTION
This clears a cargo warning