### PR TITLE
Send logs to stderr instead of stdout

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -25,6 +25,7 @@ This release introduces on-disk [spec version 2.1](https://icechunk.io/en/stable
 ### Breaking Changes
 
 - Stop publishing 32-bit wheels: `musllinux` for `i686` and `armv7l`, and `manylinux_2_28` for `armv7l`. Users on these platforms must now build from source ([#2214](https://github.com/earth-mover/icechunk/pull/2214)).
+- Console logs now go to stderr instead of stdout, so they no longer corrupt a host program's output. Set `ICECHUNK_LOG_TO_STDOUT` to any value before importing `icechunk` to restore the previous behavior.
 
 ### Documentation
 

--- a/icechunk-python/docs/docs/guides/observability.md
+++ b/icechunk-python/docs/docs/guides/observability.md
@@ -2,7 +2,7 @@
 
 Icechunk is instrumented with the Rust [`tracing`](https://docs.rs/tracing) framework. The same instrumentation drives two independent outputs:
 
-- **Console logs** — human-readable logs printed to stdout, controlled by `ICECHUNK_LOG`. Enabled by default at the `warn` level.
+- **Console logs** — human-readable logs printed to stderr, controlled by `ICECHUNK_LOG`. Enabled by default at the `warn` level.
 - **OpenTelemetry trace export** *(experimental)* — structured spans and traces are exported over OTLP/gRPC to a collector or service. Off by default, opt-in.
   Telemetry can be configured with an endpoint to use any OpenTelemetry compatible collector or service. If no endpoint is set
   by the user, there is zero exporter overhead and no spans are exported.
@@ -11,7 +11,7 @@ The two are configured separately and don't affect each other.
 
 ## Logging
 
-Icechunk prints logs to stdout. Set the verbosity with the `ICECHUNK_LOG` environment variable before importing `icechunk`:
+Icechunk prints logs to stderr, so they don't interfere with your program's own output on stdout. Set the verbosity with the `ICECHUNK_LOG` environment variable before importing `icechunk`:
 
 ```bash
 export ICECHUNK_LOG=icechunk=info
@@ -36,6 +36,8 @@ icechunk.set_logs_filter("debug,icechunk=trace")
 ```
 
 To skip logging setup entirely, set `ICECHUNK_NO_LOGS` (to any value) before importing `icechunk`.
+
+To send logs to stdout instead of stderr, set `ICECHUNK_LOG_TO_STDOUT` (to any value) before importing `icechunk`. The destination is fixed when logging is first initialized at import, so this variable has no effect if set afterwards; `set_logs_filter` only changes the verbosity, not the destination.
 
 ## OpenTelemetry tracing
 

--- a/icechunk-python/docs/docs/understanding/faq.md
+++ b/icechunk-python/docs/docs/understanding/faq.md
@@ -389,7 +389,7 @@ This is set automatically and cannot be overridden.
 
 ## Does `icechunk-python` include logging?
 
-Yes, Icechunk logs to stdout, controlled by the `ICECHUNK_LOG` environment variable (or by `set_logs_filter` at runtime). See the [Observability guide](../guides/observability.md#logging) for levels, filter syntax, and runtime control.
+Yes, Icechunk logs to stderr, controlled by the `ICECHUNK_LOG` environment variable (or by `set_logs_filter` at runtime). See the [Observability guide](../guides/observability.md#logging) for levels, filter syntax, and runtime control.
 
 ## Does Icechunk support tracing?
 

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -3714,6 +3714,9 @@ def initialize_logs() -> None:
 
     Reads the value of the environment variable ICECHUNK_LOG to obtain the filters.
     This is autamtically called on `import icechunk`.
+
+    Logs are written to stderr by default. Set ICECHUNK_LOG_TO_STDOUT (to any value)
+    before importing icechunk to write them to stdout instead.
     """
     ...
 

--- a/icechunk-python/tests/test_logs.py
+++ b/icechunk-python/tests/test_logs.py
@@ -1,5 +1,7 @@
 import os
 import re
+import subprocess
+import sys
 from unittest import mock
 
 from pytest import CaptureFixture
@@ -17,7 +19,9 @@ def test_debug_logs_from_environment(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert "Creating Repository" in capfd.readouterr().out
+    captured = capfd.readouterr()
+    assert "Creating Repository" in captured.err
+    assert "Creating Repository" not in captured.out
 
 
 @mock.patch.dict(os.environ, clear=True)
@@ -29,7 +33,7 @@ def test_no_logs_from_environment(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert capfd.readouterr().out == ""
+    assert capfd.readouterr().err == ""
 
 
 @mock.patch.dict(os.environ, clear=True)
@@ -42,7 +46,7 @@ def test_change_log_levels_from_env(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert capfd.readouterr().out == ""
+    assert capfd.readouterr().err == ""
 
     # now with logs enabled
     with mock.patch.dict(os.environ, {"ICECHUNK_LOG": "debug"}, clear=True):
@@ -51,7 +55,7 @@ def test_change_log_levels_from_env(
             storage=ic.in_memory_storage(),
             spec_version=any_spec_version,
         )
-        assert "Creating Repository" in capfd.readouterr().out
+        assert "Creating Repository" in capfd.readouterr().err
 
 
 def test_debug_logs_from_argument(
@@ -62,7 +66,7 @@ def test_debug_logs_from_argument(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert "Creating Repository" in capfd.readouterr().out
+    assert "Creating Repository" in capfd.readouterr().err
     ic.set_logs_filter(None)
 
 
@@ -75,7 +79,7 @@ def test_no_logs_from_argument(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert capfd.readouterr().out == ""
+    assert capfd.readouterr().err == ""
     ic.set_logs_filter(None)
 
 
@@ -88,7 +92,7 @@ def test_change_log_levels_from_argument(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert capfd.readouterr().out == ""
+    assert capfd.readouterr().err == ""
 
     # now with logs enabled
     ic.set_logs_filter("debug")
@@ -96,8 +100,40 @@ def test_change_log_levels_from_argument(
         storage=ic.in_memory_storage(),
         spec_version=any_spec_version,
     )
-    assert "Creating Repository" in capfd.readouterr().out
+    assert "Creating Repository" in capfd.readouterr().err
     ic.set_logs_filter(None)
+
+
+# The console writer is fixed when logging is first initialized (at `import
+# icechunk`), so the stdout/stderr routing can only be exercised in a fresh
+# interpreter with the environment set before the import.
+LOG_SNIPPET = (
+    "import icechunk as ic\nic.Repository.create(storage=ic.in_memory_storage())\n"
+)
+
+
+def run_logging_subprocess(
+    extra_env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", LOG_SNIPPET],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "ICECHUNK_LOG": "debug", **extra_env},
+        check=True,
+    )
+
+
+def test_logs_go_to_stderr_by_default() -> None:
+    result = run_logging_subprocess({})
+    assert "Creating Repository" in result.stderr
+    assert "Creating Repository" not in result.stdout
+
+
+def test_logs_go_to_stdout_when_requested() -> None:
+    result = run_logging_subprocess({"ICECHUNK_LOG_TO_STDOUT": "1"})
+    assert "Creating Repository" in result.stdout
+    assert "Creating Repository" not in result.stderr
 
 
 def test_warn_on_small_caches(
@@ -137,14 +173,14 @@ def test_warn_on_small_caches(
     array2[:] = 42
     session.commit("msg")
 
-    out = capfd.readouterr().out
+    err = capfd.readouterr().err
     # we only warn once for manifests and once for snapshots
-    assert len(re.findall("WARN", out)) == 2
+    assert len(re.findall("WARN", err)) == 2
 
-    assert re.search("5 chunk references", out)
-    assert re.search("keep 0 references", out)
-    assert re.search("3 nodes", out)
-    assert re.search("keep 0 nodes", out)
+    assert re.search("5 chunk references", err)
+    assert re.search("keep 0 references", err)
+    assert re.search("3 nodes", err)
+    assert re.search("keep 0 nodes", err)
     ic.set_logs_filter(None)
 
 

--- a/icechunk/src/lib.rs
+++ b/icechunk/src/lib.rs
@@ -201,12 +201,13 @@ pub fn initialize_tracing(log_filter_directive: Option<&str>) {
     use tracing::Level;
     use tracing_error::ErrorLayer;
     use tracing_subscriber::{
-        EnvFilter, Layer as _, Registry, layer::SubscriberExt as _, reload,
-        util::SubscriberInitExt as _,
+        EnvFilter, Layer as _, Registry, fmt::writer::BoxMakeWriter,
+        layer::SubscriberExt as _, reload, util::SubscriberInitExt as _,
     };
 
     // We have two Layers. One keeps track of the spans to feed the ICError instances.
-    // The other is the one spitting logs to stdout. Filtering only applies to the second Layer.
+    // The other writes human-readable logs to the console (stderr by default, or
+    // stdout if ICECHUNK_LOG_TO_STDOUT is set). Filtering only applies to the second Layer.
 
     let filter = log_filter_directive.map(EnvFilter::new).unwrap_or_else(|| {
         EnvFilter::from_env("ICECHUNK_LOG").add_directive(Level::WARN.into())
@@ -221,8 +222,16 @@ pub fn initialize_tracing(log_filter_directive: Option<&str>) {
             None => {
                 let (filter, handle) = reload::Layer::new(filter);
                 *guard = Some(handle);
-                let stdout_layer =
-                    tracing_subscriber::fmt::layer().pretty().with_filter(filter);
+
+                let writer = if std::env::var("ICECHUNK_LOG_TO_STDOUT").is_ok() {
+                    BoxMakeWriter::new(std::io::stdout)
+                } else {
+                    BoxMakeWriter::new(std::io::stderr)
+                };
+                let console_layer = tracing_subscriber::fmt::layer()
+                    .pretty()
+                    .with_writer(writer)
+                    .with_filter(filter);
 
                 let error_span_layer = ErrorLayer::default();
 
@@ -241,7 +250,7 @@ pub fn initialize_tracing(log_filter_directive: Option<&str>) {
 
                 if let Err(err) = Registry::default()
                     .with(error_span_layer)
-                    .with(stdout_layer)
+                    .with(console_layer)
                     .with(otel_layer)
                     .try_init()
                 {


### PR DESCRIPTION
This prevents our own logs from corrupting the user's program output.

As a escape hatch, user can set ICECHUNK_LOG_TO_STDOUT to recover the previous behavior.

This is a braking change, but I think it's more correct and most users will be OK with it.