### PR TITLE
CI: fix upstream for new wheel with abi3 name fixes

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -98,8 +98,7 @@ jobs:
           uv venv
           source .venv/bin/activate
           python --version
-          PYTHON_TAG="cp$(echo ${{ env.PYTHON_VERSION }} | tr -d '.')"
-          WHEEL=$(ls dist/*-${PYTHON_TAG}-*.whl)
+          WHEEL=$(ls dist/*-abi3-*.whl)
           uv pip install "$WHEEL" --group test
           # Install specific versions based on matrix
           if [ "${{ matrix.deps-version.name }}" = "minimum" ]; then
@@ -248,8 +247,7 @@ jobs:
           uv venv
           source .venv/bin/activate
           python --version
-          PYTHON_TAG="cp$(echo ${{ env.PYTHON_VERSION }} | tr -d '.')"
-          WHEEL=$(ls dist/*-${PYTHON_TAG}-*.whl)
+          WHEEL=$(ls dist/*-abi3-*.whl)
           uv pip install "$WHEEL" --group test
           uv pip install pytest-shard
 
@@ -313,8 +311,7 @@ jobs:
           set -e
           uv venv
           source .venv/bin/activate
-          PYTHON_TAG="cp$(echo ${{ env.PYTHON_VERSION }} | tr -d '.')"
-          WHEEL=$(ls dist/*-${PYTHON_TAG}-*.whl)
+          WHEEL=$(ls dist/*-abi3-*.whl)
           uv pip install "$WHEEL" --group test
           uv run third-wheel sync -v
 
@@ -370,8 +367,7 @@ jobs:
           uv venv
           source .venv/bin/activate
           python --version
-          PYTHON_TAG="cp$(echo ${{ env.PYTHON_VERSION }} | tr -d '.')"
-          WHEEL=$(ls dist/*-${PYTHON_TAG}-*.whl)
+          WHEEL=$(ls dist/*-abi3-*.whl)
           uv pip install "$WHEEL" --group test
           uv pip install "pytest-mypy-plugins<4"
           # Install specific xarray version based on matrix
@@ -452,8 +448,7 @@ jobs:
           set -e
           uv venv
           source .venv/bin/activate
-          PYTHON_TAG="cp$(echo ${{ env.PYTHON_VERSION }} | tr -d '.')"
-          WHEEL=$(ls dist/*-${PYTHON_TAG}-*.whl)
+          WHEEL=$(ls dist/*-abi3-*.whl)
           uv pip install "$WHEEL" --group dev
           python -m mypy.stubtest --ignore-disjoint-bases icechunk._icechunk_python --allowlist stubtest_allowlist.txt
 

--- a/Justfile
+++ b/Justfile
@@ -264,8 +264,7 @@ python-upstream-setup:
   python3 -m venv .venv
   source .venv/bin/activate
   python --version
-  PY_TAG="cp${PYTHON_VERSION//./}"
-  WHEEL=$(ls dist/*-"${PY_TAG}"-*.whl)
+  WHEEL=$(ls dist/*-abi3-*.whl)
   export UV_INDEX="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
   export UV_PRERELEASE=allow
   uv pip install "$WHEEL" --group dev \
@@ -316,8 +315,7 @@ xarray-upstream-setup:
   python3 -m venv .venv
   source .venv/bin/activate
   python --version
-  PY_TAG="cp${PYTHON_VERSION//./}"
-  WHEEL=$(ls dist/*-"${PY_TAG}"-*.whl)
+  WHEEL=$(ls dist/*-abi3-*.whl)
   export UV_INDEX="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
   export UV_PRERELEASE=allow
   uv pip install "$WHEEL" --group test pytest-mypy-plugins \


### PR DESCRIPTION
Follow-up on #2213 

Upstream CI jobs didn't account for the `abi3` changes, fixing now.