### PR TITLE
Temporarily skip timedelta tests until new xarray is released

### DIFF
--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -136,6 +136,9 @@ filterwarnings = [
   "ignore::ResourceWarning",
   "ignore:Unused async fixture loop scope:pytest.PytestWarning",
   "ignore:.*does not have a Zarr V3 specification.*",
+  # Recent NumPy deprecates the 'generic' timedelta unit; raised transitively at
+  # collection. Remove once upstream deps stop using bare-int timedelta.
+  "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning",
 ]
 
 [tool.mypy]

--- a/icechunk-python/tests/run_xarray_backends_tests.py
+++ b/icechunk-python/tests/run_xarray_backends_tests.py
@@ -105,6 +105,18 @@ class IcechunkStoreBase(SpecVersionMixin, ZarrBase):
             unpickled = pickle.loads(raw_pickle)
             assert_identical(expected["foo"], unpickled)
 
+    # Upstream xarray time-coding breaks against recent NumPy (int64 * timedelta64
+    # overflow, datetime decode). No released xarray is compatible yet; re-enable
+    # once xarray ships a fix.
+    def test_roundtrip_timedelta_data(self, *args: Any, **kwargs: Any) -> None:
+        pytest.skip("xarray/NumPy timedelta64 incompatibility")
+
+    def test_roundtrip_timedelta_data_via_dtype(self, *args: Any, **kwargs: Any) -> None:
+        pytest.skip("xarray/NumPy timedelta64 incompatibility")
+
+    def test_roundtrip_numpy_datetime_data(self, *args: Any, **kwargs: Any) -> None:
+        pytest.skip("xarray/NumPy datetime decode incompatibility")
+
 
 class TestIcechunkStoreFilesystem(IcechunkStoreBase):
     @contextlib.contextmanager


### PR DESCRIPTION
Temporarily skip `np.timedelta` tests until new xarray is released, filter deprecation warnings to avoid failure.

Follow-up issue: #2230