### PR TITLE
Clean up outdated `consolidated=False` argument

### DIFF
--- a/icechunk-python/benchmarks/create_era5.py
+++ b/icechunk-python/benchmarks/create_era5.py
@@ -27,7 +27,7 @@ from icechunk.xarray import to_icechunk
 logger = helpers.setup_logger()
 
 ICECHUNK_FORMAT = f"v{ic.spec_version():d}"
-ZARR_KWARGS = dict(zarr_format=3, consolidated=False)
+ZARR_KWARGS = dict(zarr_format=3)
 
 
 class Mode(StrEnum):
@@ -58,7 +58,7 @@ def verify(dataset: Dataset, *, ingest: IngestDataset, seed: int | None = None):
     repo = ic.Repository.open(dataset.storage)
     session = repo.readonly_session(branch="main")
     instore = xr.open_dataset(
-        session.store, group=dataset.group, engine="zarr", chunks=None, consolidated=False
+        session.store, group=dataset.group, engine="zarr", chunks=None
     )
     time = pd.Timestamp(random.choice(instore.time.data.tolist()))
     logger.info(f"Verifying {ingest.name} for {seed=!r}, {time=!r}")

--- a/icechunk-python/benchmarks/datasets.py
+++ b/icechunk-python/benchmarks/datasets.py
@@ -345,9 +345,7 @@ def setup_era5_single(dataset: Dataset):
         "PV": {"compressors": [zarr.codecs.ZstdCodec()], "chunks": (1, 1, 721, 1440)}
     }
     logger.info("Writing data...")
-    ds.to_zarr(
-        session.store, mode="w", zarr_format=3, encoding=encoding
-    )
+    ds.to_zarr(session.store, mode="w", zarr_format=3, encoding=encoding)
     logger.info(f"Wrote data in {time.time() - tic} seconds")
     session.commit(f"wrote data at {datetime.datetime.now(datetime.UTC)}")
 

--- a/icechunk-python/benchmarks/datasets.py
+++ b/icechunk-python/benchmarks/datasets.py
@@ -28,7 +28,7 @@ rng = np.random.default_rng(seed=123)
 
 type Store = Literal["s3", "gcs", "az", "tigris"]
 PUBLIC_DATA_BUCKET = "icechunk-public-data"
-ZARR_KWARGS = dict(zarr_format=3, consolidated=False)
+ZARR_KWARGS = dict(zarr_format=3)
 
 CONSTRUCTORS = {
     "s3": ic.s3_storage,
@@ -346,7 +346,7 @@ def setup_era5_single(dataset: Dataset):
     }
     logger.info("Writing data...")
     ds.to_zarr(
-        session.store, mode="w", zarr_format=3, consolidated=False, encoding=encoding
+        session.store, mode="w", zarr_format=3, encoding=encoding
     )
     logger.info(f"Wrote data in {time.time() - tic} seconds")
     session.commit(f"wrote data at {datetime.datetime.now(datetime.UTC)}")

--- a/icechunk-python/benchmarks/test_benchmark_reads.py
+++ b/icechunk-python/benchmarks/test_benchmark_reads.py
@@ -108,7 +108,6 @@ def test_time_xarray_open(synth_dataset: Dataset, benchmark) -> None:
             synth_dataset.store,
             group=synth_dataset.group,
             chunks=None,
-            consolidated=False,
         )
 
 
@@ -142,7 +141,6 @@ def test_time_xarray_read_chunks_cold_cache(
             repo.readonly_session("main").store,
             group=synth_dataset.group,
             chunks=None,
-            consolidated=False,
         )
         subset = ds.isel(subsetter)
         subset[synth_dataset.load_variables].compute()
@@ -164,7 +162,6 @@ def test_time_xarray_read_chunks_hot_cache(
         repo.readonly_session("main").store,
         group=synth_dataset.group,
         chunks=None,
-        consolidated=False,
     )
     subset = ds.isel(synth_dataset.chunk_selector)
     # important this cannot be `load`

