### PR TITLE
Pin pytest to 9.0.3 to avoid upstream bug

### DIFF
--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
 test = [
   "boto3",
   "coverage",
-  "pytest",
+  "pytest==9.0.3",
   "pytest-cov",
   "pytest-asyncio",
   "pytest-xdist",


### PR DESCRIPTION
Upstream bug: https://github.com/pytest-dev/pytest/issues/14591
Fix: https://github.com/pytest-dev/pytest/pull/14597
Still need an upstream release