### PR TITLE
ci: add PR review board (Slack)

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: earth-mover/pr-review-bot@51743beaacd59d4ef807c2dea2d5160492066485 # main
+      - uses: earth-mover/pr-review-bot@df22b2c37b6e96dc92b133e9cb9d1929a888d0e3 # main
         with:
           target: icechunk
           slack-token: ${{ secrets.SLACK_APP_TOKEN }}

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -29,9 +29,10 @@ jobs:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: earth-mover/pr-review-bot@df22b2c37b6e96dc92b133e9cb9d1929a888d0e3 # main
+      - uses: earth-mover/pr-review-bot@0b0149e845f931007f3871ce520c482d4f174912 # main
         with:
           target: icechunk
           slack-token: ${{ secrets.SLACK_APP_TOKEN }}
           claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
+          reviewers: ${{ secrets.PR_REVIEW_REVIEWERS }}

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -1,0 +1,37 @@
+name: PR Review Bot
+
+# Thin caller: all logic lives in earth-mover/pr-review-bot. Drop this file at
+# .github/workflows/pr-review-bot.yml in earth-mover/icechunk.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, review_requested, review_request_removed, synchronize, closed]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "0 13-23 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-review-bot
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: earth-mover/pr-review-bot@main
+        with:
+          target: icechunk
+          slack-token: ${{ secrets.SLACK_APP_TOKEN }}
+          claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: earth-mover/pr-review-bot@main
+      - uses: earth-mover/pr-review-bot@51743beaacd59d4ef807c2dea2d5160492066485 # main
         with:
           target: icechunk
           slack-token: ${{ secrets.SLACK_APP_TOKEN }}

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -1,8 +1,5 @@
 name: PR Review Bot
 
-# Thin caller: all logic lives in earth-mover/pr-review-bot. Drop this file at
-# .github/workflows/pr-review-bot.yml in earth-mover/icechunk.
-
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, review_requested, review_request_removed, synchronize, closed]
@@ -29,9 +26,10 @@ jobs:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: earth-mover/pr-review-bot@0b0149e845f931007f3871ce520c482d4f174912 # main
+      - uses: earth-mover/pr-review-bot@d01fbc138e78bbe91e10b598870c32d1527f79e3 # main
         with:
-          target: icechunk
+          channel: C07C8TCQQRG
+          board-name: Icechunk PR Board
           slack-token: ${{ secrets.SLACK_APP_TOKEN }}
           claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: earth-mover/pr-review-bot@d01fbc138e78bbe91e10b598870c32d1527f79e3 # main
+      - uses: earth-mover/pr-review-bot@159af5b9dffde3f3ac3c85b005b248ea1b8b50c7 # main
         with:
           channel: C07C8TCQQRG
           board-name: Icechunk PR Board


### PR DESCRIPTION
## Summary

Adds a thin caller workflow that runs the shared **earth-mover/pr-review-bot** action, giving icechunk its own ball-in-court PR review board in **#icechunk-internal** (one item per open PR, whose-court + how-long, kept in sync). All logic lives in the shared repo; this file is just the trigger + inputs.

## Context

Sibling of the arraylake board. We chose a dedicated bot repo both repos call, rather than duplicating the script. Same pattern arraylake will use.

## ⚠️ Maybe wait to merge

The action needs two secrets available to this repo: `SLACK_APP_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`. Waiting on @jhamman for claude code one.

## Risk level

Minimal — additive workflow only, read-only PR access, no effect on builds or releases.

[This is Claude Code on behalf of Samantha Hughes]