### PR TITLE
Enable nix dev env on macOS

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -43,7 +43,14 @@ gen-flatbuffers:
 
 [doc("Prepare environment for development")]
 develop *args:
-  cd icechunk-python && maturin develop --uv --profile {{profile}} "$@"
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd icechunk-python
+  if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    export VIRTUAL_ENV="$CONDA_PREFIX"
+    export UV_NO_SYNC=1
+  fi
+  exec uv run --active maturin develop --uv --profile {{profile}} "$@"
 
 [doc("Install maturin import hook for more convenient development flow")]
 import-hook:
@@ -147,7 +154,14 @@ py-pre-commit $SKIP="rust-pre-commit-fast,rust-pre-commit,rust-pre-commit-ci" *a
 
 [doc("Run Python tests via pytest")]
 pytest *args:
-  cd icechunk-python && uv run pytest "$@"
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd icechunk-python
+  if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    export VIRTUAL_ENV="$CONDA_PREFIX"
+    export UV_NO_SYNC=1
+  fi
+  exec uv run --active pytest "$@"
 
 [doc("Regenerate the post-expiration can_read_old fixtures (needs icechunk 1.1.21 + 2.0.5 wheels, installed via third-wheel)")]
 gen-expired-fixtures *args:

--- a/Justfile
+++ b/Justfile
@@ -50,7 +50,7 @@ develop *args:
     export VIRTUAL_ENV="$CONDA_PREFIX"
     export UV_NO_SYNC=1
   fi
-  exec uv run --active maturin develop --uv --profile {{profile}} "$@"
+  uv run --active maturin develop --uv --profile {{profile}} "$@"
 
 [doc("Install maturin import hook for more convenient development flow")]
 import-hook:
@@ -161,7 +161,7 @@ pytest *args:
     export VIRTUAL_ENV="$CONDA_PREFIX"
     export UV_NO_SYNC=1
   fi
-  exec uv run --active pytest "$@"
+  uv run --active pytest "$@"
 
 [doc("Regenerate the post-expiration can_read_old fixtures (needs icechunk 1.1.21 + 2.0.5 wheels, installed via third-wheel)")]
 gen-expired-fixtures *args:

--- a/flake.nix
+++ b/flake.nix
@@ -69,155 +69,176 @@
       # It's using https://pyproject-nix.github.io/pyproject.nix/build.html
     };
 
