### PR TITLE
Fix S3 empty-prefix key layout and add layout auto-detection

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -10,6 +10,7 @@ on:
   schedule:
     # three times a day to run the integration tests that take a long time
     - cron:  '33 3,10,15 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +32,8 @@ env:
 jobs:
   rust:
     name: Rust CI
-    timeout-minutes: 20
+    # Headroom for the slow macos-15-intel runner
+    timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -76,6 +78,12 @@ jobs:
           done
           for _ in {1..60}; do
               if curl --silent --fail "http://localhost:10000/devstoreaccount1/testcontainer?sv=2023-01-03&ss=btqf&srt=sco&spr=https%2Chttp&st=2025-01-06T14%3A53%3A30Z&se=2035-01-07T14%3A53%3A00Z&sp=rwdftlacup&sig=jclETGilOzONYp4Y0iK9SpVRLGyehaS5lg5booJ9VYA%3D&restype=container"; then
+              break
+              fi
+              sleep 1
+          done
+          for _ in {1..60}; do
+              if curl --silent --fail "http://localhost:4202/minio/health/live"; then
               break
               fi
               sleep 1
@@ -136,8 +144,13 @@ jobs:
         run: |
           just profile=ci unit-test
 
+      # Runs nightly, on manual dispatch, or on any PR labeled
+      # `run-integration-tests`
       - name: Run integration tests against object stores
-        if: github.event_name == 'cron'
+        if: >-
+          github.event_name == 'schedule'
+          || github.event_name == 'workflow_dispatch'
+          || contains(github.event.pull_request.labels.*.name, 'run-integration-tests')
         env:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -154,8 +167,26 @@ jobs:
           TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}
           TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}
 
+          # passed via env rather than interpolated into the shell below, to
+          # satisfy zizmor's template-injection audit
+          MATRIX_OS: ${{ matrix.os }}
+
         run: |
