### PR TITLE
Remove `pub` from test functions

### DIFF
--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -31,14 +31,14 @@ use crate::common;
 use crate::common::Permission;
 
 #[tokio_test]
-pub async fn test_gc_in_minio_spec_v1() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_gc_in_minio_spec_v1() -> Result<(), Box<dyn std::error::Error>> {
     let prefix = format!("test_gc_v1_{}", Utc::now().timestamp_millis());
     let storage = common::make_minio_integration_storage(prefix, &Permission::Modify)?;
     do_test_gc(storage, Some(SpecVersionBin::V1)).await
 }
 
 #[tokio_test]
-pub async fn test_gc_in_minio_spec_v2() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_gc_in_minio_spec_v2() -> Result<(), Box<dyn std::error::Error>> {
     let prefix = format!("test_gc_v2_{}", Utc::now().timestamp_millis());
     let storage = common::make_minio_integration_storage(prefix, &Permission::Modify)?;
     do_test_gc(storage, Some(SpecVersionBin::V2)).await
@@ -46,7 +46,7 @@ pub async fn test_gc_in_minio_spec_v2() -> Result<(), Box<dyn std::error::Error>
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-pub async fn test_gc_in_aws() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_gc_in_aws() -> Result<(), Box<dyn std::error::Error>> {
     let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
     let storage = common::make_aws_integration_storage(prefix)?;
     do_test_gc(storage, None).await
@@ -54,7 +54,7 @@ pub async fn test_gc_in_aws() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-pub async fn test_gc_in_r2() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_gc_in_r2() -> Result<(), Box<dyn std::error::Error>> {
     let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
     let storage = common::make_r2_integration_storage(prefix)?;
     do_test_gc(storage, None).await
@@ -62,7 +62,7 @@ pub async fn test_gc_in_r2() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-pub async fn test_gc_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_gc_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
     let prefix = format!("test_gc_{}", Utc::now().timestamp_millis());
     let storage = common::make_tigris_integration_storage(prefix)?;
     do_test_gc(storage, None).await
@@ -337,14 +337,14 @@ async fn make_design_doc_repo(
 }
 
 #[tokio_test]
-pub async fn test_expire_and_garbage_collect_in_memory()
+async fn test_expire_and_garbage_collect_in_memory()
 -> Result<(), Box<dyn std::error::Error>> {
     let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
     do_test_expire_and_garbage_collect(storage).await
 }
 
 #[tokio_test]
-pub async fn test_expire_and_garbage_collect_in_minio()
+async fn test_expire_and_garbage_collect_in_minio()
 -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
         format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
@@ -355,7 +355,7 @@ pub async fn test_expire_and_garbage_collect_in_minio()
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-pub async fn test_expire_and_garbage_collect_in_aws()
+async fn test_expire_and_garbage_collect_in_aws()
 -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
         format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
@@ -366,7 +366,7 @@ pub async fn test_expire_and_garbage_collect_in_aws()
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-pub async fn test_expire_and_garbage_collect_in_r2()
+async fn test_expire_and_garbage_collect_in_r2()
 -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
         format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
@@ -377,7 +377,7 @@ pub async fn test_expire_and_garbage_collect_in_r2()
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-pub async fn test_expire_and_garbage_collect_in_tigris()
+async fn test_expire_and_garbage_collect_in_tigris()
 -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
         format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
@@ -506,7 +506,7 @@ async fn do_test_expire_and_garbage_collect(
 ///
 /// We then, expire old snapshots and garbage collect. We verify we end up
 /// with what is expected according to the design document.
-pub async fn test_expire_and_garbage_collect_deleting_expired_refs()
+async fn test_expire_and_garbage_collect_deleting_expired_refs()
 -> Result<(), Box<dyn std::error::Error>> {
     let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
     let storage_settings = storage.default_settings().await?;
@@ -658,7 +658,7 @@ async fn test_gc_reset_branch() -> Result<(), Box<dyn std::error::Error>> {
 /// When two branches point to the same old commit, expire with
 /// `delete_expired_branches` should still delete the non-main branch.
 #[tokio_test]
-pub async fn test_expire_deletes_branch_sharing_tip_with_main()
+async fn test_expire_deletes_branch_sharing_tip_with_main()
 -> Result<(), Box<dyn std::error::Error>> {
     let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
     let storage_settings = storage.default_settings().await?;

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -355,8 +355,8 @@ async fn test_expire_and_garbage_collect_in_minio()
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-async fn test_expire_and_garbage_collect_in_aws()
--> Result<(), Box<dyn std::error::Error>> {
+async fn test_expire_and_garbage_collect_in_aws() -> Result<(), Box<dyn std::error::Error>>
+{
     let prefix =
         format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
     let storage: Arc<dyn Storage + Send + Sync> =
@@ -366,8 +366,8 @@ async fn test_expire_and_garbage_collect_in_aws()
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
-async fn test_expire_and_garbage_collect_in_r2()
--> Result<(), Box<dyn std::error::Error>> {
+async fn test_expire_and_garbage_collect_in_r2() -> Result<(), Box<dyn std::error::Error>>
+{
     let prefix =
         format!("test_expire_and_garbage_collect_{}", Utc::now().timestamp_millis());
     let storage: Arc<dyn Storage + Send + Sync> =

--- a/icechunk/tests/test_stats.rs
+++ b/icechunk/tests/test_stats.rs
@@ -33,7 +33,7 @@ fn spec_version_cases(#[case] spec_version: SpecVersionBin) {}
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_repo_chunks_storage_in_memory(
+async fn test_repo_chunks_storage_in_memory(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage = new_in_memory_storage().await?;
@@ -42,7 +42,7 @@ pub async fn test_repo_chunks_storage_in_memory(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_repo_chunks_storage_in_minio(
+async fn test_repo_chunks_storage_in_minio(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
@@ -54,7 +54,7 @@ pub async fn test_repo_chunks_storage_in_minio(
 #[tokio_test]
 #[apply(spec_version_cases)]
 #[ignore = "needs credentials from env"]
-pub async fn test_repo_chunks_storage_in_aws(
+async fn test_repo_chunks_storage_in_aws(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
@@ -66,7 +66,7 @@ pub async fn test_repo_chunks_storage_in_aws(
 #[tokio_test]
 #[apply(spec_version_cases)]
 #[ignore = "needs credentials from env"]
-pub async fn test_repo_chunks_storage_in_tigris(
+async fn test_repo_chunks_storage_in_tigris(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
@@ -78,7 +78,7 @@ pub async fn test_repo_chunks_storage_in_tigris(
 #[tokio_test]
 #[apply(spec_version_cases)]
 #[ignore = "needs credentials from env"]
-pub async fn test_repo_chunks_storage_in_r2(
+async fn test_repo_chunks_storage_in_r2(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let prefix =
@@ -248,7 +248,7 @@ async fn do_test_repo_chunks_storage(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_virtual_chunk_deduplication(
+async fn test_virtual_chunk_deduplication(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let storage = new_in_memory_storage().await?;

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -221,7 +221,7 @@ async fn async_read_to_bytes(
 }
 
 #[tokio_test]
-pub async fn test_object_write_read() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_object_write_read() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
         let storage_settings = storage.default_settings().await?;
         let id = SnapshotId::random();
@@ -277,7 +277,7 @@ pub async fn test_object_write_read() -> Result<(), Box<dyn std::error::Error>> 
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_tag_write_get(
+async fn test_tag_write_get(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -300,7 +300,7 @@ pub async fn test_tag_write_get(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_fetch_non_existing_tag(
+async fn test_fetch_non_existing_tag(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -323,7 +323,7 @@ pub async fn test_fetch_non_existing_tag(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_create_existing_tag(
+async fn test_create_existing_tag(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -344,7 +344,7 @@ pub async fn test_create_existing_tag(
 }
 
 #[tokio_test]
-pub async fn check_clean_repo() -> Result<(), Box<dyn std::error::Error>> {
+async fn check_clean_repo() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
         let _repo = Repository::create(
             None,
@@ -388,7 +388,7 @@ pub async fn check_clean_repo() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio_test]
-pub async fn test_list_objects() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_list_objects() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
         let settings = storage.default_settings().await?;
         storage
@@ -488,7 +488,7 @@ pub async fn test_list_objects() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio_test]
-pub async fn test_delete_objects() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_delete_objects() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
         let settings = storage.default_settings().await?;
         storage
@@ -590,7 +590,7 @@ pub async fn test_delete_objects() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_fetch_non_existing_branch(
+async fn test_fetch_non_existing_branch(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -611,7 +611,7 @@ pub async fn test_fetch_non_existing_branch(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_write_config_on_empty(
+async fn test_write_config_on_empty(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -647,7 +647,7 @@ pub async fn test_write_config_on_empty(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_write_config_on_existing(
+async fn test_write_config_on_existing(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -683,7 +683,7 @@ pub async fn test_write_config_on_existing(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_write_config_fails_on_bad_version_when_non_existing(
+async fn test_write_config_fails_on_bad_version_when_non_existing(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // FIXME: this test fails in MinIO but seems to work on S3
@@ -716,7 +716,7 @@ pub async fn test_write_config_fails_on_bad_version_when_non_existing(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_write_config_fails_on_bad_version_when_existing(
+async fn test_write_config_fails_on_bad_version_when_existing(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |storage_type, storage| async move {
@@ -770,7 +770,7 @@ pub async fn test_write_config_fails_on_bad_version_when_existing(
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_write_config_can_overwrite_with_unsafe_config(
+async fn test_write_config_can_overwrite_with_unsafe_config(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
@@ -813,7 +813,7 @@ pub async fn test_write_config_can_overwrite_with_unsafe_config(
 }
 
 #[tokio_test]
-pub async fn test_storage_classes() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_storage_classes() -> Result<(), Box<dyn std::error::Error>> {
     if let Ok(e) = env::var("AWS_BUCKET")
         && !e.is_empty()
     {
@@ -930,7 +930,7 @@ async fn test_write_object_larger_than_multipart_threshold()
 }
 
 #[tokio_test]
-pub async fn test_get_object_conditional() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_get_object_conditional() -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {
         let storage_settings = storage.default_settings().await?;
         let id = SnapshotId::random();
@@ -1104,7 +1104,7 @@ async fn test_redirect_storage() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio_test]
 #[apply(spec_version_cases)]
-pub async fn test_basic_repo_ops(
+async fn test_basic_repo_ops(
     #[case] spec_version: SpecVersionBin,
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_storage(Permission::Modify, |_, storage| async move {


### PR DESCRIPTION
This is necessary (or at least convenient) for the next release of error_log