-    # This example is only using x86_64-linux
-    pkgs = nixpkgs.legacyPackages.x86_64-linux;
-
-    # Use Python 3.12 from nixpkgs
-    python = pkgs.python312;
-
-    # Construct package set
-    pythonSet =
-      # Use base package set from pyproject.nix builders
-      (pkgs.callPackage pyproject-nix.build.packages {
-        inherit python;
-      }).overrideScope
-      (
-        lib.composeManyExtensions [
-          pyproject-build-systems.overlays.default
-          overlay
-          pyprojectOverrides
-        ]
-      );
+    # Systems we build dev shells for. mold and the manylinux LD_LIBRARY_PATH
+    # are Linux-only and gated below; macOS uses the default Apple toolchain.
+    systems = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
+    forAllSystems = lib.genAttrs systems;
   in {
-    packages.x86_64-linux.default = fenix.packages.x86_64-linux.stable.toolchain;
+    packages = forAllSystems (system: {
+      default = fenix.packages.${system}.stable.toolchain;
+    });
 
     # This example provides two different modes of development:
     # - Impurely using uv to manage virtual environments
     # - Pure development using uv2nix to manage virtual environments
-    devShells.x86_64-linux = {
-      # It is of course perfectly OK to keep using an impure virtualenv workflow and only use uv2nix to build packages.
-      # This devShell simply adds Python and undoes the dependency leakage done by Nixpkgs Python infrastructure.
-      impure =
-        pkgs.mkShell.override
-        {
-          stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.clangStdenv;
-        }
-        {
-          packages = [
-            python
-            pkgs.uv
-            pkgs.ruff
+    devShells = forAllSystems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
 
-            fenix.packages.x86_64-linux.stable.toolchain
-            pkgs.cargo-nextest # test runner
-            pkgs.cargo-deny
-            pkgs.cargo-edit
-            pkgs.cargo-msrv
-            pkgs.cargo-machete
+        # Use Python 3.12 from nixpkgs
+        python = pkgs.python312;
 
-            pkgs.mold
-            pkgs.taplo # toml lsp server
-            pkgs.awscli2
-            pkgs.google-cloud-sdk
-            pkgs.just # script launcher with a make flavor
-            pkgs.alejandra # nix code formatter
-            pkgs.markdownlint-cli2
-            pkgs.flatbuffers
-
-            # necessary for reqwest
-            pkgs.openssl
-            pkgs.pkg-config
-          ];
-
-          env =
-            {
-              # Prevent uv from managing Python downloads
-              UV_PYTHON_DOWNLOADS = "never";
-
-              RUSTFLAGS = "-W unreachable-pub -W bare-trait-objects";
-            }
-            // lib.optionalAttrs pkgs.stdenv.isLinux {
-              # Python libraries often load native shared objects using dlopen(3).
-              # Setting LD_LIBRARY_PATH makes the dynamic library loader aware of libraries without using RPATH for lookup.
-              LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux1;
-            };
-          shellHook = ''
-            unset PYTHONPATH
-          '';
-        };
-
-      # This devShell uses uv2nix to construct a virtual environment purely from Nix, using the same dependency specification as the application.
-      # The notable difference is that we also apply another overlay here enabling editable mode ( https://setuptools.pypa.io/en/latest/userguide/development_mode.html ).
-      #
-      # This means that any changes done to your local files do not require a rebuild.
-      #
-      # Note: Editable package support is still unstable and subject to change.
-      uv2nix = let
-        # Create an overlay enabling editable mode for all local dependencies.
-        editableOverlay = workspace.mkEditablePyprojectOverlay {
-          # Use environment variable
-          root = "$REPO_ROOT";
-          # Optional: Only enable editable for these packages
-          # members = [ "hello-world" ];
-        };
-
-        # Override previous set with our overridable overlay.
-        editablePythonSet = pythonSet.overrideScope (
-          lib.composeManyExtensions [
-            editableOverlay
-
-            # Apply fixups for building an editable package of your workspace packages
-            (final: prev: {
-              icechunk = prev.icechunk.overrideAttrs (old: {
-                # It's a good idea to filter the sources going into an editable build
-                # so the editable package doesn't have to be rebuilt on every change.
-                src = lib.fileset.toSource {
-                  root = old.src;
-                  fileset = lib.fileset.unions [
-                    (old.src + "/pyproject.toml")
-                    (old.src + "/README.md")
-                  ];
-                };
-
-                # Hatchling (our build system) has a dependency on the `editables` package when building editables.
-                #
-                # In normal Python flows this dependency is dynamically handled, and doesn't need to be explicitly declared.
-                # This behaviour is documented in PEP-660.
-                #
-                # With Nix the dependency needs to be explicitly declared.
-                nativeBuildInputs = old.nativeBuildInputs ++ final.resolveBuildSystem {editables = [];};
-              });
-            })
-          ]
-        );
-
-        # Build virtual environment, with local packages being editable.
-        #
-        # Enable all optional dependencies for development.
-        virtualenv = editablePythonSet.mkVirtualEnv "iechunk-dev-env" workspace.deps.all;
+        # Construct package set (only consumed by the uv2nix shell below)
+        pythonSet =
+          # Use base package set from pyproject.nix builders
+          (pkgs.callPackage pyproject-nix.build.packages {
+            inherit python;
+          }).overrideScope
+          (
+            lib.composeManyExtensions [
+              pyproject-build-systems.overlays.default
+              overlay
+              pyprojectOverrides
+            ]
+          );
       in
-        pkgs.mkShell.override {
-          packages = [
-            virtualenv
-            pkgs.uv
-          ];
+        {
+          # It is of course perfectly OK to keep using an impure virtualenv workflow and only use uv2nix to build packages.
+          # This devShell simply adds Python and undoes the dependency leakage done by Nixpkgs Python infrastructure.
+          impure =
+            pkgs.mkShell.override
+            {
+              # mold is an ELF-only linker; on macOS use the default Apple toolchain.
+              stdenv =
+                if pkgs.stdenv.isLinux
+                then pkgs.stdenvAdapters.useMoldLinker pkgs.clangStdenv
+                else pkgs.stdenv;
+            }
+            {
+              packages =
+                [
+                  python
+                  pkgs.uv
+                  pkgs.ruff
 
-          env = {
-            # Don't create venv using uv
-            UV_NO_SYNC = "1";
+                  fenix.packages.${system}.stable.toolchain
+                  pkgs.cargo-nextest # test runner
+                  pkgs.cargo-deny
+                  pkgs.cargo-edit
+                  pkgs.cargo-msrv
+                  pkgs.cargo-machete
 
-            # Prevent uv from downloading managed Python's
-            UV_PYTHON_DOWNLOADS = "never";
-          };
+                  pkgs.taplo # toml lsp server
+                  pkgs.awscli2
+                  pkgs.google-cloud-sdk
+                  pkgs.just # script launcher with a make flavor
+                  pkgs.alejandra # nix code formatter
+                  pkgs.markdownlint-cli2
+                  pkgs.flatbuffers
 
-          shellHook = ''
-            # Undo dependency propagation by nixpkgs.
-            unset PYTHONPATH
+                  # necessary for reqwest
+                  pkgs.openssl
+                  pkgs.pkg-config
+                ]
+                ++ lib.optionals pkgs.stdenv.isLinux [pkgs.mold];
 
-            # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
-            export REPO_ROOT=$(git rev-parse --show-toplevel)
-          '';
-        };
-    };
+              env =
+                {
+                  # Prevent uv from managing Python downloads
+                  UV_PYTHON_DOWNLOADS = "never";
+
+                  RUSTFLAGS = "-W unreachable-pub -W bare-trait-objects";
+                }
+                // lib.optionalAttrs pkgs.stdenv.isLinux {
+                  # Python libraries often load native shared objects using dlopen(3).
+                  # Setting LD_LIBRARY_PATH makes the dynamic library loader aware of libraries without using RPATH for lookup.
+                  LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux1;
+                };
+              shellHook = ''
+                unset PYTHONPATH
+              '';
+            };
+        }
+        // lib.optionalAttrs (system == "x86_64-linux") {
+          # This devShell uses uv2nix to construct a virtual environment purely from Nix, using the same dependency specification as the application.
+          # The notable difference is that we also apply another overlay here enabling editable mode ( https://setuptools.pypa.io/en/latest/userguide/development_mode.html ).
+          #
+          # This means that any changes done to your local files do not require a rebuild.
+          #
+          # Note: Editable package support is still unstable and subject to change.
+          
+
+        
+        uv2nix = let
+            # Create an overlay enabling editable mode for all local dependencies.
+            editableOverlay = workspace.mkEditablePyprojectOverlay {
+              # Use environment variable
+              root = "$REPO_ROOT";
+              # Optional: Only enable editable for these packages
+              # members = [ "hello-world" ];
+            };
+
+            # Override previous set with our overridable overlay.
+            editablePythonSet = pythonSet.overrideScope (
+              lib.composeManyExtensions [
+                editableOverlay
+
+                # Apply fixups for building an editable package of your workspace packages
+                (final: prev: {
+                  icechunk = prev.icechunk.overrideAttrs (old: {
+                    # It's a good idea to filter the sources going into an editable build
+                    # so the editable package doesn't have to be rebuilt on every change.
+                    src = lib.fileset.toSource {
+                      root = old.src;
+                      fileset = lib.fileset.unions [
+                        (old.src + "/pyproject.toml")
+                        (old.src + "/README.md")
+                      ];
+                    };
+
+                    # Hatchling (our build system) has a dependency on the `editables` package when building editables.
+                    #
+                    # In normal Python flows this dependency is dynamically handled, and doesn't need to be explicitly declared.
+                    # This behaviour is documented in PEP-660.
+                    #
+                    # With Nix the dependency needs to be explicitly declared.
+                    nativeBuildInputs = old.nativeBuildInputs ++ final.resolveBuildSystem {editables = [];};
+                  });
+                })
+              ]
+            );
+
+            # Build virtual environment, with local packages being editable.
+            #
+            # Enable all optional dependencies for development.
+            virtualenv = editablePythonSet.mkVirtualEnv "iechunk-dev-env" workspace.deps.all;
+          in
+            pkgs.mkShell.override {
+              packages = [
+                virtualenv
+                pkgs.uv
+              ];
+
+              env = {
+                # Don't create venv using uv
+                UV_NO_SYNC = "1";
+
+                # Prevent uv from downloading managed Python's
+                UV_PYTHON_DOWNLOADS = "never";
+              };
+
+              shellHook = ''
+                # Undo dependency propagation by nixpkgs.
+                unset PYTHONPATH
+
+                # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
+                export REPO_ROOT=$(git rev-parse --show-toplevel)
+              '';
+            };
+        }
+    );
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -169,9 +169,9 @@
           # This means that any changes done to your local files do not require a rebuild.
           #
           # Note: Editable package support is still unstable and subject to change.
