### PR TITLE
Update docs page on "Virtual Datasets" to add h5py

### DIFF
--- a/icechunk-python/docs/docs/guides/virtual.md
+++ b/icechunk-python/docs/docs/guides/virtual.md
@@ -22,10 +22,10 @@ While Icechunk works wonderfully with native chunks managed by Zarr, there is lo
 
 We are going to create a virtual dataset pointing to all of the [OISST](https://www.ncei.noaa.gov/products/optimum-interpolation-sst) data for August 2024. This data is distributed publicly as [netCDF files on AWS S3](https://registry.opendata.aws/noaa-cdr-oceanic/), with one netCDF file containing the Sea Surface Temperature (SST) data for each day of the month. We are going to use `VirtualiZarr` to combine all of these files into a single virtual dataset spanning the entire month, then write that dataset to Icechunk for use in analysis.
 
-Before we get started, we need to install `virtualizarr` (version 2.4.0 or later) and `icechunk`. We also need to install `fsspec` and `s3fs` for discovering files on s3.
+Before we get started, we need to install `virtualizarr` (version 2.4.0 or later) and `icechunk`. We also need to install `fsspec` and `s3fs` for discovering files on s3, and `h5py` for working with netCDF files.
 
 ```shell
-pip install "virtualizarr>=2.4.0" icechunk fsspec s3fs
+pip install "virtualizarr>=2.4.0" icechunk fsspec s3fs h5py
 ```
 
 First, we need to find all of the files we are interested in.


### PR DESCRIPTION
Was going through the tutorial step by step and ran into 

```
Traceback (most recent call last):
  File "/Users/Hodgs004/coding/repos/icechunk/tmp/main.py", line 29, in <module>
    open_virtual_dataset(url, registry=registry, parser=HDFParser())
  File "/Users/Hodgs004/coding/repos/icechunk/tmp/.venv/lib/python3.12/site-packages/virtualizarr/xarray.py", line 227, in open_virtual_dataset
    manifest_store = parser(
                     ^^^^^^^
  File "/Users/Hodgs004/coding/repos/icechunk/tmp/.venv/lib/python3.12/site-packages/virtualizarr/parsers/hdf/hdf.py", line 193, in __call__
    manifest_group = _construct_manifest_group(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Hodgs004/coding/repos/icechunk/tmp/.venv/lib/python3.12/site-packages/virtualizarr/parsers/hdf/hdf.py", line 108, in _construct_manifest_group
    import h5py
ModuleNotFoundError: No module named 'h5py'
```