### PR TITLE
Use `abi3-py312` pyo3 feature to reduce number of wheels

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_INTERPRETERS: "python3.12 python3.13 python3.14"
+  PYTHON_INTERPRETER: "python3.12"
 
 defaults:
   run:
@@ -162,7 +162,7 @@ jobs:
           done
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Update version in Cargo.toml
         if: ${{ github.event_name == 'schedule' || inputs.use_git_version == true }}
         run: |
@@ -174,7 +174,7 @@ jobs:
         with:
           working-directory: icechunk-python
           target: ${{ matrix.platform.target }}
-          args: --release --sdist --out dist -i ${{ env.PYTHON_INTERPRETERS }}
+          args: --release --sdist --out dist -i ${{ env.PYTHON_INTERPRETER }}
           rust-toolchain: stable
           manylinux: ${{ matrix.platform.manylinux }} # https://github.com/PyO3/maturin-action/issues/245
       - name: Upload wheels
@@ -217,7 +217,7 @@ jobs:
         with:
           working-directory: icechunk-python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_INTERPRETERS }}
+          args: --release --out dist -i ${{ env.PYTHON_INTERPRETER }}
           rust-toolchain: stable
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -256,7 +256,7 @@ jobs:
         with:
           working-directory: icechunk-python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_INTERPRETERS }}
+          args: --release --out dist -i ${{ env.PYTHON_INTERPRETER }}
           rust-toolchain: stable
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -294,7 +294,7 @@ jobs:
         with:
           working-directory: icechunk-python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_INTERPRETERS }}
+          args: --release --out dist -i ${{ env.PYTHON_INTERPRETER }}
           rust-toolchain: stable
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -96,7 +96,7 @@ docs = [
 ]
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/abi3-py312"]
 module-name = "icechunk._icechunk_python"
 python-source = "python"
 editable-profile = "dev"


### PR DESCRIPTION
Use `abi3-py312` to build wheels using `abi3`, greatly reducing the number of wheels we need to publish. (`py312` refers to the minimum version, which matches our current minimum version).

Drop unused `pyo3/extension-module` feature (it is "Deprecated: use the PYO3_BUILD_EXTENSION_MODULE environment variable when building a Python extension module (set automatically by setuptools-rust and maturin)"