-          
 
-        
+
+
         uv2nix = let
             # Create an overlay enabling editable mode for all local dependencies.
             editableOverlay = workspace.mkEditablePyprojectOverlay {

--- a/flake.nix
+++ b/flake.nix
@@ -28,203 +28,196 @@
     };
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      fenix,
-      uv2nix,
-      pyproject-nix,
-      pyproject-build-systems,
-      ...
-    }:
-    let
-      inherit (nixpkgs) lib;
+  outputs = {
+    self,
+    nixpkgs,
+    fenix,
+    uv2nix,
+    pyproject-nix,
+    pyproject-build-systems,
+    ...
+  }: let
+    inherit (nixpkgs) lib;
 
-      # Load a uv workspace from a workspace root.
-      # Uv2nix treats all uv projects as workspace projects.
-      workspace = uv2nix.lib.workspace.loadWorkspace {
-        workspaceRoot = ./icechunk-python;
-      };
+    # Load a uv workspace from a workspace root.
+    # Uv2nix treats all uv projects as workspace projects.
+    workspace = uv2nix.lib.workspace.loadWorkspace {
+      workspaceRoot = ./icechunk-python;
+    };
 
-      # Create package overlay from workspace.
-      overlay = workspace.mkPyprojectOverlay {
-        # Prefer prebuilt binary wheels as a package source.
-        # Sdists are less likely to "just work" because of the metadata missing from uv.lock.
-        # Binary wheels are more likely to, but may still require overrides for library dependencies.
-        sourcePreference = "wheel"; # or sourcePreference = "sdist";
-        # Optionally customise PEP 508 environment
-        # environ = {
-        #   platform_release = "5.10.65";
-        # };
-      };
+    # Create package overlay from workspace.
+    overlay = workspace.mkPyprojectOverlay {
+      # Prefer prebuilt binary wheels as a package source.
+      # Sdists are less likely to "just work" because of the metadata missing from uv.lock.
+      # Binary wheels are more likely to, but may still require overrides for library dependencies.
+      sourcePreference = "wheel"; # or sourcePreference = "sdist";
+      # Optionally customise PEP 508 environment
+      # environ = {
+      #   platform_release = "5.10.65";
+      # };
+    };
 