--- a/icechunk-python/docs/docs/getting-started/howto.md
+++ b/icechunk-python/docs/docs/getting-started/howto.md
@@ -137,13 +137,13 @@ For more depth, see [Xarray](../guides/xarray.md), [Parallel writes](../understa
 ### Write an in-memory Xarray Dataset
 
 ```python
-ds.to_zarr(session.store, group="my-group", zarr_format=3, consolidated=False)
+ds.to_zarr(session.store, group="my-group", zarr_format=3)
 ```
 
 ### Append to an existing datast
 
 ```python
-ds.to_zarr(session.store, group="my-group", append_dim='time', consolidated=False)
+ds.to_zarr(session.store, group="my-group", append_dim='time')
 ```
 
 ### Write an Xarray dataset with Dask
@@ -162,7 +162,7 @@ Reading can be done with a read-only session.
 
 ```python
 session = repo.readonly_session("main")
-ds = xr.open_zarr(session.store, group="my-group", zarr_format=3, consolidated=False)
+ds = xr.open_zarr(session.store, group="my-group", zarr_format=3)
 ```
 
 ## Transactions and Version Control

--- a/icechunk-python/docs/docs/guides/dask.md
+++ b/icechunk-python/docs/docs/guides/dask.md
@@ -100,7 +100,7 @@ icechunk.xarray.to_icechunk(dataset, session, mode="w")
 # remember you must commit before executing a distributed read.
 print(session.commit("wrote an Xarray dataset!"))
 
-roundtripped = xr.open_zarr(session.store, consolidated=False)
+roundtripped = xr.open_zarr(session.store)
 print(dataset.identical(roundtripped))
 ```
 

--- a/icechunk-python/docs/docs/guides/ingestion/glad-ingest.ipynb
+++ b/icechunk-python/docs/docs/guides/ingestion/glad-ingest.ipynb
@@ -458,7 +458,6 @@
     "    compute=False,  # important, don't write data values, just the array metadata!\n",
     "    mode=\"w\",\n",
     "    encoding={\"lclu\": {\"chunks\": ZARR_CHUNK_SIZE, \"fill_value\": 255}},\n",
-    "    consolidated=False,\n",
     ")\n",
     "session.commit(\"initialize array\")"
    ]
@@ -506,7 +505,6 @@
     "    tile.drop_vars(\"spatial_ref\").to_zarr(\n",
     "        session.store,\n",
     "        region=tiling.get_region(tile),\n",
-    "        consolidated=False,\n",
     "    )\n",
     "    return session"
    ]
@@ -1354,7 +1352,7 @@
    ],
    "source": [
     "ds = xr.open_dataset(\n",
-    "    repo.readonly_session(\"main\").store, engine=\"zarr\", consolidated=False\n",
+    "    repo.readonly_session(\"main\").store, engine=\"zarr\"\n",
     ")\n",
     "ds"
    ]

--- a/icechunk-python/docs/docs/guides/virtual.md
+++ b/icechunk-python/docs/docs/guides/virtual.md
@@ -151,7 +151,6 @@ Now we can read the dataset from the store using xarray to confirm everything we
 ds = xr.open_zarr(
     session.store,
     zarr_version=3,
-    consolidated=False,
     chunks={},
 )
 

--- a/icechunk-python/docs/docs/guides/xarray.md
+++ b/icechunk-python/docs/docs/guides/xarray.md
@@ -23,9 +23,7 @@ and `icechunk.xarray.to_icechunk` methods.
     See [these docs on orchestrating parallel writes](../understanding/parallel.md) and [these docs on dask.array with distributed](./dask.md#icechunk-dask-xarray)
     for more.
 
-    If using `to_zarr`, remember to set `zarr_format=3, consolidated=False`. Consolidated metadata
-    is unnecessary (and unsupported) in Icechunk. Icechunk already organizes the dataset metadata
-    in a way that makes it very fast to fetch from storage.
+    If using `to_zarr`, remember to set `zarr_format=3` to avoid an extra check for the zarr format.
 
 
 In this example, we'll explain how to create a new Icechunk repo, write some sample data
@@ -127,7 +125,7 @@ print(session.commit("append more data"))
 
 ```python exec="on" session="xarray" source="material-block" result="code"
 xr.set_options(display_style="text")
-print(xr.open_zarr(session.store, consolidated=False))
+print(xr.open_zarr(session.store))
 ```
 
 We can also read data from previous snapshots by checking out prior versions:
@@ -135,7 +133,7 @@ We can also read data from previous snapshots by checking out prior versions:
 ```python exec="on" session="xarray" source="material-block" result="code"
 session = repo.readonly_session(snapshot_id=first_snapshot)
 
-print(xr.open_zarr(session.store, consolidated=False))
+print(xr.open_zarr(session.store))
 ```
 
 Notice that this second `xarray.Dataset` has a time dimension of length 18 whereas the

--- a/icechunk-python/docs/docs/sample-datasets.md
+++ b/icechunk-python/docs/docs/sample-datasets.md
@@ -32,7 +32,7 @@ A subset of the Weatherbench2 copy of the ERA5 reanalysis dataset.
     repo = ic.Repository.open(storage=storage)
     session = repo.readonly_session("main")
     ds = xr.open_dataset(
-        session.store, group="1x721x1440", engine="zarr", chunks=None, consolidated=False
+        session.store, group="1x721x1440", engine="zarr", chunks=None
     )
     ```
 
@@ -69,7 +69,7 @@ A subset of the Weatherbench2 copy of the ERA5 reanalysis dataset.
     repo = ic.Repository.open(storage=storage)
     session = repo.readonly_session("main")
     ds = xr.open_dataset(
-        session.store, group="1x721x1440", engine="zarr", chunks=None, consolidated=False
+        session.store, group="1x721x1440", engine="zarr", chunks=None
     )
     ```
 
@@ -139,7 +139,7 @@ See [source](https://storage.googleapis.com/earthenginepartners-hansen/GLCLU2000
     repo = ic.Repository.open(storage=storage)
     session = repo.readonly_session("main")
     ds = xr.open_dataset(
-        session.store, chunks=None, consolidated=False, engine="zarr"
+        session.store, chunks=None, engine="zarr"
     )
     ```
 

--- a/icechunk-python/docs/docs/understanding/parallel.md
+++ b/icechunk-python/docs/docs/understanding/parallel.md
@@ -42,7 +42,7 @@ and `compute=False`, this will NOT write any chunked array data, but will write 
 in-memory arrays (only `time` in this case).
 
 ```python exec="on" session="parallel" source="material-block"
-ds.to_zarr(session.store, compute=False, encoding={"Tair": {"chunks": chunks}}, mode="w", consolidated=False)
+ds.to_zarr(session.store, compute=False, encoding={"Tair": {"chunks": chunks}}, mode="w")
 # this commit is optional, but may be useful in your workflow
 print(session.commit("initialize store"))
 ```
@@ -56,7 +56,7 @@ def write_timestamp(*, itime: int, session: ic.session.Session) -> None:
     # pass a list to isel to preserve the time dimension
     ds = xr.tutorial.open_dataset("rasm").isel(time=[itime])
     # region="auto" tells Xarray to infer which "region" of the output arrays to write to.
-    ds.to_zarr(session.store, region="auto", consolidated=False)
+    ds.to_zarr(session.store, region="auto")
 ```
 
 Now execute the writes.
@@ -77,7 +77,7 @@ print(session.commit("finished writes"))
 Verify that the writes worked as expected:
 
 ```python exec="on" session="parallel" source="material-block" result="code"
-ondisk = xr.open_zarr(repo.readonly_session("main").store, consolidated=False)
+ondisk = xr.open_zarr(repo.readonly_session("main").store)
 xr.testing.assert_identical(ds, ondisk)
 ```
 
@@ -119,7 +119,7 @@ def write_timestamp(*, itime: int, session: ic.session.ForkSession) -> ic.sessio
     # pass a list to isel to preserve the time dimension
     ds = xr.tutorial.open_dataset("rasm").isel(time=[itime])
     # region="auto" tells Xarray to infer which "region" of the output arrays to write to.
-    ds.to_zarr(session.store, region="auto", consolidated=False)
+    ds.to_zarr(session.store, region="auto")
     return session
 ```
 
@@ -153,7 +153,7 @@ print(session.commit("finished writes"))
 Verify that the writes worked as expected:
 
 ```python
-ondisk = xr.open_zarr(repo.readonly_session("main").store, consolidated=False)
+ondisk = xr.open_zarr(repo.readonly_session("main").store)
 xr.testing.assert_identical(ds, ondisk)
 ```
 

--- a/icechunk-python/examples/mpwrite.py
+++ b/icechunk-python/examples/mpwrite.py
@@ -28,7 +28,7 @@ def write_timestamp(*, itime: int, session: Session) -> Session:
     # and index out the right time value
     ds = make_dataset().isel(time=[itime])
     # region="auto" tells Xarray to infer which "region" of the output arrays to write to.
-    ds.to_zarr(session.store, region="auto", consolidated=False)
+    ds.to_zarr(session.store, region="auto")
     return session
 
 
@@ -44,7 +44,6 @@ if __name__ == "__main__":
         compute=False,
         encoding={"Tair": {"chunks": chunks}},
         mode="w",
-        consolidated=False,
     )
     # this commit is optional, but may be useful in your workflow
     session.commit("initialize store")
@@ -65,5 +64,5 @@ if __name__ == "__main__":
     session.merge(*fork_sessions)
     session.commit("finished writes")
 
-    ondisk = xr.open_zarr(repo.readonly_session("main").store, consolidated=False)
+    ondisk = xr.open_zarr(repo.readonly_session("main").store)
     xr.testing.assert_identical(ds, ondisk)


### PR DESCRIPTION
Icechunk pins a recent `xarray` version that doesn't require `consolidated=False` anymore. Clean up docs to avoid confusion.