-          cargo test --profile ci --workspace --all-targets -- --ignored
+          # Don't let a failure (or flake) in one group hide the other.
+          set +e
+          rc=0
+          # Most real-store ignored tests use unique prefixes, so they're safe to
+          # run on every matrix OS in parallel.
+          # Exclude icechunk-python: it has no Rust tests, but its PyO3 lib-test
+          # binary aborts at launch trying to load libpython
+          cargo test --profile ci --workspace --exclude icechunk-python --tests -- --ignored --skip rooted_roundtrip || rc=1
+          # The rooted-layout tests operate at the bucket root (empty prefix, no
+          # unique prefix), so concurrent matrix jobs would race on the same keys:
+          # run them on a single runner.
+          if [ "$MATRIX_OS" = "ubuntu-latest" ]; then
+            cargo test --profile ci -p icechunk --test main rooted_roundtrip -- --ignored || rc=1
+          fi
+          exit $rc
 
   shuttle:
     name: Shuttle concurrency tests

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -19,6 +19,7 @@ This release introduces on-disk [spec version 2.1](https://icechunk.io/en/stable
 ### Fixes
 
 - Expiration now records the full ancestry of pruned transaction logs in a new optional `pruned_ancestor_tx_logs` field on `SnapshotInfo`, so `diff`, `amend`, `rebase`, and `inspect` produce correct results after expiration ([#2184](https://github.com/earth-mover/icechunk/pull/2184)).
+- The native S3 backend used to write every object under a leading slash (`/chunks/...`) when `prefix` was empty, which made repositories unreadable by external tools and could cause garbage collection to silently orphan objects. New empty-prefix repositories now use clean keys, and pre-existing "rooted" repositories are detected and handled automatically ([#2239](https://github.com/earth-mover/icechunk/issues/2239)).
 - Preserve all URL parts (userinfo, port, query, fragment, and empty path segments) when storing virtual chunk locations ([#2219](https://github.com/earth-mover/icechunk/pull/2219)).
 - Honor the port when reading virtual chunks from HTTP stores, so a reference like `http://host:8080/...` is fetched from the correct port ([#2223](https://github.com/earth-mover/icechunk/issues/2223)).
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -19,7 +19,8 @@ This release introduces on-disk [spec version 2.1](https://icechunk.io/en/stable
 ### Fixes
 
 - Expiration now records the full ancestry of pruned transaction logs in a new optional `pruned_ancestor_tx_logs` field on `SnapshotInfo`, so `diff`, `amend`, `rebase`, and `inspect` produce correct results after expiration ([#2184](https://github.com/earth-mover/icechunk/pull/2184)).
-- The native S3 backend used to write every object under a leading slash (`/chunks/...`) when `prefix` was empty, which made repositories unreadable by external tools and could cause garbage collection to silently orphan objects. New empty-prefix repositories now use clean keys, and pre-existing "rooted" repositories are detected and handled automatically ([#2239](https://github.com/earth-mover/icechunk/issues/2239)).
+- The native S3 backend used to write every object under a leading slash (`/chunks/...`) when `prefix` was empty, which made repositories unreadable by external tools and could cause garbage collection to silently orphan objects. New empty-prefix repositories now use clean keys, and pre-existing "rooted" repositories are detected and handled automatically. Rooted repositories are
+not migrated into a new format, so external tools may still have some issues with those repos, but Icechunk 2.1.0 knows how to read and write to rooted and non-rooted repos ([#2239](https://github.com/earth-mover/icechunk/issues/2239)).
 - Preserve all URL parts (userinfo, port, query, fragment, and empty path segments) when storing virtual chunk locations ([#2219](https://github.com/earth-mover/icechunk/pull/2219)).
 - Honor the port when reading virtual chunks from HTTP stores, so a reference like `http://host:8080/...` is fetched from the correct port ([#2223](https://github.com/earth-mover/icechunk/issues/2223)).
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 volumes:
   rustfs_data:
+  minio_data:
   azurite-data:
 
 services:
@@ -92,6 +93,37 @@ services:
         rc admin policy attach local --user modify modify
 
         exit 0
+
+  # MinIO is used in addition to rustfs because it *normalizes* leading-slash
+  # object keys ("/x" -> "x") instead of rejecting them like rustfs. This lets us
+  # regression-test that empty-prefix repositories work on a normalizing store
+  # (see icechunk/tests/test_key_layout.rs and #2239).
+  minio:
+    container_name: icechunk_minio
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    hostname: minio
+    healthcheck:
+      test: curl -f http://127.0.0.1:9000/minio/health/live
+      interval: 1s
+      retries: 30
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    entrypoint: |
+        /bin/sh -c '
+        for bucket in testbucket
+        do
+          echo creating bucket "$$bucket";
+          mkdir -p /data/"$$bucket"
+        done;
+
+        exec minio server /data --console-address ":9001"
+        '
+    volumes:
+      - minio_data:/data
+    ports:
+      - '4202:9000'
+      - '4203:9001'
 
   toxiproxy:
     container_name: icechunk_toxiproxy

--- a/icechunk-js/src/storage.rs
+++ b/icechunk-js/src/storage.rs
@@ -974,8 +974,11 @@ impl JsStorage {
     ) -> napi::Result<JsStorage> {
         let creds = credentials.map(|c| c.into());
         let opts = options.map(|o| o.into()).unwrap_or_default();
-        let storage = icechunk::storage::new_s3_storage(opts, bucket, prefix, creds)
-            .map_napi_err()?;
+        // legacy_rooted_keys is not exposed to JS: pre-fix empty-prefix repos are
+        // handled transparently by auto-detection in the storage backend.
+        let storage =
+            icechunk::storage::new_s3_storage(opts, bucket, prefix, creds, None)
+                .map_napi_err()?;
         Ok(JsStorage(storage))
     }
 
@@ -989,9 +992,10 @@ impl JsStorage {
     ) -> napi::Result<JsStorage> {
         let creds = credentials.map(|c| c.into());
         let opts = options.map(|o| o.into()).unwrap_or_default();
-        let storage =
-            icechunk::storage::new_r2_storage(opts, bucket, prefix, account_id, creds)
-                .map_napi_err()?;
+        let storage = icechunk::storage::new_r2_storage(
+            opts, bucket, prefix, account_id, creds, None,
+        )
+        .map_napi_err()?;
         Ok(JsStorage(storage))
     }
 
@@ -1012,6 +1016,7 @@ impl JsStorage {
             prefix,
             creds,
             weak_consistency,
+            None,
         )
         .map_napi_err()?;
         Ok(JsStorage(storage))
@@ -1098,7 +1103,7 @@ impl JsStorage {
             icechunk::config::S3Credentials::Refreshable(std::sync::Arc::new(fetcher));
         let opts = options.map(|o| o.into()).unwrap_or(default_s3_options());
         let storage =
-            icechunk::storage::new_s3_storage(opts, bucket, prefix, Some(creds))
+            icechunk::storage::new_s3_storage(opts, bucket, prefix, Some(creds), None)
                 .map_napi_err()?;
         Ok(JsStorage(storage))
     }
@@ -1131,6 +1136,7 @@ impl JsStorage {
             prefix,
             account_id,
             Some(creds),
+            None,
         )
         .map_napi_err()?;
         Ok(JsStorage(storage))
@@ -1165,6 +1171,7 @@ impl JsStorage {
             prefix,
             Some(creds),
             weak_consistency,
+            None,
         )
         .map_napi_err()?;
         Ok(JsStorage(storage))

--- a/icechunk-python/docs/docs/guides/storage.md
+++ b/icechunk-python/docs/docs/guides/storage.md
@@ -73,6 +73,24 @@ When using Icechunk with s3 compatible storage systems, credentials must be prov
     )
     ```
 
+!!! note "Empty prefix and legacy repositories"
+
+    When `prefix` is empty (`None` or `""`) the repository lives at the bucket
+    root and objects are stored with clean keys (`chunks/...`). Repositories
+    created before [#2239](https://github.com/earth-mover/icechunk/issues/2239)
+    instead stored empty-prefix objects under a leading slash (`/chunks/...`);
+    Icechunk detects that layout automatically when opening such a repository, so
+    no action is needed to keep reading and writing it.
+
+    The `legacy_rooted_keys` parameter overrides that detection:
+
+    - `None` (default) — auto-detect the layout by probing storage. Use this
+      unless you have a specific reason not to.
+    - `True` — force the legacy leading-slash layout, skipping the probe (for
+      example, for a write-only worker that cannot probe storage). Only valid
+      with an empty prefix.
+    - `False` — force the standard layout, skipping the probe.
+
 #### Tigris
 
 [Tigris](https://www.tigrisdata.com/) is available as a storage backend for Icechunk. Icechunk provides a helper function specifically for [creating Tigris storage configurations](../reference/storage.md#icechunk.storage.tigris_storage).

--- a/icechunk-python/docs/docs/guides/storage.md
+++ b/icechunk-python/docs/docs/guides/storage.md
@@ -73,24 +73,6 @@ When using Icechunk with s3 compatible storage systems, credentials must be prov
     )
     ```
 
-!!! note "Empty prefix and legacy repositories"
-
-    When `prefix` is empty (`None` or `""`) the repository lives at the bucket
-    root and objects are stored with clean keys (`chunks/...`). Repositories
-    created before [#2239](https://github.com/earth-mover/icechunk/issues/2239)
-    instead stored empty-prefix objects under a leading slash (`/chunks/...`);
-    Icechunk detects that layout automatically when opening such a repository, so
-    no action is needed to keep reading and writing it.
-
-    The `legacy_rooted_keys` parameter overrides that detection:
-
-    - `None` (default) — auto-detect the layout by probing storage. Use this
-      unless you have a specific reason not to.
-    - `True` — force the legacy leading-slash layout, skipping the probe (for
-      example, for a write-only worker that cannot probe storage). Only valid
-      with an empty prefix.
-    - `False` — force the standard layout, skipping the probe.
-
 #### Tigris
 
 [Tigris](https://www.tigrisdata.com/) is available as a storage backend for Icechunk. Icechunk provides a helper function specifically for [creating Tigris storage configurations](../reference/storage.md#icechunk.storage.tigris_storage).
@@ -415,3 +397,13 @@ While it should never be used for production data, Icechunk can also be used wit
 ```python
 icechunk.in_memory_storage()
 ```
+
+### Empty prefix and legacy repositories
+
+When `prefix` is empty (`None` or `""`) the repository lives at the bucket root and objects are stored with clean keys (`chunks/...`). Repositories created before Icechunk version 2.1.0 stored empty-prefix objects under a leading slash (`/chunks/...`); Icechunk detects that layout automatically when opening such a repository, so no action is needed to keep reading and writing it.
+
+The `legacy_rooted_keys` parameter overrides that detection:
+
+- `None` (default) — auto-detect the layout by probing storage. Use this unless you have a specific reason not to.
+- `True` — force the legacy leading-slash layout, skipping the probe (for example, for a write-only worker that cannot probe storage). Only valid with an empty prefix.
+- `False` — force the standard layout, skipping the probe. Users shouldn't need to pass this value.

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -3370,6 +3370,7 @@ class Storage:
         bucket: str,
         prefix: str | None,
         credentials: _AnyS3Credential | None = None,
+        legacy_rooted_keys: bool | None = None,
     ) -> Storage: ...
     @classmethod
     def new_s3_object_store(
@@ -3387,6 +3388,7 @@ class Storage:
         prefix: str | None,
         use_weak_consistency: bool,
         credentials: _AnyS3Credential | None = None,
+        legacy_rooted_keys: bool | None = None,
     ) -> Storage: ...
     @classmethod
     def new_in_memory(cls) -> Storage: ...
@@ -3409,6 +3411,7 @@ class Storage:
         prefix: str | None = None,
         account_id: str | None = None,
         credentials: _AnyS3Credential | None = None,
+        legacy_rooted_keys: bool | None = None,
     ) -> Storage: ...
     @classmethod
     def new_azure_blob(

--- a/icechunk-python/python/icechunk/storage.py
+++ b/icechunk-python/python/icechunk/storage.py
@@ -198,6 +198,7 @@ def s3_storage(
     network_stream_timeout_seconds: int = 60,
     requester_pays: bool = False,
     checksum_algorithm: ChecksumAlgorithm | None = None,
+    legacy_rooted_keys: bool | None = None,
 ) -> Storage:
     """Create a Storage instance that saves data in S3 or S3 compatible object stores.
 
@@ -245,6 +246,11 @@ def s3_storage(
         UploadPart, DeleteObjects). When ``None`` (default) the AWS SDK picks
         its own default. Set explicitly when targeting an S3-compatible service
         that rejects the SDK's default.
+    legacy_rooted_keys: bool | None
+        The object key layout. ``None`` (default) detects it automatically and is
+        what most users will want; only set it explicitly if you have a special
+        situation and know what you're doing. ``True`` forces the old leading-slash
+        layout (empty prefix only); ``False`` forces the standard one.
     """
 
     credentials = s3_credentials(
@@ -272,6 +278,7 @@ def s3_storage(
         bucket=bucket,
         prefix=prefix,
         credentials=credentials,
+        legacy_rooted_keys=legacy_rooted_keys,
     )
 
 
@@ -332,6 +339,7 @@ def tigris_storage(
     scatter_initial_credentials: bool = False,
     network_stream_timeout_seconds: int = 60,
     checksum_algorithm: ChecksumAlgorithm | None = None,
+    legacy_rooted_keys: bool | None = None,
 ) -> Storage:
     """Create a Storage instance that saves data in Tigris object store.
 
@@ -374,6 +382,11 @@ def tigris_storage(
     network_stream_timeout_seconds: int
         Timeout requests if no bytes can be transmitted during this period of time.
         If set to 0, timeout is disabled. Default: 60.
+    legacy_rooted_keys: bool | None
+        The object key layout. ``None`` (default) detects it automatically and is
+        what most users will want; only set it explicitly if you have a special
+        situation and know what you're doing. ``True`` forces the old leading-slash
+        layout (empty prefix only); ``False`` forces the standard one.
     """
     credentials = s3_credentials(
         access_key_id=access_key_id,
@@ -399,6 +412,7 @@ def tigris_storage(
         prefix=prefix,
         use_weak_consistency=use_weak_consistency,
         credentials=credentials,
+        legacy_rooted_keys=legacy_rooted_keys,
     )
 
 
@@ -420,8 +434,9 @@ def r2_storage(
     scatter_initial_credentials: bool = False,
     network_stream_timeout_seconds: int = 60,
     checksum_algorithm: ChecksumAlgorithm | None = None,
+    legacy_rooted_keys: bool | None = None,
 ) -> Storage:
-    """Create a Storage instance that saves data in Tigris object store.
+    """Create a Storage instance that saves data in R2 object store.
 
     Parameters
     ----------
@@ -462,6 +477,11 @@ def r2_storage(
     network_stream_timeout_seconds: int
         Timeout requests if no bytes can be transmitted during this period of time.
         If set to 0, timeout is disabled. Default: 60.
+    legacy_rooted_keys: bool | None
+        The object key layout. ``None`` (default) detects it automatically and is
+        what most users will want; only set it explicitly if you have a special
+        situation and know what you're doing. ``True`` forces the old leading-slash
+        layout (empty prefix only); ``False`` forces the standard one.
     """
     credentials = s3_credentials(
         access_key_id=access_key_id,
@@ -487,6 +507,7 @@ def r2_storage(
         prefix=prefix,
         account_id=account_id,
         credentials=credentials,
+        legacy_rooted_keys=legacy_rooted_keys,
     )
 
 

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -2873,7 +2873,7 @@ impl PyLatencyStorage {
 
 #[pymethods]
 impl PyStorage {
-    #[pyo3(signature = ( config, bucket, prefix, credentials=None))]
+    #[pyo3(signature = ( config, bucket, prefix, credentials=None, legacy_rooted_keys=None))]
     #[classmethod]
     pub(crate) fn new_s3(
         _cls: &Bound<'_, PyType>,
@@ -2881,12 +2881,14 @@ impl PyStorage {
         bucket: String,
         prefix: Option<String>,
         credentials: Option<PyS3Credentials>,
+        legacy_rooted_keys: Option<bool>,
     ) -> PyResult<Self> {
         let storage = storage::new_s3_storage(
             config.into(),
             bucket,
             prefix,
             credentials.map(|cred| cred.into()),
+            legacy_rooted_keys,
         )
         .map_err(PyIcechunkStoreError::StorageError)?;
 
@@ -2919,7 +2921,7 @@ impl PyStorage {
         })
     }
 
-    #[pyo3(signature = ( config, bucket, prefix, use_weak_consistency, credentials=None))]
+    #[pyo3(signature = ( config, bucket, prefix, use_weak_consistency, credentials=None, legacy_rooted_keys=None))]
     #[classmethod]
     pub(crate) fn new_tigris(
         _cls: &Bound<'_, PyType>,
@@ -2928,6 +2930,7 @@ impl PyStorage {
         prefix: Option<String>,
         use_weak_consistency: bool,
         credentials: Option<PyS3Credentials>,
+        legacy_rooted_keys: Option<bool>,
     ) -> PyResult<Self> {
         let storage = storage::new_tigris_storage(
             config.into(),
@@ -2935,13 +2938,14 @@ impl PyStorage {
             prefix,
             credentials.map(|cred| cred.into()),
             use_weak_consistency,
+            legacy_rooted_keys,
         )
         .map_err(PyIcechunkStoreError::StorageError)?;
 
         Ok(PyStorage(storage))
     }
 
-    #[pyo3(signature = ( config, bucket=None, prefix=None, account_id=None, credentials=None))]
+    #[pyo3(signature = ( config, bucket=None, prefix=None, account_id=None, credentials=None, legacy_rooted_keys=None))]
     #[classmethod]
     pub(crate) fn new_r2(
         _cls: &Bound<'_, PyType>,
@@ -2950,6 +2954,7 @@ impl PyStorage {
         prefix: Option<String>,
         account_id: Option<String>,
         credentials: Option<PyS3Credentials>,
+        legacy_rooted_keys: Option<bool>,
     ) -> PyResult<Self> {
         let storage = storage::new_r2_storage(
             config.into(),
@@ -2957,6 +2962,7 @@ impl PyStorage {
             prefix,
             account_id,
             credentials.map(|cred| cred.into()),
+            legacy_rooted_keys,
         )
         .map_err(PyIcechunkStoreError::StorageError)?;
 

--- a/icechunk-python/tests/test_key_layout.py
+++ b/icechunk-python/tests/test_key_layout.py
@@ -1,0 +1,123 @@
+"""Integration tests for the empty-`prefix` S3 key layout fix (#2239).
+
+Before the fix, ``ic.s3_storage(prefix=None)`` made the native-S3 backend write
+every object under a leading slash (``/chunks/...``); external tools 404'd. These
+run against rustfs at ``http://localhost:4200``.
+
+Empty-prefix repositories live at the bucket root, so each test creates its own
+bucket (rustfs root credentials) for isolation. The ``LegacyRoot`` round-trip is
+not exercised here because rustfs rejects leading-slash keys; see the Rust unit
+tests and ``icechunk/tests/test_key_layout.rs``.
+"""
+
+import time
+import uuid
+
+import boto3
+import numpy as np
+import pytest
+from mypy_boto3_s3.client import S3Client
+from numpy.testing import assert_array_equal
+
+import icechunk as ic
+import zarr
+
+# Older botocore signs requests with the deprecated datetime.utcnow(); ignore that
+# specific warning so these tests pass regardless of the installed botocore version.
+pytestmark = pytest.mark.filterwarnings("ignore:datetime.datetime.utcnow")
+
+ENDPOINT = "http://localhost:4200"
+REGION = "us-east-1"
+# rustfs server admin credentials: can create buckets and access any bucket.
+ROOT_KEY, ROOT_SECRET = "test123", "test123"
+
+
+def root_s3_client() -> S3Client:
+    return boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        use_ssl=False,
+        region_name=REGION,
+        aws_access_key_id=ROOT_KEY,
+        aws_secret_access_key=ROOT_SECRET,
+    )
+
+
+@pytest.fixture
+def fresh_bucket() -> str:
+    # Name sorts lexicographically after `testbucket`, and the zero-padded
+    # microsecond timestamp makes lexicographic order match creation order; the
+    # random suffix keeps it unique under parallel test runs.
+    bucket = f"testbucket-layout-{time.time_ns() // 1000:016d}-{uuid.uuid4().hex[:12]}"
+    root_s3_client().create_bucket(Bucket=bucket)
+    return bucket
+
+
+def empty_prefix_storage(bucket: str, prefix: str | None = None) -> ic.Storage:
+    return ic.s3_storage(
+        bucket=bucket,
+        prefix=prefix,
+        region=REGION,
+        endpoint_url=ENDPOINT,
+        allow_http=True,
+        access_key_id=ROOT_KEY,
+        secret_access_key=ROOT_SECRET,
+        force_path_style=True,
+    )
+
+
+def bucket_keys(bucket: str) -> list[str]:
+    resp = root_s3_client().list_objects_v2(Bucket=bucket)
+    return [o["Key"] for o in resp.get("Contents", [])]
+
+
+def write_array(repo: ic.Repository, value: int) -> None:
+    session = repo.writable_session("main")
+    root = zarr.group(store=session.store)
+    arr = root.require_array("array", shape=(4,), chunks=(2,), dtype="i4")
+    arr[:] = np.full((4,), value, dtype="i4")
+    session.commit(f"write {value}")
+
+
+def test_empty_prefix_writes_clean_keys(fresh_bucket: str) -> None:
+    # threshold 0 forces chunks to be written as separate `chunks/...` objects
+    config = ic.RepositoryConfig.default()
+    config.inline_chunk_threshold_bytes = 0
+    repo = ic.Repository.create(storage=empty_prefix_storage(fresh_bucket), config=config)
+    write_array(repo, 42)
+
+    keys = bucket_keys(fresh_bucket)
+    assert keys, "repository wrote no objects"
+    bad = [k for k in keys if k.startswith("/")]
+    assert not bad, f"keys must not start with a slash (the #2239 bug): {bad}"
+    assert "repo" in keys, f"expected a clean `repo` key, got {keys}"
+    assert any(k.startswith("chunks/") for k in keys), (
+        f"expected clean `chunks/...` keys, got {keys}"
+    )
+
+
+def test_empty_prefix_roundtrips(fresh_bucket: str) -> None:
+    repo = ic.Repository.create(storage=empty_prefix_storage(fresh_bucket))
+    write_array(repo, 7)
+
+    # Re-open with a fresh storage (re-runs layout detection).
+    repo2 = ic.Repository.open(storage=empty_prefix_storage(fresh_bucket))
+    session = repo2.readonly_session(branch="main")
+    arr = zarr.open_array(store=session.store, path="array", mode="r")
+    assert_array_equal(arr[:], np.full((4,), 7, dtype="i4"))
+
+
+def test_legacy_rooted_keys_rejected_with_nonempty_prefix() -> None:
+    # The escape hatch is only valid for an empty prefix.
+    with pytest.raises(Exception, match="empty prefix"):
+        ic.s3_storage(
+            bucket="testbucket",
+            prefix="some/prefix",
+            region=REGION,
+            endpoint_url=ENDPOINT,
+            allow_http=True,
+            access_key_id=ROOT_KEY,
+            secret_access_key=ROOT_SECRET,
+            force_path_style=True,
+            legacy_rooted_keys=True,
+        )

--- a/icechunk-s3/src/lib.rs
+++ b/icechunk-s3/src/lib.rs
@@ -4,8 +4,8 @@
 pub use aws_sdk_s3;
 
 use std::{
-    collections::HashMap, fmt, future::ready, ops::Range, path::PathBuf, pin::Pin,
-    sync::Arc, time::Duration,
+    collections::HashMap, fmt, future::ready, ops::Range, pin::Pin, sync::Arc,
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -56,6 +56,52 @@ use tokio_util::io::StreamReader;
 use tracing::{error, instrument, trace};
 use typed_path::Utf8UnixPath;
 
+/// How object keys are laid out inside the bucket for a given repository.
+///
+/// Native-S3 repositories written before the fix for
+/// <https://github.com/earth-mover/icechunk/issues/2239> stored every object
+/// under a leading slash when the prefix was empty (`"/chunks/..."`, etc.).
+/// We keep being able to read and write those repositories via [`KeyLayout::LegacyRoot`],
+/// while all new repositories use the clean [`KeyLayout::Standard`] layout.
+///
+/// A repository has exactly one layout, decided once and never mixed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KeyLayout {
+    /// `prefix == ""` -> `"chunks/x"`; `prefix == "p"` -> `"p/chunks/x"`.
+    Standard,
+    /// Only used with an empty prefix: reproduces the historical `"/chunks/x"`.
+    LegacyRoot,
+}
+
+/// Well-known object names probed by [`S3Storage::probe_layout`] to auto-detect
+/// the key layout of a pre-existing repository. These are fixed keys that exist
+/// in every repository.
+///
+/// It's awful to have to have this tacit dependency here, this is icechunk-format stuff.
+/// But... reality hits you hard. I don't want an explicit dependency between the crates
+/// but there are some tests that verify these strings are "right".
+pub const DEFAULT_LAYOUT_ANCHORS: &[&str] = &["repo", "refs/branch.main/ref.json"];
+
+/// Serializes the resolved [`KeyLayout`] as `Option<KeyLayout>`.
+mod layout_cell_serde {
+    use super::{KeyLayout, OnceCell};
+    use serde::{Deserialize as _, Deserializer, Serialize as _, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(
+        cell: &OnceCell<KeyLayout>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        cell.get().copied().serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<OnceCell<KeyLayout>, D::Error> {
+        let resolved = Option::<KeyLayout>::deserialize(deserializer)?;
+        Ok(OnceCell::new_with(resolved))
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct S3Storage {
     // config and credentials are stored so we are able to serialize and deserialize the struct
@@ -66,9 +112,11 @@ pub struct S3Storage {
     can_write: bool,
     extra_read_headers: Vec<(String, String)>,
     extra_write_headers: Vec<(String, String)>,
+    #[serde(default, with = "layout_cell_serde")]
+    key_layout: OnceCell<KeyLayout>,
     #[serde(skip)]
     /// We need to use `OnceCell` to allow async initialization, because serde
-    /// does not support async cfunction calls from deserialization. This gives
+    /// does not support async function calls from deserialization. This gives
     /// us a way to lazily initialize the client.
     client: OnceCell<Arc<Client>>,
 }
@@ -317,6 +365,16 @@ fn stream2stream(
 }
 
 impl S3Storage {
+    /// Build an [`S3Storage`].
+    ///
+    /// `legacy_rooted_keys` declares the bucket's key layout:
+    /// - `None` — unknown: the layout is auto-detected by probing storage on first
+    ///   use. The right choice when opening a repository whose layout you don't know.
+    /// - `Some(true)` — force the legacy leading-slash layout used before the fix
+    ///   for <https://github.com/earth-mover/icechunk/issues/2239>. Only valid with
+    ///   an empty prefix; errors otherwise.
+    /// - `Some(false)` — force the standard layout, skipping the probe.
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         config: S3Options,
         bucket: String,
@@ -325,10 +383,25 @@ impl S3Storage {
         can_write: bool,
         extra_read_headers: Vec<(String, String)>,
         extra_write_headers: Vec<(String, String)>,
+        legacy_rooted_keys: Option<bool>,
     ) -> Result<S3Storage, StorageError> {
         let client = OnceCell::new();
         let prefix = prefix.unwrap_or_default();
         let prefix = prefix.strip_suffix("/").unwrap_or(prefix.as_str()).to_string();
+        // A known layout pre-seeds the cell so `probe_layout` is never reached;
+        // `None` leaves it empty to be detected lazily on first use.
+        let key_layout = match legacy_rooted_keys {
+            Some(true) => {
+                if !prefix.is_empty() {
+                    return Err(other_error(
+                        "legacy_rooted_keys is only valid with an empty prefix",
+                    ));
+                }
+                OnceCell::new_with(Some(KeyLayout::LegacyRoot))
+            }
+            Some(false) => OnceCell::new_with(Some(KeyLayout::Standard)),
+            None => OnceCell::new(),
+        };
         Ok(S3Storage {
             client,
             config,
@@ -338,6 +411,7 @@ impl S3Storage {
             can_write,
             extra_read_headers,
             extra_write_headers,
+            key_layout,
         })
     }
 
@@ -362,18 +436,86 @@ impl S3Storage {
             .await
     }
 
-    pub fn get_path_str(&self, file_prefix: &str, id: &str) -> StorageResult<String> {
-        let path = PathBuf::from_iter([self.prefix.as_str(), file_prefix, id]);
-        let path_str = path
-            .into_os_string()
-            .into_string()
-            .map_err(|s| StorageError::capture(StorageErrorKind::BadPrefix(s)))?;
-
-        Ok(path_str.replace("\\", "/"))
+    /// Build the object key for a repository-relative path under the given layout.
+    fn key_for(&self, layout: KeyLayout, relpath: &str) -> String {
+        match layout {
+            // Only reachable with an empty prefix (enforced at construction and
+            // by `probe_layout`), so the prefix is intentionally ignored here.
+            KeyLayout::LegacyRoot => format!("/{relpath}"),
+            KeyLayout::Standard if self.prefix.is_empty() => relpath.to_string(),
+            KeyLayout::Standard => format!("{}/{}", self.prefix, relpath),
+        }
     }
 
-    fn prefixed_path(&self, path: &str) -> String {
-        format!("{}/{path}", self.prefix)
+    /// Resolve this repository's [`KeyLayout`], probing storage at most once.
+    async fn layout(&self, settings: &Settings) -> StorageResult<KeyLayout> {
+        self.key_layout.get_or_try_init(|| self.probe_layout(settings)).await.copied()
+    }
+
+    /// Detect the key layout of the repository.
+    ///
+    /// Only ever issues requests for empty-prefix repositories — a non-empty
+    /// prefix can never produce a leading slash, so the layout is unambiguously
+    /// [`KeyLayout::Standard`]. The probe HEADs a few fixed anchor files under
+    /// both layouts.
+    async fn probe_layout(&self, settings: &Settings) -> StorageResult<KeyLayout> {
+        if !self.prefix.is_empty() {
+            // the legacy bug only triggered on empty prefixes
+            return Ok(KeyLayout::Standard);
+        }
+        // For each anchor, HEAD the clean and rooted keys and compare `ETag`s
+        // rather than mere existence. Some S3-compatible stores (e.g. MinIO) strip
+        // a leading slash, so HEAD("/repo") returns the *same* object as
+        // HEAD("repo"); that is key normalization, not a mixed repository, and must
+        // resolve to the clean layout.
+        let probes = DEFAULT_LAYOUT_ANCHORS.iter().map(|anchor| {
+            let clean_key = self.key_for(KeyLayout::Standard, anchor);
+            let rooted_key = self.key_for(KeyLayout::LegacyRoot, anchor);
+            async move {
+                let (clean, rooted) = futures::future::try_join(
+                    self.head_etag(settings, &clean_key),
+                    self.head_etag(settings, &rooted_key),
+                )
+                .await?;
+                Ok::<_, StorageError>(AnchorProbe { clean, rooted })
+            }
+        });
+        let anchors = futures::future::try_join_all(probes).await?;
+        layout_from_anchor_etags(&anchors, &self.bucket)
+    }
+
+    /// HEAD a single key, returning its `ETag` if the object exists, or `None` if
+    /// absent.
+    ///
+    /// Treats both 404 and 400 as "absent" because some S3-compatible stores
+    /// (rustfs, some `MinIO` versions) reject leading-slash keys with 400 rather
+    /// than 404. The `ETag` lets [`Self::probe_layout`] tell a genuinely-rooted
+    /// object apart from a normalizing store that maps `"/x"` to the same object
+    /// as `"x"`.
+    async fn head_etag(
+        &self,
+        settings: &Settings,
+        key: &str,
+    ) -> StorageResult<Option<String>> {
+        let mut req = self
+            .get_client(settings)
+            .await
+            .head_object()
+            .bucket(self.bucket.clone())
+            .key(key);
+        if self.config.requester_pays {
+            req = req.request_payer(aws_sdk_s3::types::RequestPayer::Requester);
+        }
+        match req.send().await {
+            Ok(out) => Ok(Some(out.e_tag().unwrap_or_default().to_string())),
+            Err(sdk_err) => {
+                let absent = sdk_err.as_service_error().is_some_and(|e| e.is_not_found())
+                    || sdk_err
+                        .raw_response()
+                        .is_some_and(|r| matches!(r.status().as_u16(), 404 | 400));
+                if absent { Ok(None) } else { obj_store_error_res(sdk_err) }
+            }
+        }
     }
 
     async fn put_object_single<
@@ -640,7 +782,8 @@ impl Storage for S3Storage {
         metadata: Vec<(String, String)>,
         previous_version: Option<&VersionInfo>,
     ) -> StorageResult<VersionedUpdateResult> {
-        let path = self.prefixed_path(path);
+        let layout = self.layout(settings).await?;
+        let path = self.key_for(layout, path);
         if bytes.len() >= settings.minimum_size_for_multipart_upload() as usize {
             self.put_object_multipart(
                 settings,
@@ -672,8 +815,9 @@ impl Storage for S3Storage {
         content_type: Option<&str>,
         version: &VersionInfo,
     ) -> StorageResult<VersionedUpdateResult> {
-        let from = format!("{}/{}", self.bucket, self.prefixed_path(from));
-        let to = self.prefixed_path(to);
+        let layout = self.layout(settings).await?;
+        let from = format!("{}/{}", self.bucket, self.key_for(layout, from));
+        let to = self.key_for(layout, to);
         let mut req = self
             .get_client(settings)
             .await
@@ -743,7 +887,13 @@ impl Storage for S3Storage {
         settings: &Settings,
         prefix: &str,
     ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
-        let prefix = format!("{}/{}", self.prefix, prefix).replace("//", "/");
+        let layout = self.layout(settings).await?;
+        // The caller-supplied prefix can carry a leading `/` — e.g. someone
+        // inspecting a legacy rooted repo (whose raw keys look like `/chunks/...`)
+        // through the public `list_objects` API. `key_for` then doubles it against
+        // LegacyRoot's synthesized `/` or Standard's `{prefix}/{relpath}` join, and
+        // S3 matches `//` literally (so the listing would hit nothing). Collapse it.
+        let prefix = self.key_for(layout, prefix).replace("//", "/");
         let mut req = self
             .get_client(settings)
             .await
@@ -779,12 +929,20 @@ impl Storage for S3Storage {
         prefix: &str,
         batch: Vec<(String, u64)>,
     ) -> StorageResult<DeleteObjectsResult> {
+        fn join_prefix_id(prefix: &str, id: &str) -> String {
+            if prefix.is_empty() {
+                id.to_string()
+            } else {
+                format!("{}/{}", prefix.trim_end_matches('/'), id)
+            }
+        }
+
+        let layout = self.layout(settings).await?;
         let mut sizes = HashMap::new();
         let mut ids = Vec::new();
         for (id, size) in batch.into_iter() {
-            if let Ok(key) = self.get_path_str(prefix, id.as_str())
-                && let Ok(ident) = ObjectIdentifier::builder().key(key.clone()).build()
-            {
+            let key = self.key_for(layout, &join_prefix_id(prefix, &id));
+            if let Ok(ident) = ObjectIdentifier::builder().key(key.clone()).build() {
                 ids.push(ident);
                 sizes.insert(key, size);
             }
@@ -838,7 +996,8 @@ impl Storage for S3Storage {
         path: &str,
         settings: &Settings,
     ) -> StorageResult<DateTime<Utc>> {
-        let key = self.prefixed_path(path);
+        let layout = self.layout(settings).await?;
+        let key = self.key_for(layout, path);
         let mut req = self
             .get_client(settings)
             .await
@@ -914,9 +1073,10 @@ impl S3Storage {
             VersionInfo,
         )>,
     > {
+        let layout = self.layout(settings).await?;
         let client = self.get_client(settings).await;
         let bucket = self.bucket.clone();
-        let key = self.prefixed_path(path);
+        let key = self.key_for(layout, path);
 
         let mut req = client.get_object().bucket(bucket).key(key);
 
@@ -979,6 +1139,63 @@ impl S3Storage {
     }
 }
 
+#[derive(Debug)]
+struct AnchorProbe<T> {
+    /// Modern layout using non-rooted keys
+    clean: T,
+    /// Legacy buggy layout using /chunks style keys on empty prefixes
+    rooted: T,
+}
+
+/// Resolve the layout from per-anchor HEAD results.
+///
+/// For each anchor, comparing `ETag`s (not mere existence) distinguishes a store
+/// that normalizes `"/x"` to `"x"` (same object under both keys → clean layout)
+/// from one that genuinely holds distinct objects at both keys (→ mixed).
+fn layout_from_anchor_etags(
+    anchors: &[AnchorProbe<Option<String>>],
+    bucket: &str,
+) -> StorageResult<KeyLayout> {
+    let seen = anchors.iter().fold(
+        AnchorProbe { clean: false, rooted: false },
+        |AnchorProbe { clean: clean_seen, rooted: rooted_seen },
+         AnchorProbe { clean, rooted }| {
+            let (clean_vote, rooted_vote) = match (clean, rooted) {
+                // Same physical object under both keys: the store normalized away
+                // the leading slash. Clean layout, not a mixed repository.
+                (Some(c), Some(r)) if c == r => (true, false),
+                // Genuinely distinct objects at both keys: ambiguous; flag as mixed.
+                (Some(_), Some(_)) => (true, true),
+                (Some(_), None) => (true, false),
+                (None, Some(_)) => (false, true),
+                (None, None) => (false, false),
+            };
+            AnchorProbe {
+                clean: clean_seen || clean_vote,
+                rooted: rooted_seen || rooted_vote,
+            }
+        },
+    );
+
+    decide_layout(&seen, bucket)
+}
+
+/// `bucket` is only used to build the mixed-layout error.
+fn decide_layout(seen: &AnchorProbe<bool>, bucket: &str) -> StorageResult<KeyLayout> {
+    match seen {
+        // Both layouts present: ambiguous and unsafe
+        AnchorProbe { clean: true, rooted: true } => Err(other_error(format!(
+            "repository in bucket {bucket} has objects under both the standard and the \
+             legacy leading-slash key layouts; this is ambiguous and unsafe. \
+             See https://github.com/earth-mover/icechunk/issues/2239"
+        ))),
+        AnchorProbe { clean: false, rooted: true } => Ok(KeyLayout::LegacyRoot),
+        // (true, false) => existing clean repo;
+        // (false, false) => empty/new repository. Both use the clean layout.
+        _ => Ok(KeyLayout::Standard),
+    }
+}
+
 fn object_to_list_info(prefix: &str, object: &Object) -> StorageResult<ListInfo<String>> {
     let inner = || {
         let key = object.key()?;
@@ -1030,11 +1247,17 @@ impl ProvideRefreshableCredentials {
 
 // Factory functions
 
+/// Build storage for an S3 (or S3-compatible, non-Tigris) bucket.
+///
+/// For `legacy_rooted_keys`, see [`S3Storage::new`]: `None` auto-detects the key
+/// layout (the usual choice), `Some(true)` forces the legacy leading-slash layout,
+/// and `Some(false)` forces the standard layout.
 pub fn new_s3_storage(
     config: S3Options,
     bucket: String,
     prefix: Option<String>,
     credentials: Option<S3Credentials>,
+    legacy_rooted_keys: Option<bool>,
 ) -> StorageResult<Arc<dyn Storage + Send + Sync>> {
     if let Some(endpoint) = &config.endpoint_url
         && (endpoint.contains("fly.storage.tigris.dev")
@@ -1054,16 +1277,23 @@ pub fn new_s3_storage(
         true,
         Vec::new(),
         Vec::new(),
+        legacy_rooted_keys,
     )?;
     Ok(Arc::new(st))
 }
 
+/// Build storage for a Cloudflare R2 bucket.
+///
+/// For `legacy_rooted_keys`, see [`S3Storage::new`]: `None` auto-detects the key
+/// layout (the usual choice), `Some(true)` forces the legacy leading-slash layout,
+/// and `Some(false)` forces the standard layout.
 pub fn new_r2_storage(
     config: S3Options,
     bucket: Option<String>,
     prefix: Option<String>,
     account_id: Option<String>,
     credentials: Option<S3Credentials>,
+    legacy_rooted_keys: Option<bool>,
 ) -> StorageResult<Arc<dyn Storage + Send + Sync>> {
     let (bucket, prefix) = match (bucket, prefix) {
         (Some(bucket), Some(prefix)) => (bucket, Some(prefix)),
@@ -1104,16 +1334,23 @@ pub fn new_r2_storage(
         true,
         Vec::new(),
         Vec::new(),
+        legacy_rooted_keys,
     )?;
     Ok(Arc::new(st))
 }
 
+/// Build storage for a Tigris bucket.
+///
+/// For `legacy_rooted_keys`, see [`S3Storage::new`]: `None` auto-detects the key
+/// layout (the usual choice), `Some(true)` forces the legacy leading-slash layout,
+/// and `Some(false)` forces the standard layout.
 pub fn new_tigris_storage(
     config: S3Options,
     bucket: String,
     prefix: Option<String>,
     credentials: Option<S3Credentials>,
     use_weak_consistency: bool,
+    legacy_rooted_keys: Option<bool>,
 ) -> StorageResult<Arc<dyn Storage + Send + Sync>> {
     let mut config = config;
     if config.endpoint_url.is_none() {
@@ -1147,6 +1384,7 @@ pub fn new_tigris_storage(
         !use_weak_consistency, // notice eventually consistent storage can't do writes
         extra_read_headers,
         extra_write_headers,
+        legacy_rooted_keys,
     )?;
     Ok(Arc::new(st))
 }
@@ -1177,6 +1415,7 @@ mod tests {
             true,
             Vec::new(),
             Vec::new(),
+            None,
         )
         .unwrap();
 
@@ -1184,10 +1423,145 @@ mod tests {
 
         assert_eq!(
             serialized,
-            r#"{"config":{"region":"us-west-2","endpoint_url":"http://localhost:4200","anonymous":false,"allow_http":true,"force_path_style":false,"network_stream_timeout_seconds":null,"requester_pays":false,"checksum_algorithm":null},"credentials":{"s3_credential_type":"static","access_key_id":"access_key_id","secret_access_key":"secret_access_key","session_token":"session_token","expires_after":null},"bucket":"bucket","prefix":"prefix","can_write":true,"extra_read_headers":[],"extra_write_headers":[]}"#
+            r#"{"config":{"region":"us-west-2","endpoint_url":"http://localhost:4200","anonymous":false,"allow_http":true,"force_path_style":false,"network_stream_timeout_seconds":null,"requester_pays":false,"checksum_algorithm":null},"credentials":{"s3_credential_type":"static","access_key_id":"access_key_id","secret_access_key":"secret_access_key","session_token":"session_token","expires_after":null},"bucket":"bucket","prefix":"prefix","can_write":true,"extra_read_headers":[],"extra_write_headers":[],"key_layout":null}"#
         );
 
         let deserialized: S3Storage = serde_json::from_str(&serialized).unwrap();
         assert_eq!(storage.config, deserialized.config);
+    }
+
+    fn storage_with_prefix(prefix: Option<&str>, legacy_rooted_keys: bool) -> S3Storage {
+        S3Storage::new(
+            S3Options::default(),
+            "bucket".to_string(),
+            prefix.map(str::to_string),
+            S3Credentials::FromEnv,
+            true,
+            Vec::new(),
+            Vec::new(),
+            // map the helper's bool: force legacy when set, else auto-detect
+            legacy_rooted_keys.then_some(true),
+        )
+        .unwrap()
+    }
+
+    /// empty prefix + Standard layout never produces a
+    /// leading slash, for every kind of object.
+    #[test]
+    fn test_key_for_standard_empty_prefix() {
+        let s = storage_with_prefix(Some(""), false);
+        for relpath in
+            ["chunks/abc123", "repo", "refs/branch.main/ref.json", "config.yaml"]
+        {
+            let key = s.key_for(KeyLayout::Standard, relpath);
+            assert_eq!(key, relpath);
+            assert!(!key.starts_with('/'), "key {key:?} must not start with a slash");
+        }
+    }
+
+    #[test]
+    fn test_key_for_standard_nonempty_prefix() {
+        let s = storage_with_prefix(Some("foo"), false);
+        assert_eq!(s.key_for(KeyLayout::Standard, "chunks/abc123"), "foo/chunks/abc123");
+        // A trailing slash on the prefix is normalized away at construction.
+        let s = storage_with_prefix(Some("foo/"), false);
+        assert_eq!(s.key_for(KeyLayout::Standard, "chunks/abc123"), "foo/chunks/abc123");
+    }
+
+    /// `None` and `""` are the two ways #2239 was triggered; they must produce an
+    /// identical empty prefix (they converge at `unwrap_or_default` in `new`).
+    #[test]
+    fn test_none_and_empty_prefix_are_equivalent() {
+        let from_none = storage_with_prefix(None, false);
+        let from_empty = storage_with_prefix(Some(""), false);
+        for relpath in ["chunks/abc123", "repo"] {
+            assert_eq!(
+                from_none.key_for(KeyLayout::Standard, relpath),
+                from_empty.key_for(KeyLayout::Standard, relpath),
+            );
+        }
+    }
+
+    /// `LegacyRoot` reproduces the exact pre-#2239 buggy layout, so we can keep
+    /// reading repositories written by old clients.
+    #[test]
+    fn test_key_for_legacy_root_reproduces_bug() {
+        let s = storage_with_prefix(Some(""), true);
+        assert_eq!(s.key_for(KeyLayout::LegacyRoot, "chunks/abc123"), "/chunks/abc123");
+        assert_eq!(s.key_for(KeyLayout::LegacyRoot, "repo"), "/repo");
+    }
+
+    #[test]
+    fn test_legacy_rooted_keys_rejected_with_nonempty_prefix() {
+        let err = S3Storage::new(
+            S3Options::default(),
+            "bucket".to_string(),
+            Some("foo".to_string()),
+            S3Credentials::FromEnv,
+            true,
+            Vec::new(),
+            Vec::new(),
+            Some(true),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("empty prefix"), "got: {err}");
+    }
+
+    #[test]
+    fn test_decide_layout_four_way() {
+        let seen = |clean, rooted| AnchorProbe { clean, rooted };
+        // empty/new repo -> clean
+        assert_eq!(decide_layout(&seen(false, false), "b").unwrap(), KeyLayout::Standard);
+        // clean repo -> clean
+        assert_eq!(decide_layout(&seen(true, false), "b").unwrap(), KeyLayout::Standard);
+        // legacy rooted repo -> legacy
+        assert_eq!(
+            decide_layout(&seen(false, true), "b").unwrap(),
+            KeyLayout::LegacyRoot
+        );
+        // mixed -> hard error
+        let err = decide_layout(&seen(true, true), "mybucket").unwrap_err();
+        assert!(err.to_string().contains("both"), "got: {err}");
+        assert!(err.to_string().contains("mybucket"), "got: {err}");
+    }
+
+    #[test]
+    fn test_layout_from_anchor_etags() {
+        let et = |s: &str| Some(s.to_string());
+        let probe =
+            |clean: Option<String>, rooted: Option<String>| AnchorProbe { clean, rooted };
+        let layout = |anchors: &[AnchorProbe<Option<String>>]| {
+            layout_from_anchor_etags(anchors, "b")
+        };
+
+        // empty/new repo: nothing found -> clean
+        assert_eq!(layout(&[probe(None, None)]).unwrap(), KeyLayout::Standard);
+        // clean repo (clean key found, rooted key absent: AWS 404 or rustfs 400)
+        assert_eq!(layout(&[probe(et("E"), None)]).unwrap(), KeyLayout::Standard);
+        // genuine legacy rooted repo: only the rooted key exists
+        assert_eq!(layout(&[probe(None, et("E"))]).unwrap(), KeyLayout::LegacyRoot);
+        // normalizing store (MinIO): "/x" and "x" are the SAME object (equal ETag)
+        // -> clean, NOT a spurious mixed-layout error (regression for #2239 probe).
+        assert_eq!(layout(&[probe(et("E"), et("E"))]).unwrap(), KeyLayout::Standard);
+        // genuinely distinct objects at both keys -> mixed, hard error
+        assert!(layout(&[probe(et("CLEAN"), et("ROOTED"))]).is_err());
+        // multi-anchor: V2 repo on a normalizing store (repo found+normalized,
+        // refs anchor absent) -> clean
+        assert_eq!(
+            layout(&[probe(et("E"), et("E")), probe(None, None)]).unwrap(),
+            KeyLayout::Standard
+        );
+    }
+
+    /// Forcing the layout pre-seeds the cell and survives a serialize round-trip,
+    /// so a deserialized (forked/pickled) storage inherits it without probing.
+    #[test]
+    fn test_forced_layout_serializes_and_is_inherited() {
+        let s = storage_with_prefix(Some(""), true);
+        assert_eq!(s.key_layout.get().copied(), Some(KeyLayout::LegacyRoot));
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains(r#""key_layout":"LegacyRoot""#), "got: {json}");
+        let restored: S3Storage = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.key_layout.get().copied(), Some(KeyLayout::LegacyRoot));
     }
 }

--- a/icechunk-s3/src/lib.rs
+++ b/icechunk-s3/src/lib.rs
@@ -79,7 +79,7 @@ pub enum KeyLayout {
 ///
 /// It's awful to have to have this tacit dependency here, this is icechunk-format stuff.
 /// But... reality hits you hard. I don't want an explicit dependency between the crates
-/// but there are some tests that verify these strings are "right".
+/// but there are some tests in `icechunk/src/refs.rs` that verify these strings are "right".
 pub const DEFAULT_LAYOUT_ANCHORS: &[&str] = &["repo", "refs/branch.main/ref.json"];
 
 /// Serializes the resolved [`KeyLayout`] as `Option<KeyLayout>`.
@@ -445,6 +445,13 @@ impl S3Storage {
             KeyLayout::Standard if self.prefix.is_empty() => relpath.to_string(),
             KeyLayout::Standard => format!("{}/{}", self.prefix, relpath),
         }
+    }
+
+    /// Key prefix to list. Strips one leading `/` from the relpath so it
+    /// doesn't double against the join (S3 matches `//` literally).
+    /// An interior `//` is left intact.
+    fn list_prefix(&self, layout: KeyLayout, relpath: &str) -> String {
+        self.key_for(layout, relpath.strip_prefix('/').unwrap_or(relpath))
     }
 
     /// Resolve this repository's [`KeyLayout`], probing storage at most once.
@@ -888,12 +895,7 @@ impl Storage for S3Storage {
         prefix: &str,
     ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
         let layout = self.layout(settings).await?;
-        // The caller-supplied prefix can carry a leading `/` — e.g. someone
-        // inspecting a legacy rooted repo (whose raw keys look like `/chunks/...`)
-        // through the public `list_objects` API. `key_for` then doubles it against
-        // LegacyRoot's synthesized `/` or Standard's `{prefix}/{relpath}` join, and
-        // S3 matches `//` literally (so the listing would hit nothing). Collapse it.
-        let prefix = self.key_for(layout, prefix).replace("//", "/");
+        let prefix = self.list_prefix(layout, prefix);
         let mut req = self
             .get_client(settings)
             .await
@@ -1480,6 +1482,27 @@ mod tests {
                 from_empty.key_for(KeyLayout::Standard, relpath),
             );
         }
+    }
+
+    /// A leading slash on the relpath is collapsed at the join, but an interior
+    /// `//` is preserved
+    #[test]
+    fn test_list_prefix() {
+        // leading slash stripped for each layout
+        let s = storage_with_prefix(Some("foo"), false);
+        assert_eq!(s.list_prefix(KeyLayout::Standard, "/chunks"), "foo/chunks");
+        let s = storage_with_prefix(Some(""), false);
+        assert_eq!(s.list_prefix(KeyLayout::Standard, "/chunks"), "chunks");
+        let s = storage_with_prefix(Some(""), true);
+        assert_eq!(s.list_prefix(KeyLayout::LegacyRoot, "/chunks"), "/chunks");
+
+        // interior `//` is preserved, matching `key_for`
+        let s = storage_with_prefix(Some("a//b"), false);
+        assert_eq!(s.list_prefix(KeyLayout::Standard, "chunks/x"), "a//b/chunks/x");
+        assert_eq!(
+            s.list_prefix(KeyLayout::Standard, "chunks/x"),
+            s.key_for(KeyLayout::Standard, "chunks/x"),
+        );
     }
 
     /// `LegacyRoot` reproduces the exact pre-#2239 buggy layout, so we can keep

--- a/icechunk/benches/helpers.rs
+++ b/icechunk/benches/helpers.rs
@@ -234,6 +234,7 @@ pub(crate) fn make_s3_storage(
         "testbucket".to_string(),
         Some(format!("bench-{}", uuid::Uuid::new_v4())),
         Some(rustfs_credentials()),
+        None,
     )?;
     Ok(storage)
 }

--- a/icechunk/src/cli/interface.rs
+++ b/icechunk/src/cli/interface.rs
@@ -153,6 +153,7 @@ async fn get_storage(
                 location.bucket.clone(),
                 location.prefix.clone(),
                 Some(credentials.clone()),
+                None, // auto-detect key layout
             )
             .context("Failed to create S3 storage")?;
             Ok(storage)
@@ -169,6 +170,7 @@ async fn get_storage(
                 location.prefix.clone(),
                 Some(credentials.clone()),
                 false,
+                None, // auto-detect key layout
             )
             .context("Failed to create Tigris storage")?;
             Ok(storage)

--- a/icechunk/src/refs.rs
+++ b/icechunk/src/refs.rs
@@ -503,6 +503,29 @@ mod tests {
 
     roundtrip_serialization_tests!(serialize_and_deserialize_ref_data - ref_data);
 
+    /// Drift guard: `icechunk-s3` cannot depend on `icechunk-format`, so its
+    /// layout-detection anchors are hardcoded literals. Assert they still match
+    /// the real format path constants and ref-key helper, so a future rename of
+    /// those constants cannot silently break S3 legacy-layout detection.
+    #[cfg(feature = "s3")]
+    #[test]
+    fn s3_layout_anchors_match_format_constants() {
+        use icechunk_format::REPO_INFO_FILE_PATH;
+        let anchors = icechunk_s3::DEFAULT_LAYOUT_ANCHORS;
+        // V2 anchor: the repo-info file.
+        assert!(
+            anchors.contains(&REPO_INFO_FILE_PATH),
+            "{anchors:?} missing REPO_INFO_FILE_PATH {REPO_INFO_FILE_PATH:?}"
+        );
+        // V1 anchor: the default-branch ref, built from the real (private) helper.
+        let v1_default_branch_ref =
+            format!("{V1_REFS_FILE_PATH}/{}", branch_key(Ref::DEFAULT_BRANCH).unwrap());
+        assert!(
+            anchors.contains(&v1_default_branch_ref.as_str()),
+            "{anchors:?} missing V1 default-branch ref {v1_default_branch_ref:?}"
+        );
+    }
+
     /// Execute the passed block with all test implementations of Storage.
     ///
     /// Currently this function executes against the in-memory and local filesystem `object_store`

--- a/icechunk/src/storage/redirect.rs
+++ b/icechunk/src/storage/redirect.rs
@@ -139,6 +139,7 @@ impl RedirectStorage {
                     bucket,
                     Some(prefix),
                     Some(S3Credentials::Anonymous),
+                    None, // auto-detect key layout
                 )
             }
             #[cfg(not(feature = "s3"))]
@@ -164,6 +165,7 @@ impl RedirectStorage {
                     Some(prefix),
                     Some(account_id),
                     Some(S3Credentials::Anonymous),
+                    None, // auto-detect key layout
                 )
             }
             #[cfg(not(feature = "s3"))]
@@ -188,6 +190,7 @@ impl RedirectStorage {
                     Some(prefix),
                     Some(S3Credentials::Anonymous),
                     true,
+                    None, // auto-detect key layout
                 )
             }
             #[cfg(not(feature = "s3"))]

--- a/icechunk/tests/common/mod.rs
+++ b/icechunk/tests/common/mod.rs
@@ -211,7 +211,7 @@ impl RealStore {
     }
 }
 
-/// `None` when the AWS env vars are not set (so the caller can skip).
+/// `None` when the AWS env vars are not set.
 pub(crate) fn aws_real_store() -> Option<RealStore> {
     let bucket = env::var("AWS_BUCKET").ok().filter(|s| !s.is_empty())?;
     Some(RealStore {

--- a/icechunk/tests/common/mod.rs
+++ b/icechunk/tests/common/mod.rs
@@ -5,7 +5,7 @@ use icechunk::{
     Storage,
     config::{S3Credentials, S3Options, S3StaticCredentials},
     new_s3_storage,
-    storage::{new_r2_storage, new_tigris_storage},
+    storage::{Settings, mk_client, new_r2_storage, new_tigris_storage},
 };
 
 pub(crate) enum Permission {
@@ -43,6 +43,7 @@ pub(crate) fn make_minio_integration_storage(
             session_token: None,
             expires_after: None,
         })),
+        None,
     )?;
     Ok(storage)
 }
@@ -65,6 +66,7 @@ pub(crate) fn make_tigris_integration_storage(
         Some(prefix),
         Some(credentials),
         false,
+        None,
     )?;
     Ok(storage)
 }
@@ -86,6 +88,7 @@ pub(crate) fn make_r2_integration_storage(
         Some(prefix),
         Some(env::var("R2_ACCOUNT_ID")?),
         Some(credentials),
+        None,
     )?;
     Ok(storage)
 }
@@ -123,8 +126,143 @@ pub(crate) fn make_aws_integration_storage(
         get_aws_integration_bucket()?,
         Some(prefix),
         Some(get_aws_integration_credentials()?),
+        None,
     )?;
     Ok(storage)
+}
+
+/// A real (non-local) object store configured from environment variables, used by
+/// the `#[ignore]` integration tests that run in the nightly / `workflow_dispatch`
+/// CI job. `options`/`credentials` are the *resolved* values (endpoint, region,
+/// path-style already filled in) so they drive both the icechunk storage and a raw
+/// client for cleanup.
+pub(crate) struct RealStore {
+    options: S3Options,
+    credentials: S3Credentials,
+    bucket: String,
+    kind: RealStoreKind,
+}
+
+pub(crate) enum RealStoreKind {
+    Aws,
+    R2,
+    Tigris,
+}
+
+impl RealStore {
+    /// Native-S3 storage at the bucket root (empty prefix), optionally forcing the
+    /// legacy leading-slash layout. Goes through each store's real constructor.
+    pub(crate) fn rooted_storage(
+        &self,
+        legacy_rooted_keys: bool,
+    ) -> Result<Arc<dyn Storage + Send + Sync>, Box<dyn std::error::Error>> {
+        let prefix = Some(String::new());
+        let creds = Some(self.credentials.clone());
+        let storage: Arc<dyn Storage + Send + Sync> = match self.kind {
+            RealStoreKind::Aws => new_s3_storage(
+                self.options.clone(),
+                self.bucket.clone(),
+                prefix,
+                creds,
+                legacy_rooted_keys.then_some(true),
+            )?,
+            RealStoreKind::R2 => new_r2_storage(
+                self.options.clone(),
+                Some(self.bucket.clone()),
+                prefix,
+                None, // endpoint already resolved into options
+                creds,
+                legacy_rooted_keys.then_some(true),
+            )?,
+            RealStoreKind::Tigris => new_tigris_storage(
+                self.options.clone(),
+                self.bucket.clone(),
+                prefix,
+                creds,
+                false,
+                legacy_rooted_keys.then_some(true),
+            )?,
+        };
+        Ok(storage)
+    }
+
+    /// Delete every object whose key starts with `/`. A legacy-rooted repository
+    /// lives entirely under `/...`, so this makes the shared bucket reusable across
+    /// runs without disturbing other tests' (non-slash-prefixed) objects.
+    pub(crate) async fn cleanup_rooted_keys(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let client = mk_client(
+            &self.options,
+            self.credentials.clone(),
+            vec![],
+            vec![],
+            &Settings::default(),
+        )
+        .await;
+        let resp =
+            client.list_objects_v2().bucket(&self.bucket).prefix("/").send().await?;
+        for obj in resp.contents() {
+            if let Some(key) = obj.key() {
+                client.delete_object().bucket(&self.bucket).key(key).send().await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// `None` when the AWS env vars are not set (so the caller can skip).
+pub(crate) fn aws_real_store() -> Option<RealStore> {
+    let bucket = env::var("AWS_BUCKET").ok().filter(|s| !s.is_empty())?;
+    Some(RealStore {
+        options: S3Options::default().with_region(env::var("AWS_REGION").ok()?),
+        credentials: S3Credentials::Static(S3StaticCredentials {
+            access_key_id: env::var("AWS_ACCESS_KEY_ID").ok()?,
+            secret_access_key: env::var("AWS_SECRET_ACCESS_KEY").ok()?,
+            session_token: None,
+            expires_after: None,
+        }),
+        bucket,
+        kind: RealStoreKind::Aws,
+    })
+}
+
+/// `None` when the R2 env vars are not set.
+pub(crate) fn r2_real_store() -> Option<RealStore> {
+    let bucket = env::var("R2_BUCKET").ok().filter(|s| !s.is_empty())?;
+    let account_id = env::var("R2_ACCOUNT_ID").ok()?;
+    Some(RealStore {
+        options: S3Options::default()
+            .with_region("auto")
+            .with_endpoint_url(format!("https://{account_id}.r2.cloudflarestorage.com"))
+            .with_force_path_style(true),
+        credentials: S3Credentials::Static(S3StaticCredentials {
+            access_key_id: env::var("R2_ACCESS_KEY_ID").ok()?,
+            secret_access_key: env::var("R2_SECRET_ACCESS_KEY").ok()?,
+            session_token: None,
+            expires_after: None,
+        }),
+        bucket,
+        kind: RealStoreKind::R2,
+    })
+}
+
+/// `None` when the Tigris env vars are not set.
+pub(crate) fn tigris_real_store() -> Option<RealStore> {
+    let bucket = env::var("TIGRIS_BUCKET").ok().filter(|s| !s.is_empty())?;
+    Some(RealStore {
+        options: S3Options::default()
+            .with_region(env::var("TIGRIS_REGION").ok()?)
+            .with_endpoint_url("https://t3.storage.dev"),
+        credentials: S3Credentials::Static(S3StaticCredentials {
+            access_key_id: env::var("TIGRIS_ACCESS_KEY_ID").ok()?,
+            secret_access_key: env::var("TIGRIS_SECRET_ACCESS_KEY").ok()?,
+            session_token: None,
+            expires_after: None,
+        }),
+        bucket,
+        kind: RealStoreKind::Tigris,
+    })
 }
 
 pub(crate) fn get_random_prefix(base: &str) -> String {

--- a/icechunk/tests/main.rs
+++ b/icechunk/tests/main.rs
@@ -10,6 +10,7 @@ mod test_concurrency;
 mod test_distributed_writes;
 mod test_flaky_connections;
 mod test_gc;
+mod test_key_layout;
 #[cfg(feature = "shuttle")]
 mod test_shuttle;
 mod test_stats;

--- a/icechunk/tests/test_flaky_connections.rs
+++ b/icechunk/tests/test_flaky_connections.rs
@@ -49,6 +49,7 @@ fn create_proxied_storage(
         true,
         Vec::new(),
         Vec::new(),
+        None,
     )?;
 
     Ok(Arc::new(storage))

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -137,6 +137,12 @@ async fn do_test_gc(
     assert_eq!(repo.asset_manager().list_manifests().await?.count().await, 111);
 
     // verify doing gc without dangling objects doesn't change the repo
+
+    // GC compares the cutoff against each object's `created_at`, which on a real
+    // store is its second-precision, server-clock `LastModified`. Sleep so the
+    // cutoff clears second-truncation and clock skew (in-memory needs only 1ms;
+    // see `threshold_between_commits`).
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     let now = Utc::now();
     let gc_config = GCConfig::clean_all(
         now,
@@ -194,12 +200,16 @@ async fn do_test_gc(
         assert_eq!(&42i8.to_be_bytes(), bytes.as_ref());
     }
 
-    // Create 5 anonymous snapshots (detached, not on any branch)
+    // Create 5 anonymous snapshots (detached, not on any branch). The first two
+    // are expired, the last three kept. Take the cutoff between the groups from
+    // `Utc::now()` after a sleep so it clears the second-truncation + clock skew
+    // of the server-side `created_at` (`LastModified`) that GC deletes by
     let mut anon_snaps = vec![];
+    let mut cutoff = None;
     for i in 0..5 {
-        // gap so the cutoff lands clear of created_at(ms) vs flushed_at(µs) truncation
         if i == 2 {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            cutoff = Some(Utc::now());
         }
         let mut session = repo.writable_session("main").await?;
         let bytes = Bytes::copy_from_slice(&(100i8 + i as i8).to_be_bytes());
@@ -211,10 +221,8 @@ async fn do_test_gc(
         anon_snaps.push(snap_id);
     }
 
-    // expire the first two: cutoff sits in the gap between anon[1] and anon[2]
-    let before = repo.lookup_snapshot(&anon_snaps[1]).await?.flushed_at;
-    let after = repo.lookup_snapshot(&anon_snaps[2]).await?.flushed_at;
-    let cutoff = before + (after - before) / 2;
+    // anon[0..2] were created before the cutoff, anon[2..5] after it.
+    let cutoff = cutoff.expect("cutoff set at i == 2");
     let gc_config = GCConfig::clean_all(
         cutoff,
         cutoff,

--- a/icechunk/tests/test_key_layout.rs
+++ b/icechunk/tests/test_key_layout.rs
@@ -1,0 +1,476 @@
+//! Integration tests for the S3 key layout fix (#2239).
+//!
+//! Before the fix, an empty `prefix` made the native-S3 backend write every
+//! object under a leading slash (`/chunks/...`); external tools 404'd and GC
+//! silently orphaned objects (delete used a different join than write). These
+//! tests verify the fix against local rustfs.
+//!
+//! ## Why no live `LegacyRoot` round-trip here
+//!
+//! Empty-prefix repositories live at the bucket root, so each test uses its own
+//! freshly created bucket (via rustfs root credentials) for isolation.
+
+use std::{
+    collections::HashMap,
+    num::{NonZeroU16, NonZeroUsize},
+    panic::AssertUnwindSafe,
+    sync::Arc,
+};
+
+use bytes::Bytes;
+use chrono::Utc;
+use futures::FutureExt as _;
+use icechunk::{
+    Repository, RepositoryConfig, Storage,
+    config::{S3Credentials, S3Options, S3StaticCredentials},
+    format::{
+        ByteRange, ChunkIndices, Path, format_constants::SpecVersionBin,
+        snapshot::ArrayShape,
+    },
+    new_s3_storage,
+    ops::gc::{GCConfig, garbage_collect},
+    repository::{RepositoryError, RepositoryErrorKind, VersionInfo},
+    session::get_chunk,
+    storage::{Settings, mk_client},
+};
+use icechunk_macros::tokio_test;
+
+use crate::common;
+
+const ENDPOINT: &str = "http://localhost:4200";
+
+fn rustfs_options() -> S3Options {
+    S3Options::default()
+        .with_region("us-east-1")
+        .with_endpoint_url(ENDPOINT)
+        .with_allow_http(true)
+        .with_force_path_style(true)
+}
+
+fn static_credentials(access_key_id: &str, secret_access_key: &str) -> S3Credentials {
+    S3Credentials::Static(S3StaticCredentials {
+        access_key_id: access_key_id.to_string(),
+        secret_access_key: secret_access_key.to_string(),
+        session_token: None,
+        expires_after: None,
+    })
+}
+
+/// rustfs server admin credentials: can create buckets and access any bucket.
+fn root_credentials() -> S3Credentials {
+    static_credentials("test123", "test123")
+}
+
+fn root_storage(
+    bucket: &str,
+    prefix: Option<&str>,
+    legacy_rooted_keys: bool,
+) -> Arc<dyn Storage + Send + Sync> {
+    new_s3_storage(
+        rustfs_options(),
+        bucket.to_string(),
+        prefix.map(str::to_string),
+        Some(root_credentials()),
+        legacy_rooted_keys.then_some(true),
+    )
+    .unwrap()
+}
+
+const MINIO_ENDPOINT: &str = "http://localhost:4202";
+
+fn minio_options() -> S3Options {
+    S3Options::default()
+        .with_region("us-east-1")
+        .with_endpoint_url(MINIO_ENDPOINT)
+        .with_allow_http(true)
+        .with_force_path_style(true)
+}
+
+fn minio_credentials() -> S3Credentials {
+    static_credentials("minioadmin", "minioadmin")
+}
+
+fn minio_storage(bucket: &str, prefix: Option<&str>) -> Arc<dyn Storage + Send + Sync> {
+    new_s3_storage(
+        minio_options(),
+        bucket.to_string(),
+        prefix.map(str::to_string),
+        Some(minio_credentials()),
+        None,
+    )
+    .unwrap()
+}
+
+/// Create a fresh, uniquely named bucket and return its name.
+///
+/// The name sorts lexicographically after `testbucket`, and the zero-padded
+/// microsecond timestamp makes lexicographic order match creation order; the
+/// random suffix keeps it unique under parallel test runs.
+async fn fresh_bucket() -> String {
+    create_fresh_bucket(&rustfs_options(), root_credentials()).await
+}
+
+async fn fresh_minio_bucket() -> String {
+    create_fresh_bucket(&minio_options(), minio_credentials()).await
+}
+
+async fn create_fresh_bucket(options: &S3Options, credentials: S3Credentials) -> String {
+    let bucket = format!(
+        "testbucket-layout-{:016}-{:016x}",
+        Utc::now().timestamp_micros(),
+        rand::random::<u64>(),
+    );
+    let client =
+        mk_client(options, credentials, vec![], vec![], &Settings::default()).await;
+    client.create_bucket().bucket(&bucket).send().await.expect("create_bucket");
+    bucket
+}
+
+/// List every object key in a bucket (raw, with the leading slash, if any, that
+/// the object was actually stored under).
+async fn raw_keys(bucket: &str) -> Vec<String> {
+    let client = mk_client(
+        &rustfs_options(),
+        root_credentials(),
+        vec![],
+        vec![],
+        &Settings::default(),
+    )
+    .await;
+    let resp =
+        client.list_objects_v2().bucket(bucket).send().await.expect("list_objects_v2");
+    resp.contents().iter().filter_map(|o| o.key().map(str::to_string)).collect()
+}
+
+/// Minimal repo: one group, one array, one separate (non-inlined) chunk at [0].
+async fn create_repo_with_one_chunk(
+    storage: Arc<dyn Storage + Send + Sync>,
+    spec_version: SpecVersionBin,
+    value: i8,
+) -> Result<Repository, Box<dyn std::error::Error>> {
+    let repo = Repository::create(
+        Some(RepositoryConfig {
+            // force chunks to be written as separate objects (not inlined)
+            inline_chunk_threshold_bytes: Some(0),
+            ..Default::default()
+        }),
+        storage,
+        HashMap::new(),
+        Some(spec_version),
+        true,
+    )
+    .await?;
+    write_one_chunk(&repo, value).await?;
+    Ok(repo)
+}
+
+fn version_anchor(spec_version: SpecVersionBin) -> &'static str {
+    match spec_version {
+        SpecVersionBin::V2 => "repo",
+        SpecVersionBin::V1 => "refs/branch.main/ref.json",
+    }
+}
+
+async fn write_one_chunk(
+    repo: &Repository,
+    value: i8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut ds = repo.writable_session("main").await?;
+    let array_path: Path = "/array".try_into().unwrap();
+    if ds.get_node(&array_path).await.is_err() {
+        ds.add_group(Path::root(), Bytes::new()).await?;
+        let shape = ArrayShape::new(vec![(2, 1)]).unwrap();
+        ds.add_array(array_path.clone(), shape, None, Bytes::new()).await?;
+    }
+    let payload =
+        ds.get_chunk_writer()?(Bytes::copy_from_slice(&value.to_be_bytes())).await?;
+    ds.set_chunk_ref(array_path.clone(), ChunkIndices(vec![0]), Some(payload)).await?;
+    ds.commit(format!("write {value}")).execute().await?;
+    Ok(())
+}
+
+async fn read_chunk0(repo: &Repository) -> Result<i8, Box<dyn std::error::Error>> {
+    let array_path: Path = "/array".try_into().unwrap();
+    let ds =
+        repo.readonly_session(&VersionInfo::BranchTipRef("main".to_string())).await?;
+    let bytes = get_chunk(
+        ds.get_chunk_reader(&array_path, &ChunkIndices(vec![0]), &ByteRange::ALL).await?,
+    )
+    .await?
+    .unwrap();
+    Ok(i8::from_be_bytes([bytes[0]]))
+}
+
+/// Direct fix for #2239: an empty-prefix repository must write clean keys, never
+/// a leading slash.
+#[tokio_test]
+async fn empty_prefix_writes_clean_keys() -> Result<(), Box<dyn std::error::Error>> {
+    // Run against both spec versions: they write different anchor files (V2 `repo`,
+    // V1 `refs/...`), which are the keys the layout probe detects.
+    for spec_version in [SpecVersionBin::V1, SpecVersionBin::V2] {
+        let bucket = fresh_bucket().await;
+        let storage = root_storage(&bucket, Some(""), false);
+        create_repo_with_one_chunk(Arc::clone(&storage), spec_version, 42).await?;
+
+        let keys = raw_keys(&bucket).await;
+        assert!(!keys.is_empty(), "repo wrote no objects");
+        for key in &keys {
+            assert!(
+                !key.starts_with('/'),
+                "key {key:?} starts with a slash (the #2239 bug)"
+            );
+        }
+        let anchor = version_anchor(spec_version);
+        assert!(
+            keys.iter().any(|k| k == anchor),
+            "expected a clean `{anchor}` key, got {keys:?}"
+        );
+        assert!(
+            keys.iter().any(|k| k.starts_with("chunks/")),
+            "expected a clean `chunks/...` key, got {keys:?}"
+        );
+    }
+    Ok(())
+}
+
+/// Round-trip through icechunk on a clean empty-prefix repo. Both spec versions,
+/// so reopen exercises layout detection via each version's anchor file.
+#[tokio_test]
+async fn empty_prefix_roundtrips() -> Result<(), Box<dyn std::error::Error>> {
+    for spec_version in [SpecVersionBin::V1, SpecVersionBin::V2] {
+        let bucket = fresh_bucket().await;
+        create_repo_with_one_chunk(
+            root_storage(&bucket, Some(""), false),
+            spec_version,
+            7,
+        )
+        .await?;
+
+        // Re-open with a fresh storage (forces the detection probe to run again).
+        let repo =
+            Repository::open(None, root_storage(&bucket, None, false), HashMap::new())
+                .await?;
+        assert_eq!(read_chunk0(&repo).await?, 7);
+    }
+    Ok(())
+}
+
+/// Regression for #2239 on a *normalizing* store: `MinIO` maps `"/x"` to `"x"`, so
+/// the layout probe sees the clean and rooted anchors as the same object. It must
+/// resolve to the clean layout (by comparing `ETag`s), not raise a spurious
+/// mixed-layout error. Without the fix, the reopen below fails.
+#[tokio_test]
+async fn empty_prefix_roundtrips_on_normalizing_store()
+-> Result<(), Box<dyn std::error::Error>> {
+    let bucket = fresh_minio_bucket().await;
+    create_repo_with_one_chunk(minio_storage(&bucket, Some("")), SpecVersionBin::V2, 13)
+        .await?;
+
+    // A fresh storage forces the detection probe to run on reopen.
+    let repo =
+        Repository::open(None, minio_storage(&bucket, None), HashMap::new()).await?;
+    assert_eq!(read_chunk0(&repo).await?, 13);
+    Ok(())
+}
+
+/// `create` over a bucket that already holds an empty-prefix repo must refuse.
+#[tokio_test]
+async fn empty_prefix_create_refuses_over_existing_repo()
+-> Result<(), Box<dyn std::error::Error>> {
+    let bucket = fresh_bucket().await;
+    create_repo_with_one_chunk(
+        root_storage(&bucket, Some(""), false),
+        SpecVersionBin::V2,
+        1,
+    )
+    .await?;
+
+    let err = Repository::create(
+        None,
+        root_storage(&bucket, Some(""), false),
+        HashMap::new(),
+        Some(SpecVersionBin::V2),
+        true,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RepositoryError { kind: RepositoryErrorKind::ParentDirectoryNotClean, .. }
+        ),
+        "expected ParentDirectoryNotClean, got {err:?}"
+    );
+    Ok(())
+}
+
+/// Opening an empty bucket with an empty prefix reports the repo as missing
+#[tokio_test]
+async fn empty_prefix_nonexistent_repo() -> Result<(), Box<dyn std::error::Error>> {
+    let bucket = fresh_bucket().await;
+    let err =
+        Repository::open(None, root_storage(&bucket, Some(""), false), HashMap::new())
+            .await
+            .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RepositoryError { kind: RepositoryErrorKind::RepositoryDoesntExist, .. }
+        ),
+        "expected RepositoryDoesntExist, got {err:?}"
+    );
+    Ok(())
+}
+
+/// Regression for the silent-orphan bug: on an empty-prefix repo, GC must
+/// actually remove the chunk *objects* from the bucket (delete now builds the
+/// same key as write, instead of a no-leading-slash key that hit nothing).
+#[tokio_test]
+async fn empty_prefix_gc_actually_deletes_chunks()
+-> Result<(), Box<dyn std::error::Error>> {
+    let bucket = fresh_bucket().await;
+    let storage = root_storage(&bucket, Some(""), false);
+    let repo =
+        create_repo_with_one_chunk(Arc::clone(&storage), SpecVersionBin::V2, 42).await?;
+
+    // second commit overwrites chunk [0]; capture the first snapshot to reset to.
+    let first = repo.lookup_branch("main").await?;
+    write_one_chunk(&repo, 7).await?;
+
+    let chunks_before =
+        raw_keys(&bucket).await.iter().filter(|k| k.starts_with("chunks/")).count();
+    assert_eq!(chunks_before, 2, "expected two distinct chunk objects");
+
+    // forget the second commit, making its chunk garbage
+    repo.reset_branch("main", &first, None).await?;
+
+    let now = Utc::now();
+    let gc_config = GCConfig::clean_all(
+        now,
+        now,
+        None,
+        NonZeroU16::new(50).unwrap(),
+        NonZeroUsize::new(512 * 1024 * 1024).unwrap(),
+        NonZeroU16::new(500).unwrap(),
+        false,
+    );
+    let summary =
+        garbage_collect(Arc::clone(repo.asset_manager()), &gc_config, None, 100).await?;
+    assert_eq!(summary.chunks_deleted, 1, "GC should report one deleted chunk");
+
+    let chunks_after =
+        raw_keys(&bucket).await.iter().filter(|k| k.starts_with("chunks/")).count();
+    assert_eq!(
+        chunks_after, 1,
+        "the deleted chunk object must actually be gone from the bucket (orphan-bug regression)"
+    );
+    Ok(())
+}
+
+/// Create a rooted repo, then prove a plain auto-detecting client can read it,
+/// append to it, and garbage-collect it — the end-to-end backward-compat
+/// guarantee for pre-#2239 empty-prefix repositories.
+async fn do_rooted_roundtrip(
+    store: common::RealStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Remove any rooted objects left by a previous run, so `create` (which
+    // conditionally creates `/repo`) starts from a clean root.
+    store.cleanup_rooted_keys().await?;
+
+    // Run the body under catch_unwind so we always clean up the rooted `/...` keys
+    // afterwards, even when an assertion panics — otherwise a failed run would leave
+    // them polluting the shared bucket.
+    let result = AssertUnwindSafe(rooted_roundtrip_body(&store)).catch_unwind().await;
+
+    // Leave the bucket as we found it, but don't let a cleanup error mask the body's
+    // own panic or error.
+    let cleanup = store.cleanup_rooted_keys().await;
+    match result {
+        Err(panic) => std::panic::resume_unwind(panic),
+        Ok(Err(e)) => Err(e),
+        Ok(Ok(())) => cleanup,
+    }
+}
+
+/// The rooted round-trip work; see [`do_rooted_roundtrip`], which wraps this to
+/// guarantee bucket cleanup even when an assertion here fails.
+async fn rooted_roundtrip_body(
+    store: &common::RealStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Create a rooted repo (empty prefix + forced legacy layout). check_clean_root
+    // is false because the bucket is shared with other integration tests' objects
+    // (which live under non-slash prefixes, a disjoint key space).
+    let repo = Repository::create(
+        Some(RepositoryConfig {
+            inline_chunk_threshold_bytes: Some(0),
+            ..Default::default()
+        }),
+        store.rooted_storage(true)?,
+        HashMap::new(),
+        Some(SpecVersionBin::V2),
+        false,
+    )
+    .await?;
+    write_one_chunk(&repo, 42).await?;
+
+    // Reopen with auto-detection (a fresh storage forces the probe). On a
+    // leading-slash-preserving store this resolves to LegacyRoot and reads back.
+    let repo =
+        Repository::open(None, store.rooted_storage(false)?, HashMap::new()).await?;
+    assert_eq!(read_chunk0(&repo).await?, 42);
+
+    // Append through the reopened repo, then reopen + read again (write path).
+    write_one_chunk(&repo, 7).await?;
+    let repo =
+        Repository::open(None, store.rooted_storage(false)?, HashMap::new()).await?;
+    assert_eq!(read_chunk0(&repo).await?, 7);
+
+    // GC must run cleanly under the detected (rooted) layout.
+    let now = Utc::now();
+    let gc_config = GCConfig::clean_all(
+        now,
+        now,
+        None,
+        NonZeroU16::new(50).unwrap(),
+        NonZeroUsize::new(512 * 1024 * 1024).unwrap(),
+        NonZeroU16::new(500).unwrap(),
+        false,
+    );
+    garbage_collect(Arc::clone(repo.asset_manager()), &gc_config, None, 100).await?;
+    Ok(())
+}
+
+#[tokio_test]
+#[ignore = "needs credentials from env"]
+async fn rooted_roundtrip_in_aws() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(store) = common::aws_real_store() {
+        do_rooted_roundtrip(store).await?;
+    }
+    Ok(())
+}
+
+#[tokio_test]
+#[ignore = "needs credentials from env"]
+async fn rooted_roundtrip_in_r2() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(store) = common::r2_real_store() {
+        do_rooted_roundtrip(store).await?;
+    }
+    Ok(())
+}
+
+#[tokio_test]
+#[ignore = "needs credentials from env"]
+async fn rooted_roundtrip_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(store) = common::tigris_real_store() {
+        do_rooted_roundtrip(store).await?;
+    }
+    Ok(())
+}
+
+// These run only against real S3/R2/Tigris (hence `#[ignore]` + credentials), never
+// the local stores: a rooted repo keeps every object under a leading slash
+// (`/chunks/...`), and neither local store can hold those keys as written. rustfs
+// (:4200) rejects leading-slash keys with a 400, and minio (:4202) silently
+// normalizes them (`/x` -> `x`), which collapses the repo into the standard layout
+// so there is no rooted repo left to round-trip. Only a store that preserves the
+// leading slash, like real S3/R2/Tigris, can exercise the legacy layout end to end.

--- a/icechunk/tests/test_key_layout.rs
+++ b/icechunk/tests/test_key_layout.rs
@@ -4,11 +4,6 @@
 //! object under a leading slash (`/chunks/...`); external tools 404'd and GC
 //! silently orphaned objects (delete used a different join than write). These
 //! tests verify the fix against local rustfs.
-//!
-//! ## Why no live `LegacyRoot` round-trip here
-//!
-//! Empty-prefix repositories live at the bucket root, so each test uses its own
-//! freshly created bucket (via rustfs root credentials) for isolation.
 
 use std::{
     collections::HashMap,
@@ -137,6 +132,7 @@ async fn raw_keys(bucket: &str) -> Vec<String> {
         &Settings::default(),
     )
     .await;
+    // we have only a few objects, first page of results is enough
     let resp =
         client.list_objects_v2().bucket(bucket).send().await.expect("list_objects_v2");
     resp.contents().iter().filter_map(|o| o.key().map(str::to_string)).collect()
@@ -273,34 +269,37 @@ async fn empty_prefix_roundtrips_on_normalizing_store()
     Ok(())
 }
 
-/// `create` over a bucket that already holds an empty-prefix repo must refuse.
+/// `create` over a bucket that already holds an empty-prefix repo must refuse,
+/// across every combination of the existing and new repo's spec versions.
 #[tokio_test]
 async fn empty_prefix_create_refuses_over_existing_repo()
 -> Result<(), Box<dyn std::error::Error>> {
-    let bucket = fresh_bucket().await;
-    create_repo_with_one_chunk(
-        root_storage(&bucket, Some(""), false),
-        SpecVersionBin::V2,
-        1,
-    )
-    .await?;
+    use SpecVersionBin::{V1, V2};
+    for (existing, new) in [(V1, V1), (V1, V2), (V2, V1), (V2, V2)] {
+        let bucket = fresh_bucket().await;
+        create_repo_with_one_chunk(root_storage(&bucket, Some(""), false), existing, 1)
+            .await?;
 
-    let err = Repository::create(
-        None,
-        root_storage(&bucket, Some(""), false),
-        HashMap::new(),
-        Some(SpecVersionBin::V2),
-        true,
-    )
-    .await
-    .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            RepositoryError { kind: RepositoryErrorKind::ParentDirectoryNotClean, .. }
-        ),
-        "expected ParentDirectoryNotClean, got {err:?}"
-    );
+        let err = Repository::create(
+            None,
+            root_storage(&bucket, Some(""), false),
+            HashMap::new(),
+            Some(new),
+            true,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                RepositoryError {
+                    kind: RepositoryErrorKind::ParentDirectoryNotClean,
+                    ..
+                }
+            ),
+            "expected ParentDirectoryNotClean for {existing:?} -> {new:?}, got {err:?}"
+        );
+    }
     Ok(())
 }
 
@@ -443,28 +442,22 @@ async fn rooted_roundtrip_body(
 #[tokio_test]
 #[ignore = "needs credentials from env"]
 async fn rooted_roundtrip_in_aws() -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(store) = common::aws_real_store() {
-        do_rooted_roundtrip(store).await?;
-    }
-    Ok(())
+    let store = common::aws_real_store().expect("AWS_* env vars must be set");
+    do_rooted_roundtrip(store).await
 }
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
 async fn rooted_roundtrip_in_r2() -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(store) = common::r2_real_store() {
-        do_rooted_roundtrip(store).await?;
-    }
-    Ok(())
+    let store = common::r2_real_store().expect("R2_* env vars must be set");
+    do_rooted_roundtrip(store).await
 }
 
 #[tokio_test]
 #[ignore = "needs credentials from env"]
 async fn rooted_roundtrip_in_tigris() -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(store) = common::tigris_real_store() {
-        do_rooted_roundtrip(store).await?;
-    }
-    Ok(())
+    let store = common::tigris_real_store().expect("TIGRIS_* env vars must be set");
+    do_rooted_roundtrip(store).await
 }
 
 // These run only against real S3/R2/Tigris (hence `#[ignore]` + credentials), never

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -66,6 +66,7 @@ async fn mk_s3_storage(
             session_token: None,
             expires_after: None,
         })),
+        None,
     )
     .expect("Creating minio storage failed");
 
@@ -119,6 +120,30 @@ async fn mk_azure_blob_storage(
     Ok(storage)
 }
 
+/// We use `MinIO` in addition to our main `RustFS` because it's a
+/// *normalizing* store: it maps leading-slash keys `"/x"` to `"x"`,
+/// unlike rustfs which rejects them
+async fn mk_minio_storage(prefix: &str) -> StorageResult<Arc<dyn Storage + Send + Sync>> {
+    let options = S3Options::default()
+        .with_region("us-east-1")
+        .with_endpoint_url("http://localhost:4202")
+        .with_allow_http(true)
+        .with_force_path_style(true);
+    let credentials = S3Credentials::Static(S3StaticCredentials {
+        access_key_id: "minioadmin".into(),
+        secret_access_key: "minioadmin".into(),
+        session_token: None,
+        expires_after: None,
+    });
+    new_s3_storage(
+        options,
+        "testbucket".to_string(),
+        Some(prefix.to_string()),
+        Some(credentials),
+        None,
+    )
+}
+
 #[expect(clippy::expect_used)]
 async fn with_storage<F, Fut>(
     permission: Permission,
@@ -155,6 +180,11 @@ where
         format!("{}/", common::get_random_prefix("with_storage")).as_str(),
     )
     .await?;
+    let s6 = mk_minio_storage(common::get_random_prefix("with_storage").as_str()).await?;
+    let s6slash = mk_minio_storage(
+        format!("{}/", common::get_random_prefix("with_storage")).as_str(),
+    )
+    .await?;
     let dir = tempdir().expect("cannot create temp dir");
     let s5 = new_local_filesystem_storage(dir.path())
         .await
@@ -169,6 +199,8 @@ where
         ("s3_object_store_slash", s3slash),
         ("azure_blob", s4),
         ("azure_blob_slash", s4slash),
+        ("minio", s6),
+        ("minio_slash", s6slash),
     ];
 
     if let Ok(e) = env::var("AWS_BUCKET")

--- a/icechunk/tests/test_virtual_refs.rs
+++ b/icechunk/tests/test_virtual_refs.rs
@@ -203,9 +203,14 @@ async fn create_local_repository(
 async fn create_minio_repository(spec_version: SpecVersionBin) -> Repository {
     let prefix = format!("{:?}", ChunkId::random());
     let (config, credentials) = minio_s3_config();
-    let storage: Arc<dyn Storage + Send + Sync> =
-        new_s3_storage(config, "testbucket".to_string(), Some(prefix), Some(credentials))
-            .expect("Creating minio storage failed");
+    let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
+        config,
+        "testbucket".to_string(),
+        Some(prefix),
+        Some(credentials),
+        None,
+    )
+    .expect("Creating minio storage failed");
 
     let containers = vec![
         VirtualChunkContainer::new(
@@ -1161,9 +1166,14 @@ async fn test_zarr_store_with_multiple_virtual_chunk_containers(
 
     let prefix = format!("{:?}", ChunkId::random());
     let (config, credentials) = minio_s3_config();
-    let storage: Arc<dyn Storage + Send + Sync> =
-        new_s3_storage(config, "testbucket".to_string(), Some(prefix), Some(credentials))
-            .expect("Creating minio storage failed");
+    let storage: Arc<dyn Storage + Send + Sync> = new_s3_storage(
+        config,
+        "testbucket".to_string(),
+        Some(prefix),
+        Some(credentials),
+        None,
+    )
+    .expect("Creating minio storage failed");
 
     let chunk_dir = TempDir::new()?;
 


### PR DESCRIPTION
Closes: #2239

- We autodetect the layout (initial / which we call "rooted" vs. clean no-bug keys)
- We still offer a escape hatch if you really want to skip auto detection and create a specific layout (for example for tests).
- Autodetection has a minimum performance price:
  - Exclusively in repos with an empty prefix, 4 concurrent HEAD requests are executed the first time the storage instance is used.
  - Nothing changes for repos with non-empty prefix, or repos that are using the ObjectStore based Storage.

Main test changes:
- New `icechunk-python/tests/test_key_layout.py`: clean-key writes, round-trip, and rejecting `legacy_rooted_keys` with a non-empty prefix.
- `test_gc.rs`: fix a real-store flake in `do_test_gc`. GC deletes by `created_at` (S3 `LastModified`, truncated to whole seconds) while the cutoff came from `flushed_at` (microseconds), so a sub-second gap near the cutoff was unreliable.

CI (.github/workflows/rust-ci.yaml):
- Run the real-object-store integration tests on `workflow_dispatch` and on any PR labeled `run-integration-tests`, not only the nightly cron.
- Fix integration tests that were not running at all on the cron.
- Run the prefix-unique `--ignored` tests across the whole OS matrix, but run the bucket-root "rooted" tests on a single runner so concurrent jobs don't race on the same keys.
- Raise the job timeout 20 -> 45 min for the slow `macos-15-intel` runner now that integration tests run on the matrix.

Tooling and docs:
- compose.yaml: add MinIO container to test with an object store that collapses objects with an initial /.