-      # Extend generated overlay with build fixups
-      #
-      # Uv2nix can only work with what it has, and uv.lock is missing essential metadata to perform some builds.
-      # This is an additional overlay implementing build fixups.
-      # See:
-      # - https://pyproject-nix.github.io/uv2nix/FAQ.html
-      pyprojectOverrides = _final: _prev: {
-        # Implement build fixups here.
-        # Note that uv2nix is _not_ using Nixpkgs buildPythonPackage.
-        # It's using https://pyproject-nix.github.io/pyproject.nix/build.html
-      };
+    # Extend generated overlay with build fixups
+    #
+    # Uv2nix can only work with what it has, and uv.lock is missing essential metadata to perform some builds.
+    # This is an additional overlay implementing build fixups.
+    # See:
+    # - https://pyproject-nix.github.io/uv2nix/FAQ.html
+    pyprojectOverrides = _final: _prev: {
+      # Implement build fixups here.
+      # Note that uv2nix is _not_ using Nixpkgs buildPythonPackage.
+      # It's using https://pyproject-nix.github.io/pyproject.nix/build.html
+    };
 
-      # This example is only using x86_64-linux
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    # This example is only using x86_64-linux
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
 
-      # Use Python 3.12 from nixpkgs
-      python = pkgs.python312;
+    # Use Python 3.12 from nixpkgs
+    python = pkgs.python312;
 
