### PR TITLE
Add optional OpenTelemetry export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2281,9 @@ dependencies = [
  "icechunk-types",
  "itertools 0.14.0",
  "noxious-client",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "port_check",
  "pretty_assertions",
  "proptest",
@@ -2294,6 +2310,7 @@ dependencies = [
  "tracing",
  "tracing-chrome",
  "tracing-error",
+ "tracing-opentelemetry",
  "tracing-samply",
  "tracing-subscriber",
  "typetag",
@@ -3316,6 +3333,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.2",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3687,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1675727965d66ff6f335e7d398e477184da08f4bed22f1a7f0dbf2f077f56f2e"
 dependencies = [
  "proptest",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5203,6 +5311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,6 +5396,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5284,11 +5451,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util 0.7.18",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5384,6 +5555,20 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ miette = { version = "7.6.0", features = ["fancy"] }
 noxious-client = "1.0"
 numpy = "0.29.0"
 object_store = { version = "0.13.2", default-features = false }
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"] }
 port_check = "0.3.0"
 pretty_assertions = "1.4.1"
 proptest = "1.11.0"
@@ -91,6 +94,7 @@ tokio-util = { version = "0.7.18", features = ["io-util"] }
 tracing = "0.1.44"
 tracing-chrome = "0.7"
 tracing-error = "0.2.1"
+tracing-opentelemetry = { version = "0.33", default-features = false }
 tracing-samply = "0.1.5"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 typed-path = "0.12.3"

--- a/Justfile
+++ b/Justfile
@@ -62,7 +62,7 @@ import-hook-remove:
 
 # Use --all-features for the workspace but skip icechunk's `shuttle` feature,
 # which swaps tokio for shuttle-tokio and is incompatible with other crates.
-icechunk_features := "s3,object-store-s3,object-store-gcs,object-store-azure,object-store-http,object-store-fs,redirect,logs,cli,napi-send-contract"
+icechunk_features := "s3,object-store-s3,object-store-gcs,object-store-azure,object-store-http,object-store-fs,redirect,logs,otel,cli,napi-send-contract"
 
 [doc("Run clippy lints on all features and targets")]
 lint *args:
@@ -163,6 +163,17 @@ pytest *args:
   fi
   uv run --active pytest "$@"
 
+[doc("Run the Python tests with OpenTelemetry export to local Jaeger (starts Jaeger; traces at http://localhost:16686)")]
+pytest-otel *args: jaeger-up
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export ICECHUNK_OTLP_ENDPOINT="${ICECHUNK_OTLP_ENDPOINT:-http://localhost:4317}"
+  echo "Exporting traces to $ICECHUNK_OTLP_ENDPOINT (filter ${ICECHUNK_OTEL_FILTER:-icechunk=info}) — view at http://localhost:16686"
+  # test_logs.py asserts on exact console output, which races with the background
+  # OTLP export: its gRPC transport (h2/tonic) emits debug logs into the same
+  # tracing subscriber. Those tests are meaningless under telemetry, so skip them.
+  just pytest --ignore=tests/test_logs.py "$@"
+
 [doc("Regenerate the post-expiration can_read_old fixtures (needs icechunk 1.1.21 + 2.0.5 wheels, installed via third-wheel)")]
 gen-expired-fixtures *args:
   cd icechunk-python && uv run --with third-wheel third-wheel sync --rename "icechunk==1.1.21=icechunk_v1" --rename "icechunk==2.0.5=icechunk_v2"
@@ -243,6 +254,15 @@ azurite-wait:
 
 [doc("Wait for all docker compose services to be ready")]
 contwait: rustfs-wait azurite-wait
+
+[doc("Start Jaeger for local OpenTelemetry tracing (UI http://localhost:16686, OTLP gRPC localhost:4317)")]
+jaeger-up:
+  docker compose up -d jaeger
+  @echo "Jaeger UI: http://localhost:16686 — set ICECHUNK_OTLP_ENDPOINT=http://localhost:4317 to export traces"
+
+[doc("Stop and remove the Jaeger container")]
+jaeger-down:
+  docker compose rm --force --stop --volumes jaeger
 
 [doc("Publish workspace crates to crates.io via cargo-release")]
 publish-crates:

--- a/compose.yaml
+++ b/compose.yaml
@@ -117,6 +117,19 @@ services:
     volumes:
       - azurite-data:/workspace
 
+  # Local OpenTelemetry trace collector + UI for the `otel` feature.
+  # Profiled so it is NOT started by `docker compose up -d` / `just contup`;
+  # use `just jaeger-up` to start it on demand. Jaeger v2 accepts OTLP out of
+  # the box (gRPC on 4317, HTTP on 4318) and serves its UI on 16686.
+  jaeger:
+    container_name: icechunk_jaeger
+    image: jaegertracing/jaeger:2.19.0
+    profiles: ["jaeger"]
+    ports:
+      - "16686:16686" # Jaeger UI
+      - "4317:4317" # OTLP gRPC (ICECHUNK_OTLP_ENDPOINT=http://localhost:4317)
+      - "4318:4318" # OTLP HTTP
+
   azurite-init:
     image: mcr.microsoft.com/azure-storage/azurite:3.33.0
     container_name: azurite_init

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -46,7 +46,8 @@ clap = { workspace = true, optional = true }
 
 [features]
 cli = ["clap", "icechunk/cli"]
-default = ["cli"]
+otel = ["icechunk/otel"]
+default = ["cli", "otel"]
 
 [lints]
 workspace = true

--- a/icechunk-python/docs/docs/guides/observability.md
+++ b/icechunk-python/docs/docs/guides/observability.md
@@ -1,0 +1,100 @@
+# Observability
+
+Icechunk is instrumented with the Rust [`tracing`](https://docs.rs/tracing) framework. The same instrumentation drives two independent outputs:
+
+- **Console logs** — human-readable logs printed to stdout, controlled by `ICECHUNK_LOG`. Enabled by default at the `warn` level.
+- **OpenTelemetry trace export** *(experimental)* — structured spans exported over OTLP/gRPC to a collector. Off by default, opt-in.
+
+The two are configured separately and don't affect each other.
+
+## Logging
+
+Icechunk prints logs to stdout. Set the verbosity with the `ICECHUNK_LOG` environment variable before importing `icechunk`:
+
+```bash
+export ICECHUNK_LOG=icechunk=info
+```
+
+Levels, from least to most verbose, are `error`, `warn`, `info`, `debug`, and `trace`. The default is `warn`.
+
+`ICECHUNK_LOG` uses [`tracing-subscriber`'s `EnvFilter` syntax](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives), so you can target specific modules:
+
+- `ICECHUNK_LOG=trace` — `trace` level for icechunk **and** all of its dependencies
+- `ICECHUNK_LOG=icechunk=trace` — `trace` level for icechunk only
+- `ICECHUNK_LOG=debug,icechunk=trace,rustls=info,h2=info,hyper=info` — `trace` for icechunk, `info` for `rustls`/`h2`/`hyper`, and `debug` for everything else
+
+### Changing the level at runtime
+
+`ICECHUNK_LOG` is read once, when `icechunk` is imported. To change the filter afterwards, call `set_logs_filter`, which takes the same directive syntax (or `None` to re-read `ICECHUNK_LOG` from the environment):
+
+```python
+import icechunk
+
+icechunk.set_logs_filter("debug,icechunk=trace")
+```
+
+To skip logging setup entirely, set `ICECHUNK_NO_LOGS` (to any value) before importing `icechunk`.
+
+## OpenTelemetry tracing
+
+!!! warning "Experimental"
+
+    OpenTelemetry export is experimental and its configuration may change in future releases.
+
+Icechunk's internal `tracing` spans offer a lot of information into the inner work of Icechunk. They can be exported using the vendor-neutral [OpenTelemetry](https://opentelemetry.io/) protocol (OTLP/gRPC). Because it speaks standard OTLP, traces can be sent to **any** OpenTelemetry-compatible backend, either directly or through the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/). Examples are: [Jaeger](https://www.jaegertracing.io/), [Grafana Tempo](https://grafana.com/oss/tempo/), [Datadog](https://www.datadoghq.com/), [Honeycomb](https://www.honeycomb.io/), or [New Relic](https://newrelic.com/). Icechunk is not tied to any particular vendor.
+
+**Export is opt-in and off by default** — nothing is collected or transmitted unless you turn it on:
+
+- In the **Python wheel**, the exporter is compiled in but stays inactive until you configure an endpoint.
+- In the **Rust crate**, you must additionally enable the `otel` Cargo feature (off by default, so the OTLP dependencies aren't compiled in at all).
+
+Icechunk will never export traces or logs to any service unless you opt-in and configure the desired service. Icechunk doesn't run a collector, it can only optionally export to one if you configure it.
+
+### Enabling export
+
+Run and set a collector endpoint before importing `icechunk`:
+
+```bash
+export ICECHUNK_OTLP_ENDPOINT=http://localhost:4317
+```
+
+With no endpoint set there is zero exporter overhead, and behavior is identical to a build without the feature.
+
+### Configuration
+
+Currently, all export configuration is via environment variables, read once at import. Each Icechunk-specific variable falls back to the corresponding standard OpenTelemetry variable:
+
+| Variable | Falls back to | Default | Description |
+|----------|---------------|---------|-------------|
+| `ICECHUNK_OTLP_ENDPOINT` | `OTEL_EXPORTER_OTLP_ENDPOINT` | *unset (export disabled)* | OTLP/gRPC endpoint of the collector. Setting either variable enables export. |
+| `ICECHUNK_OTEL_SERVICE_NAME` | `OTEL_SERVICE_NAME` | `icechunk` | The `service.name` reported to the collector. |
+| `ICECHUNK_OTEL_FILTER` | — | `icechunk=info` | Which spans are exported, using the same `EnvFilter` directive syntax as `ICECHUNK_LOG`. |
+
+`ICECHUNK_OTEL_FILTER` is independent of `ICECHUNK_LOG` / `set_logs_filter`: it controls only what is exported (not console output) and is fixed at startup. The default `icechunk=info` captures icechunk's higher-level operations. Lower it (e.g. `icechunk=debug` or `icechunk=trace`) to also export finer-grained spans, such as individual store operations, and the diagnostic events logged inside calls.
+
+### Flushing
+
+Spans are batched and exported in the background. The final batch is flushed automatically when the interpreter exits, via an `atexit` handler registered on import. You can also flush manually:
+
+```python
+import icechunk
+
+icechunk.shutdown_telemetry()
+```
+
+### Trying it locally
+
+Run any OTLP-compatible collector. Jaeger, for example, exposes an OTLP receiver and a UI:
+
+```bash
+docker run --rm -p 16686:16686 -p 4317:4317 jaegertracing/jaeger:2.19.0
+```
+
+Then point Icechunk at it and run your workload:
+
+```bash
+export ICECHUNK_OTLP_ENDPOINT=http://localhost:4317
+python your_script.py
+```
+
+Open <http://localhost:16686>, select the `icechunk` service, and browse the traces.

--- a/icechunk-python/docs/docs/guides/observability.md
+++ b/icechunk-python/docs/docs/guides/observability.md
@@ -3,7 +3,9 @@
 Icechunk is instrumented with the Rust [`tracing`](https://docs.rs/tracing) framework. The same instrumentation drives two independent outputs:
 
 - **Console logs** — human-readable logs printed to stdout, controlled by `ICECHUNK_LOG`. Enabled by default at the `warn` level.
-- **OpenTelemetry trace export** *(experimental)* — structured spans exported over OTLP/gRPC to a collector. Off by default, opt-in.
+- **OpenTelemetry trace export** *(experimental)* — structured spans and traces are exported over OTLP/gRPC to a collector or service. Off by default, opt-in.
+  Telemetry can be configured with an endpoint to use any OpenTelemetry compatible collector or service. If no endpoint is set
+  by the user, there is zero exporter overhead and no spans are exported.
 
 The two are configured separately and don't affect each other.
 

--- a/icechunk-python/docs/docs/understanding/faq.md
+++ b/icechunk-python/docs/docs/understanding/faq.md
@@ -48,7 +48,6 @@ As with all things in technology, the benefits of Icechunk come with some tradeo
 - The on-disk format is less transparent than regular Zarr.
 - The process for distributed writes is more complex to coordinate.
 
-
 ## What is Icechunk's relationship to Zarr?
 
 The Zarr format and protocol is agnostic to the underlying storage system ("store" in Zarr terminology)
@@ -68,7 +67,7 @@ Icechunk figures out how to materialize these keys based on its [storage schema]
 
 <div class="grid cards" markdown>
 
--   __Standard Zarr + Fsspec__
+- __Standard Zarr + Fsspec__
 
     ---
 
@@ -81,7 +80,7 @@ Icechunk figures out how to materialize these keys based on its [storage schema]
         icechunk <-- key / value --> storage[(Object Storage)]
     ```
 
--   __Zarr + Icechunk__
+- __Zarr + Icechunk__
 
     ---
 
@@ -95,7 +94,6 @@ Icechunk figures out how to materialize these keys based on its [storage schema]
     ```
 
 </div>
-
 
 Implementing Icechunk this way allows Icechunk's specification to evolve independently from Zarr's,
 maintaining interoperability while enabling rapid iteration and promoting innovation on the I/O layer.
@@ -158,7 +156,7 @@ HDF is widely used in high-performance computing.
 
 <div class="grid cards" markdown>
 
--   __Similarities__
+- __Similarities__
 
     ---
 
@@ -167,7 +165,7 @@ HDF is widely used in high-performance computing.
 
     Both Icechunk and HDF5 use the concept of "chunking" to split large arrays into smaller storage units.
 
--   __Differences__
+- __Differences__
 
     ---
 
@@ -231,15 +229,15 @@ However, there are a number of difference, enumerated below.
 
 The following table compares Zarr + Icechunk with TileDB Embedded in a few key areas
 
-| feature | **Zarr + Icechunk** | **TileDB Embedded** | Comment |
+| feature | __Zarr + Icechunk__ | __TileDB Embedded__ | Comment |
 |---------|---------------------|---------------------|---------|
-| *atomicity* | atomic updates can span multiple arrays and groups | _array fragments_ limited to a single array  |  Icechunk's model allows a writer to stage many updates across interrelated arrays into a single transaction. |
-| *concurrency and isolation* | serializable isolation of transactions | [eventual consistency](https://docs.tiledb.com/main/background/internal-mechanics/consistency) | While both formats enable lock-free concurrent reading and writing, Icechunk can catch (and potentially reject) inconsistent, out-of order updates. |
-| *versioning* | snapshots, branches, tags | linear version history | Icechunk's data versioning model is closer to Git's. |
-| *unit of storage* | chunk | tile | (basically the same thing) |
-| *minimum write* | chunk | cell | TileDB allows atomic updates to individual cells, while Zarr requires writing an entire chunk. |
-| *sparse arrays* | :material-close: | :material-check: | Zarr + Icechunk do not currently support sparse arrays. |
-| *virtual chunk references* |  :material-check: |  :material-close: | Icechunk enables references to chunks in other file formats (HDF5, NetCDF, GRIB, etc.), while TileDB does not. |
+| _atomicity_ | atomic updates can span multiple arrays and groups | _array fragments_ limited to a single array  |  Icechunk's model allows a writer to stage many updates across interrelated arrays into a single transaction. |
+| _concurrency and isolation_ | serializable isolation of transactions | [eventual consistency](https://docs.tiledb.com/main/background/internal-mechanics/consistency) | While both formats enable lock-free concurrent reading and writing, Icechunk can catch (and potentially reject) inconsistent, out-of order updates. |
+| _versioning_ | snapshots, branches, tags | linear version history | Icechunk's data versioning model is closer to Git's. |
+| _unit of storage_ | chunk | tile | (basically the same thing) |
+| _minimum write_ | chunk | cell | TileDB allows atomic updates to individual cells, while Zarr requires writing an entire chunk. |
+| _sparse arrays_ | :material-close: | :material-check: | Zarr + Icechunk do not currently support sparse arrays. |
+| _virtual chunk references_ |  :material-check: |  :material-close: | Icechunk enables references to chunks in other file formats (HDF5, NetCDF, GRIB, etc.), while TileDB does not. |
 
 Beyond this list, there are numerous differences in the design, file layout, and implementation of Icechunk and TileDB embedded
 which may lead to differences in suitability and performance for different workfloads.
@@ -371,7 +369,6 @@ TensorStore implements an [ocdbt](https://google.github.io/tensorstore/kvstore/o
 Ocdbt implements a transactional, versioned key-value store suitable for storing Zarr data, thereby supporting some of the same features as Icechunk.
 Unlike Icechunk, the ocdbt key-value store is not specialized to Zarr, does not differentiate between chunk or metadata keys, and does not store any metadata about chunks.
 
-
 ## Why do I have to fork a Session for parallel writes?**
 
 Icechunk is different from normal Zarr stores because it is stateful. In a distributed setting, you have to be careful to communicate back the Session objects from remote write tasks, merge them appropriately, and then execute the commit. The explicit use of a `fork` allows Icechunk to hint to the user that they need to be sure about what they are doing.
@@ -392,16 +389,11 @@ This is set automatically and cannot be overridden.
 
 ## Does `icechunk-python` include logging?
 
-Yes! Set the environment variable `ICECHUNK_LOG=icechunk=debug` to print debug logs to stdout. Available "levels" in order of increasing verbosity are `error`, `warn`, `info`, `debug`, `trace`. The default level is `error`. The Rust library uses `tracing-subscriber` crate. The `ICECHUNK_LOG` variable can be used to filter logging following that crate's [documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives). For example, `ICECHUNK_LOG=trace` will set both icechunk and it's dependencies' log levels to `trace` while `ICECHUNK_LOG=icechunk=trace` will enable the `trace` level for icechunk only. For more complex control `ICECHUNK_LOG=debug,icechunk=trace,rustls=info,h2=info,hyper=info` will set `trace` for `icechunk`, `info` for `rustls`,`hyper`, and `h2` crates, and `debug` for every other crate.
+Yes, Icechunk logs to stdout, controlled by the `ICECHUNK_LOG` environment variable (or by `set_logs_filter` at runtime). See the [Observability guide](../guides/observability.md#logging) for levels, filter syntax, and runtime control.
 
-You can also use Python's `os.environ` to set or change the value of the variable. If you change the environment variable after `icechunk` was
-imported, you will need to call `icechunk.set_logs_filter(None)` for changes to take effect.
+## Does Icechunk support tracing?
 
-This function also accepts the filter directive. If you prefer not to use environment variables, you can do:
-
-```python
-icechunk.set_logs_filter("debug,icechunk=trace")
-```
+Yes, optionally, and it is off by default. Once you set a collector endpoint, Icechunk can export its `tracing` spans over OTLP/gRPC to any OpenTelemetry-compatible backend, like Jaeger, Grafana Tempo, Datadog, Honeycomb, etc. See the [Observability guide](../guides/observability.md#opentelemetry-tracing) for setup and configuration.
 
 ## How to get a read-only Icechunk store?
 
@@ -409,7 +401,6 @@ Zarr has a few mechanisms to define read-only zarr stores. These don't always wo
 because Icechunk has a more advanced session model. The safest way to make sure you don't write to
 an Icechunk repo is to use `Repository.readonly_session` to create the session. It doesn't matter what
 you do to the Zarr store, a read-only session cannot do writes.
-
 
 ## Does Icechunk work with Zarr sharding?
 

--- a/icechunk-python/docs/mkdocs.yml
+++ b/icechunk-python/docs/mkdocs.yml
@@ -248,6 +248,7 @@ nav:
     - Zarr: guides/zarr.md
     - Tuning Performance: guides/performance.md
     - Flaky Networks: guides/flaky-networks.md
+    - Observability: guides/observability.md
     - Virtual Datasets: guides/virtual.md
     - Async Usage: guides/async.md
     - Storing Sensitive Data: guides/sensitive-data.md

--- a/icechunk-python/python/icechunk/__init__.py
+++ b/icechunk-python/python/icechunk/__init__.py
@@ -31,6 +31,7 @@ from icechunk.config import (
     RepositoryConfig,
     initialize_logs,
     set_logs_filter,
+    shutdown_telemetry,
 )
 from icechunk.conflicts import (
     BasicConflictSolver,
@@ -207,6 +208,7 @@ __all__ = [
     "s3_storage",
     "s3_store",
     "set_logs_filter",
+    "shutdown_telemetry",
     "spec_version",
     "tigris_storage",
     "user_agent",

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -3719,6 +3719,30 @@ def set_logs_filter(log_filter_directive: str | None) -> None:
     """
     ...
 
+def shutdown_telemetry() -> None:
+    """
+    Flush and shut down OpenTelemetry trace export.
+
+    Experimental: OpenTelemetry export and its configuration may change in future
+    releases.
+
+    Registered with `atexit` on `import icechunk`, so the final batch of spans is
+    exported before the interpreter exits. Idempotent, and a no-op unless the
+    library was built with the `otel` feature and an OTLP endpoint was configured.
+
+    Trace export is opt-in and off by default. It is configured at `import icechunk`
+    through these environment variables (each Icechunk-specific variable falls back
+    to the standard OpenTelemetry one):
+
+    - ICECHUNK_OTLP_ENDPOINT (else OTEL_EXPORTER_OTLP_ENDPOINT): OTLP/gRPC endpoint of
+      the collector. Setting it enables export; with neither set, nothing is exported.
+    - ICECHUNK_OTEL_SERVICE_NAME (else OTEL_SERVICE_NAME): the `service.name` reported
+      to the collector. Defaults to "icechunk".
+    - ICECHUNK_OTEL_FILTER: which spans are exported, in `tracing-subscriber` filter
+      syntax. Defaults to "icechunk=info".
+    """
+    ...
+
 def spec_version() -> SpecVersion:
     """
     The version of the Icechunk specification that the library is compatible with.

--- a/icechunk-python/python/icechunk/config.py
+++ b/icechunk-python/python/icechunk/config.py
@@ -14,6 +14,7 @@ from icechunk._icechunk_python import (
     RepositoryConfig,
     initialize_logs,
     set_logs_filter,
+    shutdown_telemetry,
 )
 
 __all__ = [
@@ -32,6 +33,7 @@ __all__ = [
     "RepositoryConfig",
     "initialize_logs",
     "set_logs_filter",
+    "shutdown_telemetry",
 ]
 
 

--- a/icechunk-python/src/lib.rs
+++ b/icechunk-python/src/lib.rs
@@ -98,8 +98,29 @@ fn log_filters_from_env(py: Python<'_>) -> PyResult<Option<String>> {
 fn initialize_logs(py: Python<'_>) -> PyResult<()> {
     if env::var("ICECHUNK_NO_LOGS").is_err() {
         let log_filter_directive = log_filters_from_env(py)?;
+        // The OTLP exporter must be built inside a Tokio runtime
+        // Bind it to Icechunk's long-lived global runtime so it lives for the life of the process
+        // and can flush the last spans on shutdown
+        let _rt_guard = pyo3_async_runtimes::tokio::get_runtime().enter();
         initialize_tracing(log_filter_directive.as_deref());
+
+        // The final span batch must be flushed before process shutdown
+        register_telemetry_shutdown(py)?;
     }
+    Ok(())
+}
+
+/// Flush and shut down OpenTelemetry trace export. A no-op unless the library
+/// was built with the `otel` feature and an OTLP endpoint was configured.
+#[pyfunction]
+fn shutdown_telemetry() {
+    icechunk::shutdown_telemetry();
+}
+
+fn register_telemetry_shutdown(py: Python<'_>) -> PyResult<()> {
+    let atexit = py.import("atexit")?;
+    let shutdown = wrap_pyfunction!(shutdown_telemetry, py)?;
+    atexit.call_method1("register", (shutdown,))?;
     Ok(())
 }
 
@@ -232,6 +253,7 @@ fn _icechunk_python(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<VirtualChunkSpec>()?;
     m.add_function(wrap_pyfunction!(initialize_logs, m)?)?;
     m.add_function(wrap_pyfunction!(set_logs_filter, m)?)?;
+    m.add_function(wrap_pyfunction!(shutdown_telemetry, m)?)?;
     m.add_function(wrap_pyfunction!(spec_version, m)?)?;
     m.add_function(wrap_pyfunction!(user_agent, m)?)?;
     m.add_function(wrap_pyfunction!(cli_entrypoint, m)?)?;

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -54,7 +54,11 @@ anyhow = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 dialoguer = { workspace = true, optional = true }
 dirs = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 shuttle-tokio = { workspace = true, optional = true }
 
@@ -123,6 +127,13 @@ object-store-http = ["icechunk-arrow-object-store/http"]
 object-store-fs = ["icechunk-arrow-object-store/fs"]
 redirect = ["dep:reqwest"]
 logs = ["dep:tracing-subscriber"]
+otel = [
+  "logs",
+  "dep:opentelemetry",
+  "dep:opentelemetry_sdk",
+  "dep:opentelemetry-otlp",
+  "dep:tracing-opentelemetry",
+]
 cli = ["dep:clap", "dep:anyhow", "dep:dialoguer", "dep:dirs"]
 shuttle = ["dep:shuttle-tokio", "shuttle-tokio/shuttle"]
 

--- a/icechunk/src/lib.rs
+++ b/icechunk/src/lib.rs
@@ -111,6 +111,91 @@ static LOG_FILTER: std::sync::LazyLock<
     >,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
 
+/// Holds the OTLP tracer provider so spans can be flushed at shutdown.
+#[cfg(feature = "otel")]
+static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    std::sync::OnceLock::new();
+
+/// Set once `shutdown_telemetry` has run, so repeated calls are a no-op.
+#[cfg(feature = "otel")]
+static TELEMETRY_SHUTDOWN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Build the OTLP span exporter and tracer when an endpoint is configured.
+///
+/// Returns `None` when no endpoint env var is set (export disabled) or when the
+/// exporter fails to build. The icechunk-specific `ICECHUNK_OTLP_ENDPOINT` takes
+/// precedence over the standard `OTEL_EXPORTER_OTLP_ENDPOINT`, so a global
+/// collector can be overridden just for icechunk.
+///
+/// Must be called from within a Tokio runtime context: the tonic channel spawns
+/// a background driver task on the current runtime, which must stay alive for
+/// spans to be exported and flushed.
+#[cfg(feature = "otel")]
+fn build_otel_tracer() -> Option<opentelemetry_sdk::trace::SdkTracer> {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_otlp::{SpanExporter, WithExportConfig as _};
+    use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+
+    let endpoint = std::env::var("ICECHUNK_OTLP_ENDPOINT")
+        .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        .ok()?;
+
+    let exporter =
+        match SpanExporter::builder().with_tonic().with_endpoint(endpoint).build() {
+            Ok(exporter) => exporter,
+            Err(err) => {
+                eprintln!("Error building OpenTelemetry exporter: {err}");
+                return None;
+            }
+        };
+
+    let service_name = std::env::var("ICECHUNK_OTEL_SERVICE_NAME")
+        .or_else(|_| std::env::var("OTEL_SERVICE_NAME"))
+        .unwrap_or_else(|_| "icechunk".to_string());
+    let resource = Resource::builder().with_service_name(service_name).build();
+    let provider = SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(exporter)
+        .build();
+
+    let tracer = provider.tracer("icechunk");
+    // Keep the provider alive so `shutdown_telemetry` can flush it.
+    let _ = TRACER_PROVIDER.set(provider);
+    Some(tracer)
+}
+
+/// The filter controlling which spans are exported over OTLP. Fixed at startup.
+#[cfg(feature = "otel")]
+fn otel_export_filter() -> tracing_subscriber::EnvFilter {
+    // TODO: allow changing this at runtime
+    std::env::var("ICECHUNK_OTEL_FILTER")
+        .ok()
+        .map(tracing_subscriber::EnvFilter::new)
+        .unwrap_or_else(|| tracing_subscriber::EnvFilter::new("icechunk=info"))
+}
+
+/// Flush and shut down the OpenTelemetry exporter, if one is active.
+///
+/// Call before process exit so the final batch of spans is exported. Idempotent,
+/// and a no-op when the `otel` feature is disabled or no exporter was started.
+#[cfg(feature = "otel")]
+pub fn shutdown_telemetry() {
+    use std::sync::atomic::Ordering;
+    if TELEMETRY_SHUTDOWN.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    if let Some(provider) = TRACER_PROVIDER.get()
+        && let Err(err) = provider.shutdown()
+    {
+        eprintln!("Error shutting down telemetry: {err}");
+    }
+}
+
+/// No-op operation for callers with otel feature disabled
+#[cfg(not(feature = "otel"))]
+pub fn shutdown_telemetry() {}
+
 #[cfg(feature = "logs")]
 pub fn initialize_tracing(log_filter_directive: Option<&str>) {
     use tracing::Level;
@@ -130,7 +215,7 @@ pub fn initialize_tracing(log_filter_directive: Option<&str>) {
         Ok(mut guard) => match guard.as_ref() {
             Some(handle) => {
                 if let Err(err) = handle.reload(filter) {
-                    println!("Error reloading log settings: {err}");
+                    eprintln!("Error reloading log settings: {err}");
                 }
             }
             None => {
@@ -141,17 +226,31 @@ pub fn initialize_tracing(log_filter_directive: Option<&str>) {
 
                 let error_span_layer = ErrorLayer::default();
 
+                // Appended last so the console filter's `S` type — and thus the
+                // `LOG_FILTER` reload handle stored above — is unchanged. A `None`
+                // layer is a no-op, so "OTel disabled" needs no separate path.
+                #[cfg(feature = "otel")]
+                let otel_layer = build_otel_tracer().map(|tracer| {
+                    tracing_opentelemetry::OpenTelemetryLayer::new(tracer)
+                        .with_filter(otel_export_filter())
+                });
+                #[cfg(not(feature = "otel"))]
+                let otel_layer: Option<
+                    tracing_subscriber::layer::Identity,
+                > = None;
+
                 if let Err(err) = Registry::default()
                     .with(error_span_layer)
                     .with(stdout_layer)
+                    .with(otel_layer)
                     .try_init()
                 {
-                    println!("Error initializing logs: {err}");
+                    eprintln!("Error initializing logs: {err}");
                 }
             }
         },
         Err(err) => {
-            println!("Error setting up logs: {err}");
+            eprintln!("Error setting up logs: {err}");
         }
     }
 }


### PR DESCRIPTION
New `otel` Cargo feature, off by default for library builds, enabled in the Python wheel.

Export tracing spans over OTLP/gRPC when
ICECHUNK_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_ENDPOINT is set

Add a profiled Jaeger compose service plus just recipes (jaeger-up/down, pytest-otel) for local testing.

Documents the feature (opt-in, off by default, vendor-neutral OTLP, flagged experimental).