-      # Construct package set
-      pythonSet =
-        # Use base package set from pyproject.nix builders
-        (pkgs.callPackage pyproject-nix.build.packages {
-          inherit python;
-        }).overrideScope
-          (
-            lib.composeManyExtensions [
-              pyproject-build-systems.overlays.default
-              overlay
-              pyprojectOverrides
-            ]
-          );
+    # Construct package set
+    pythonSet =
+      # Use base package set from pyproject.nix builders
+      (pkgs.callPackage pyproject-nix.build.packages {
+        inherit python;
+      }).overrideScope
+      (
+        lib.composeManyExtensions [
+          pyproject-build-systems.overlays.default
+          overlay
+          pyprojectOverrides
+        ]
+      );
+  in {
+    packages.x86_64-linux.default = fenix.packages.x86_64-linux.stable.toolchain;
 
-    in
-    {
-      packages.x86_64-linux.default = fenix.packages.x86_64-linux.stable.toolchain;
+    # This example provides two different modes of development:
+    # - Impurely using uv to manage virtual environments
+    # - Pure development using uv2nix to manage virtual environments
+    devShells.x86_64-linux = {
+      # It is of course perfectly OK to keep using an impure virtualenv workflow and only use uv2nix to build packages.
+      # This devShell simply adds Python and undoes the dependency leakage done by Nixpkgs Python infrastructure.
+      impure =
+        pkgs.mkShell.override
+        {
+          stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.clangStdenv;
+        }
+        {
+          packages = [
+            python
+            pkgs.uv
+            pkgs.ruff
 
-      # This example provides two different modes of development:
-      # - Impurely using uv to manage virtual environments
-      # - Pure development using uv2nix to manage virtual environments
-      devShells.x86_64-linux = {
-        # It is of course perfectly OK to keep using an impure virtualenv workflow and only use uv2nix to build packages.
-        # This devShell simply adds Python and undoes the dependency leakage done by Nixpkgs Python infrastructure.
-        impure =
-          pkgs.mkShell.override
+            fenix.packages.x86_64-linux.stable.toolchain
+            pkgs.cargo-nextest # test runner
+            pkgs.cargo-deny
+            pkgs.cargo-edit
+            pkgs.cargo-msrv
+            pkgs.cargo-machete
+
+            pkgs.mold
+            pkgs.taplo # toml lsp server
+            pkgs.awscli2
+            pkgs.google-cloud-sdk
+            pkgs.just # script launcher with a make flavor
+            pkgs.alejandra # nix code formatter
+            pkgs.markdownlint-cli2
+            pkgs.flatbuffers
+
+            # necessary for reqwest
+            pkgs.openssl
+            pkgs.pkg-config
+          ];
+
+          env =
             {
-              stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.clangStdenv;
-            }
-            {
-              packages = [
-                python
-                pkgs.uv
-                pkgs.ruff
-
-                fenix.packages.x86_64-linux.stable.toolchain
-                pkgs.cargo-nextest # test runner
-                pkgs.cargo-deny
-                pkgs.cargo-edit
-                pkgs.cargo-msrv
-                pkgs.cargo-machete
-
-                pkgs.mold
-                pkgs.taplo # toml lsp server
-                pkgs.awscli2
-                pkgs.google-cloud-sdk
-                pkgs.just # script launcher with a make flavor
-                pkgs.alejandra # nix code formatter
-                pkgs.markdownlint-cli2
-                pkgs.flatbuffers
-
-                # necessary for reqwest
-                pkgs.openssl
-                pkgs.pkg-config
-              ];
-
-              env = {
-                # Prevent uv from managing Python downloads
-                UV_PYTHON_DOWNLOADS = "never";
-
-                RUSTFLAGS = "-W unreachable-pub -W bare-trait-objects";
-              }
-              // lib.optionalAttrs pkgs.stdenv.isLinux {
-                # Python libraries often load native shared objects using dlopen(3).
-                # Setting LD_LIBRARY_PATH makes the dynamic library loader aware of libraries without using RPATH for lookup.
-                LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux1;
-              };
-              shellHook = ''
-                unset PYTHONPATH
-              '';
-            };
-
-        # This devShell uses uv2nix to construct a virtual environment purely from Nix, using the same dependency specification as the application.
-        # The notable difference is that we also apply another overlay here enabling editable mode ( https://setuptools.pypa.io/en/latest/userguide/development_mode.html ).
-        #
-        # This means that any changes done to your local files do not require a rebuild.
-        #
-        # Note: Editable package support is still unstable and subject to change.
-        uv2nix =
-          let
-            # Create an overlay enabling editable mode for all local dependencies.
-            editableOverlay = workspace.mkEditablePyprojectOverlay {
-              # Use environment variable
-              root = "$REPO_ROOT";
-              # Optional: Only enable editable for these packages
-              # members = [ "hello-world" ];
-            };
-
-            # Override previous set with our overridable overlay.
-            editablePythonSet = pythonSet.overrideScope (
-              lib.composeManyExtensions [
-                editableOverlay
-
-                # Apply fixups for building an editable package of your workspace packages
-                (final: prev: {
-                  icechunk = prev.icechunk.overrideAttrs (old: {
-                    # It's a good idea to filter the sources going into an editable build
-                    # so the editable package doesn't have to be rebuilt on every change.
-                    src = lib.fileset.toSource {
-                      root = old.src;
-                      fileset = lib.fileset.unions [
-                        (old.src + "/pyproject.toml")
-                        (old.src + "/README.md")
-                      ];
-                    };
-
-                    # Hatchling (our build system) has a dependency on the `editables` package when building editables.
-                    #
-                    # In normal Python flows this dependency is dynamically handled, and doesn't need to be explicitly declared.
-                    # This behaviour is documented in PEP-660.
-                    #
-                    # With Nix the dependency needs to be explicitly declared.
-                    nativeBuildInputs = old.nativeBuildInputs ++ final.resolveBuildSystem { editables = [ ]; };
-                  });
-
-                })
-              ]
-            );
-
-            # Build virtual environment, with local packages being editable.
-            #
-            # Enable all optional dependencies for development.
-            virtualenv = editablePythonSet.mkVirtualEnv "iechunk-dev-env" workspace.deps.all;
-
-          in
-          pkgs.mkShell.override {
-            packages = [
-              virtualenv
-              pkgs.uv
-            ];
-
-            env = {
-              # Don't create venv using uv
-              UV_NO_SYNC = "1";
-
-              # Prevent uv from downloading managed Python's
+              # Prevent uv from managing Python downloads
               UV_PYTHON_DOWNLOADS = "never";
 
+              RUSTFLAGS = "-W unreachable-pub -W bare-trait-objects";
+            }
+            // lib.optionalAttrs pkgs.stdenv.isLinux {
+              # Python libraries often load native shared objects using dlopen(3).
+              # Setting LD_LIBRARY_PATH makes the dynamic library loader aware of libraries without using RPATH for lookup.
+              LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux1;
             };
+          shellHook = ''
+            unset PYTHONPATH
+          '';
+        };
 
-            shellHook = ''
-              # Undo dependency propagation by nixpkgs.
-              unset PYTHONPATH
+      # This devShell uses uv2nix to construct a virtual environment purely from Nix, using the same dependency specification as the application.
+      # The notable difference is that we also apply another overlay here enabling editable mode ( https://setuptools.pypa.io/en/latest/userguide/development_mode.html ).
+      #
+      # This means that any changes done to your local files do not require a rebuild.
+      #
+      # Note: Editable package support is still unstable and subject to change.
+      uv2nix = let
+        # Create an overlay enabling editable mode for all local dependencies.
+        editableOverlay = workspace.mkEditablePyprojectOverlay {
+          # Use environment variable
+          root = "$REPO_ROOT";
+          # Optional: Only enable editable for these packages
+          # members = [ "hello-world" ];
+        };
 
-              # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
-              export REPO_ROOT=$(git rev-parse --show-toplevel)
-            '';
+        # Override previous set with our overridable overlay.
+        editablePythonSet = pythonSet.overrideScope (
+          lib.composeManyExtensions [
+            editableOverlay
+
+            # Apply fixups for building an editable package of your workspace packages
+            (final: prev: {
+              icechunk = prev.icechunk.overrideAttrs (old: {
+                # It's a good idea to filter the sources going into an editable build
+                # so the editable package doesn't have to be rebuilt on every change.
+                src = lib.fileset.toSource {
+                  root = old.src;
+                  fileset = lib.fileset.unions [
+                    (old.src + "/pyproject.toml")
+                    (old.src + "/README.md")
+                  ];
+                };
+
+                # Hatchling (our build system) has a dependency on the `editables` package when building editables.
+                #
+                # In normal Python flows this dependency is dynamically handled, and doesn't need to be explicitly declared.
+                # This behaviour is documented in PEP-660.
+                #
+                # With Nix the dependency needs to be explicitly declared.
+                nativeBuildInputs = old.nativeBuildInputs ++ final.resolveBuildSystem {editables = [];};
+              });
+            })
+          ]
+        );
+
+        # Build virtual environment, with local packages being editable.
+        #
+        # Enable all optional dependencies for development.
+        virtualenv = editablePythonSet.mkVirtualEnv "iechunk-dev-env" workspace.deps.all;
+      in
+        pkgs.mkShell.override {
+          packages = [
+            virtualenv
+            pkgs.uv
+          ];
+
+          env = {
+            # Don't create venv using uv
+            UV_NO_SYNC = "1";
+
+            # Prevent uv from downloading managed Python's
+            UV_PYTHON_DOWNLOADS = "never";
           };
-      };
+
+          shellHook = ''
+            # Undo dependency propagation by nixpkgs.
+            unset PYTHONPATH
+
+            # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
+            export REPO_ROOT=$(git rev-parse --show-toplevel)
+          '';
+        };
     };
+  };
 }


### PR DESCRIPTION
Reorg nix flake a bit so it can be used on macOS too.

Arrange `just develop` and `just pytest` so they can execute under both Nix and pixi dev environments.