### PR TITLE
Expose manifest update concurrency configuration option

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add an exception tree: all Icechunk errors now derive from `IcechunkError` and are grouped into catchable categories. Every exception carries a stable machine-readable `kind` code (see the new `icechunk.ErrorKind` enum), and the full diagnostic report is attached as a PEP 678 note ([#2267](https://github.com/earth-mover/icechunk/issues/2151)).
+- Add `ManifestConfig.max_concurrent_manifest_fetches_during_commit` to control how many manifests are fetched and updated concurrently during a commit, amend, flush, or `rewrite_manifests`. Defaults to `1` (serial) ([#2273](https://github.com/earth-mover/icechunk/issues/2273)).
 
 ### Fixes
 

--- a/icechunk-python/docs/docs/guides/configuration.md
+++ b/icechunk-python/docs/docs/guides/configuration.md
@@ -141,6 +141,18 @@ config.manifest = ic.config.ManifestConfig(
 )
 ```
 
+#### [`max_concurrent_manifest_fetches_during_commit`](../reference/config.md#icechunk.config.ManifestConfig.max_concurrent_manifest_fetches_during_commit)
+
+How many manifests are fetched and updated concurrently during a commit, amend,
+flush, or `rewrite_manifests`. Each changed array's manifest update downloads,
+decompresses, merges, recompresses, and uploads its manifest(s), so raising this
+trades memory for lower commit latency on datasets with many arrays. Defaults to
+`1` (serial).
+
+```python exec="on" session="config" source="material-block"
+config.manifest.max_concurrent_manifest_fetches_during_commit = 16
+```
+
 ### Applying Configuration
 
 Now we can now create or open an Icechunk repo using our config.

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1094,6 +1094,7 @@ class ManifestConfig:
         splitting: ManifestSplittingConfig | None = None,
         virtual_chunk_location_compression: ManifestVirtualChunkLocationCompressionConfig
         | None = None,
+        max_concurrent_manifest_fetches_during_commit: int | None = None,
     ) -> ManifestConfig:
         """
         Create a new `ManifestConfig` object
@@ -1112,6 +1113,10 @@ class ManifestConfig:
             The configuration for zstd compression of virtual chunk location URLs.
             When None, the default `ManifestVirtualChunkLocationCompressionConfig` is used.
             Default: None
+        max_concurrent_manifest_fetches_during_commit: int | None
+            How many manifests are fetched and updated concurrently during a
+            commit, amend, flush, or rewrite_manifests.
+            Default: 1
         """
         ...
     @property
@@ -1192,6 +1197,34 @@ class ManifestConfig:
         ----------
         value: ManifestVirtualChunkLocationCompressionConfig | None
             The compression configuration.
+        """
+        ...
+
+    @property
+    def max_concurrent_manifest_fetches_during_commit(self) -> int | None:
+        """
+        How many manifests are fetched and updated concurrently during a
+        commit, amend, flush, or rewrite_manifests.
+
+        Default: 1
+
+        Returns
+        -------
+        int | None
+            The number of manifests fetched and updated concurrently during a commit.
+        """
+        ...
+
+    @max_concurrent_manifest_fetches_during_commit.setter
+    def max_concurrent_manifest_fetches_during_commit(self, value: int | None) -> None:
+        """
+        Set how many manifests are fetched and updated concurrently during a
+        commit, amend, flush, or rewrite_manifests.
+
+        Parameters
+        ----------
+        value: int | None
+            The number of manifests to fetch and update concurrently.
         """
         ...
 

--- a/icechunk-python/src/config.rs
+++ b/icechunk-python/src/config.rs
@@ -2306,6 +2306,8 @@ pub struct PyManifestConfig {
     #[pyo3(get, set)]
     pub virtual_chunk_location_compression:
         Option<Py<PyManifestVirtualChunkLocationCompressionConfig>>,
+    #[pyo3(get, set)]
+    pub max_concurrent_manifest_fetches_during_commit: Option<u16>,
 }
 
 impl PyRepr for PyManifestConfig {
@@ -2335,6 +2337,16 @@ impl PyRepr for PyManifestConfig {
                     || ManifestVirtualChunkLocationCompressionConfig::default().into(),
                 ),
             ),
+            (
+                "max_concurrent_manifest_fetches_during_commit",
+                py_option_or_default(
+                    &self.max_concurrent_manifest_fetches_during_commit,
+                    &ManifestConfig::default()
+                        .max_concurrent_manifest_fetches_during_commit()
+                        .to_string(),
+                    mode,
+                ),
+            ),
         ]
     }
 }
@@ -2342,15 +2354,21 @@ impl PyRepr for PyManifestConfig {
 #[pymethods]
 impl PyManifestConfig {
     #[new]
-    #[pyo3(signature = (preload=None, splitting=None, virtual_chunk_location_compression=None))]
+    #[pyo3(signature = (preload=None, splitting=None, virtual_chunk_location_compression=None, max_concurrent_manifest_fetches_during_commit=None))]
     fn new(
         preload: Option<Py<PyManifestPreloadConfig>>,
         splitting: Option<Py<PyManifestSplittingConfig>>,
         virtual_chunk_location_compression: Option<
             Py<PyManifestVirtualChunkLocationCompressionConfig>,
         >,
+        max_concurrent_manifest_fetches_during_commit: Option<u16>,
     ) -> Self {
-        Self { preload, splitting, virtual_chunk_location_compression }
+        Self {
+            preload,
+            splitting,
+            virtual_chunk_location_compression,
+            max_concurrent_manifest_fetches_during_commit,
+        }
     }
 
     pub fn __repr__(&self) -> String {
@@ -2381,6 +2399,8 @@ impl From<&PyManifestConfig> for ManifestConfig {
                 .virtual_chunk_location_compression
                 .as_ref()
                 .map(|c| (&*c.borrow(py)).into()),
+            max_concurrent_manifest_fetches_during_commit: value
+                .max_concurrent_manifest_fetches_during_commit,
         })
     }
 }
@@ -2409,6 +2429,8 @@ impl From<ManifestConfig> for PyManifestConfig {
                         "Cannot create instance of ManifestVirtualChunkLocationCompressionConfig",
                     )
                 }),
+            max_concurrent_manifest_fetches_during_commit: value
+                .max_concurrent_manifest_fetches_during_commit,
         }
         })
     }

--- a/icechunk-python/src/repository.rs
+++ b/icechunk-python/src/repository.rs
@@ -2717,9 +2717,16 @@ impl PyRepository {
             let result =
                 pyo3_async_runtimes::tokio::get_runtime().block_on(async move {
                     let lock = self.0.read().await;
-                    rewrite_manifests(&lock, branch, message, 1, metadata, commit_method)
-                        .await
-                        .map_err(PyIcechunkStoreError::ManifestOpsError)
+                    rewrite_manifests(
+                        &lock,
+                        branch,
+                        message,
+                        None,
+                        metadata,
+                        commit_method,
+                    )
+                    .await
+                    .map_err(PyIcechunkStoreError::ManifestOpsError)
                 })?;
             Ok(result.to_string())
         })
@@ -2746,7 +2753,7 @@ impl PyRepository {
                 &repository,
                 &branch,
                 &message,
-                1,
+                None,
                 metadata,
                 commit_method,
             )

--- a/icechunk-python/tests/test_config.py
+++ b/icechunk-python/tests/test_config.py
@@ -178,6 +178,7 @@ def test_can_change_deep_config_values(any_spec_version: int | None) -> None:
     config.storage.storage_class = "STANDARD_IA"
     config.manifest = icechunk.ManifestConfig()
     config.manifest.preload = icechunk.ManifestPreloadConfig(max_total_refs=42)
+    config.manifest.max_concurrent_manifest_fetches_during_commit = 16
     config.max_concurrent_requests = 10
     config.num_updates_per_repo_info_file = 50
     config.repo_update_retries = RepoUpdateRetryConfig(
@@ -239,6 +240,7 @@ def test_can_change_deep_config_values(any_spec_version: int | None) -> None:
     assert stored_config.repo_update_retries.default.initial_backoff_ms == 100
     assert stored_config.repo_update_retries.default.max_backoff_ms == 60_000
     assert stored_config.manifest
+    assert stored_config.manifest.max_concurrent_manifest_fetches_during_commit == 16
     assert stored_config.manifest.preload
     assert stored_config.manifest.preload.max_total_refs == 42
     assert (

--- a/icechunk-python/tests/test_display.py
+++ b/icechunk-python/tests/test_display.py
@@ -443,6 +443,8 @@ class TestReprStructural:
         assert "preload" in repr_str
         assert "splitting" in repr_str
         assert "virtual_chunk_location_compression" in repr_str
+        assert "max_concurrent_manifest_fetches_during_commit" in repr_str
+        assert "max_concurrent_manifest_fetches_during_commit: 1 (default)" in str(c)
 
     def test_virtual_chunk_container_shows_fields(self) -> None:
         store_config = icechunk.s3_store(

--- a/icechunk/benches/helpers.rs
+++ b/icechunk/benches/helpers.rs
@@ -273,6 +273,7 @@ pub(crate) async fn setup_repo(
         }),
         splitting: split_config,
         virtual_chunk_location_compression: None,
+        max_concurrent_manifest_fetches_during_commit: None,
     };
 
     let mut config = RepositoryConfig {

--- a/icechunk/src/config.rs
+++ b/icechunk/src/config.rs
@@ -409,6 +409,8 @@ pub struct ManifestConfig {
     #[serde(default)]
     pub virtual_chunk_location_compression:
         Option<ManifestVirtualChunkLocationCompressionConfig>,
+    #[serde(default)]
+    pub max_concurrent_manifest_fetches_during_commit: Option<u16>,
 }
 
 static DEFAULT_MANIFEST_PRELOAD_CONFIG: OnceLock<ManifestPreloadConfig> = OnceLock::new();
@@ -432,6 +434,9 @@ impl ManifestConfig {
                 (Some(c), None) => Some(*c),
                 (Some(mine), Some(theirs)) => Some(mine.merge(theirs)),
             },
+            max_concurrent_manifest_fetches_during_commit: other
+                .max_concurrent_manifest_fetches_during_commit
+                .or(self.max_concurrent_manifest_fetches_during_commit),
         }
     }
 
@@ -457,6 +462,11 @@ impl ManifestConfig {
         })
     }
 
+    /// The effective manifest update concurrency, always at least 1.
+    pub fn max_concurrent_manifest_fetches_during_commit(&self) -> u16 {
+        self.max_concurrent_manifest_fetches_during_commit.unwrap_or(1).max(1)
+    }
+
     // for testing only, create a config with no preloading, no splitting, and no max_arrays to scan
     pub fn empty() -> Self {
         ManifestConfig {
@@ -467,6 +477,7 @@ impl ManifestConfig {
             }),
             splitting: None,
             virtual_chunk_location_compression: None,
+            max_concurrent_manifest_fetches_during_commit: None,
         }
     }
 }
@@ -771,6 +782,43 @@ mod tests {
 
     #[cfg(feature = "object-store-azure")]
     use crate::strategies::azure_static_credentials;
+
+    #[icechunk_macros::test]
+    fn test_max_concurrent_manifest_fetches_during_commit_default_and_merge() {
+        use crate::config::ManifestConfig;
+
+        // Unset resolves to the serial default.
+        let unset = ManifestConfig::default();
+        assert_eq!(unset.max_concurrent_manifest_fetches_during_commit, None);
+        assert_eq!(unset.max_concurrent_manifest_fetches_during_commit(), 1);
+
+        // An explicit value is returned by the accessor.
+        let set = ManifestConfig {
+            max_concurrent_manifest_fetches_during_commit: Some(16),
+            ..Default::default()
+        };
+        assert_eq!(set.max_concurrent_manifest_fetches_during_commit(), 16);
+
+        // merge: the other config's value wins when set, otherwise ours is kept.
+        assert_eq!(
+            unset.merge(set.clone()).max_concurrent_manifest_fetches_during_commit,
+            Some(16)
+        );
+        assert_eq!(
+            set.merge(ManifestConfig::default())
+                .max_concurrent_manifest_fetches_during_commit,
+            Some(16)
+        );
+        // When both are set, the other config's value wins.
+        let other = ManifestConfig {
+            max_concurrent_manifest_fetches_during_commit: Some(4),
+            ..Default::default()
+        };
+        assert_eq!(
+            set.merge(other).max_concurrent_manifest_fetches_during_commit,
+            Some(4)
+        );
+    }
 
     #[icechunk_macros::test]
     fn test_merge_replaces_virtual_chunk_containers() {

--- a/icechunk/src/ops/manifests.rs
+++ b/icechunk/src/ops/manifests.rs
@@ -24,7 +24,7 @@ pub async fn rewrite_manifests(
     repository: &Repository,
     branch: &str,
     message: &str,
-    max_concurrent_manifests: usize,
+    max_concurrent_manifests: Option<usize>,
     properties: Option<SnapshotProperties>,
     commit_method: CommitMethod,
 ) -> ManifestOpsResult<SnapshotId> {
@@ -39,10 +39,10 @@ pub async fn rewrite_manifests(
         .await
         .map_err(|e| ManifestOpsError::ManifestRewriteError(Box::new(e.inject())))?;
 
-    let mut builder = session
-        .commit(message)
-        .max_concurrent_nodes(max_concurrent_manifests)
-        .rewrite_manifests();
+    let mut builder = session.commit(message).rewrite_manifests();
+    if let Some(n) = max_concurrent_manifests {
+        builder = builder.max_concurrent_nodes(n);
+    }
     if commit_method == CommitMethod::Amend {
         builder = builder.amend();
     }

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -2522,6 +2522,7 @@ mod tests {
             }),
             splitting: Some(split_config.clone()),
             virtual_chunk_location_compression: None,
+            max_concurrent_manifest_fetches_during_commit: None,
         };
         let config = RepositoryConfig {
             manifest: Some(man_config),
@@ -2550,6 +2551,7 @@ mod tests {
             }),
             splitting: Some(split_config.clone()),
             virtual_chunk_location_compression: None,
+            max_concurrent_manifest_fetches_during_commit: None,
         };
         let config = RepositoryConfig {
             manifest: Some(man_config),
@@ -2851,7 +2853,7 @@ mod tests {
             &new_repo,
             "main",
             "rewrite_manifests with split-size=12",
-            8,
+            Some(8),
             None,
             commit_method,
         )
@@ -2885,7 +2887,7 @@ mod tests {
             &new_repo,
             "main",
             "rewrite_manifests with split-size=4",
-            8,
+            Some(8),
             None,
             commit_method,
         )
@@ -4238,7 +4240,7 @@ mod tests {
             &repo,
             "main",
             "rewrite manifests",
-            8,
+            Some(8),
             None,
             CommitMethod::NewCommit,
         )
@@ -4303,7 +4305,7 @@ mod tests {
             &repo2,
             "main",
             "rewriting manifests",
-            8,
+            Some(8),
             None,
             CommitMethod::Amend,
         )
@@ -4315,7 +4317,7 @@ mod tests {
             &repo2,
             "main",
             "rewriting manifests",
-            8,
+            Some(8),
             None,
             CommitMethod::NewCommit,
         )

--- a/icechunk/src/session.rs
+++ b/icechunk/src/session.rs
@@ -316,11 +316,14 @@ impl std::fmt::Debug for CommitBuilder<'_> {
 
 impl<'a> CommitBuilder<'a> {
     fn new(session: &'a mut Session, message: String) -> Self {
+        let max_concurrent_nodes = usize::from(
+            session.config().manifest().max_concurrent_manifest_fetches_during_commit(),
+        );
         Self {
             session,
             message,
             properties: None,
-            max_concurrent_nodes: 1,
+            max_concurrent_nodes,
             allow_empty: false,
             amend: false,
             kind: CommitKind::NewCommit,
@@ -337,7 +340,7 @@ impl<'a> CommitBuilder<'a> {
     }
 
     pub fn max_concurrent_nodes(mut self, n: usize) -> Self {
-        self.max_concurrent_nodes = n;
+        self.max_concurrent_nodes = n.max(1); // Must be > 0 to flush
         self
     }
 
@@ -3749,6 +3752,87 @@ mod tests {
         assert!(splits.find(&ChunkIndices(vec![21, 0])).is_none());
 
         Ok(())
+    }
+
+    async fn write_array_and_commit(
+        repo: &Repository,
+        concurrency: Option<usize>,
+    ) -> Result<(Path, Bytes, SnapshotId), Box<dyn Error>> {
+        let mut session = repo.writable_session("main").await?;
+        session.add_group(Path::root(), Bytes::copy_from_slice(b"")).await?;
+
+        let array_path: Path = "/array".to_string().try_into().unwrap();
+        let shape = ArrayShape::new(vec![(4, 4)]).unwrap();
+        let array_def = Bytes::from_static(br#"{"this":"array"}"#);
+        session
+            .add_array(array_path.clone(), shape, Some(vec!["t".into()]), array_def)
+            .await?;
+
+        let bytes = Bytes::copy_from_slice(&42i8.to_be_bytes());
+        let payload = session.get_chunk_writer()?(bytes.clone()).await?;
+        session
+            .set_chunk_ref(array_path.clone(), ChunkIndices(vec![0]), Some(payload))
+            .await?;
+
+        let mut builder = session.commit("commit");
+        if let Some(n) = concurrency {
+            builder = builder.max_concurrent_nodes(n);
+        }
+        let snapshot = builder.execute().await?;
+        Ok((array_path, bytes, snapshot))
+    }
+
+    async fn assert_chunk_readable(
+        repo: &Repository,
+        array_path: &Path,
+        bytes: Bytes,
+        snapshot: SnapshotId,
+    ) -> Result<(), Box<dyn Error>> {
+        let session = repo.readonly_session(&VersionInfo::SnapshotId(snapshot)).await?;
+        let chunk = get_chunk(
+            session
+                .get_chunk_reader(array_path, &ChunkIndices(vec![0]), &ByteRange::ALL)
+                .await?,
+        )
+        .await?;
+        assert_eq!(chunk, Some(bytes));
+        Ok(())
+    }
+
+    // A concurrency of 0 must not silently drop manifests: `buffer_unordered(0)`
+    // yields an empty stream, so without clamping no node would be flushed and
+    // the commit would silently drop all manifests.
+    #[tokio_test]
+    async fn test_commit_concurrency_zero_still_flushes() -> Result<(), Box<dyn Error>> {
+        let repo = create_memory_store_repository(SpecVersionBin::V2).await;
+        let (array_path, bytes, snapshot) =
+            write_array_and_commit(&repo, Some(0)).await?;
+        assert_chunk_readable(&repo, &array_path, bytes, snapshot).await
+    }
+
+    // The commit concurrency defaults from
+    // `ManifestConfig::max_concurrent_manifest_fetches_during_commit`; a configured
+    // 0 is clamped the same way as an explicit one.
+    #[tokio_test]
+    async fn test_commit_concurrency_from_config() -> Result<(), Box<dyn Error>> {
+        let backend: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+        let config = RepositoryConfig {
+            manifest: Some(ManifestConfig {
+                max_concurrent_manifest_fetches_during_commit: Some(0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let repo = Repository::create(
+            Some(config),
+            backend,
+            HashMap::new(),
+            Some(SpecVersionBin::V2),
+            true,
+        )
+        .await?;
+        let (array_path, bytes, snapshot) = write_array_and_commit(&repo, None).await?;
+        assert_chunk_readable(&repo, &array_path, bytes, snapshot).await
     }
 
     #[tokio_test]

--- a/icechunk/src/strategies.rs
+++ b/icechunk/src/strategies.rs
@@ -391,9 +391,11 @@ prop_compose! {
 
 prop_compose! {
     pub fn manifest_config()
-        (splitting in option::of(manifest_splitting_config()), preload in option::of(manifest_preload_config()))
+        (splitting in option::of(manifest_splitting_config()),
+        preload in option::of(manifest_preload_config()),
+        max_concurrent_manifest_fetches_during_commit in option::of(any::<u16>()))
     -> ManifestConfig {
-        ManifestConfig{preload, splitting, virtual_chunk_location_compression: None}
+        ManifestConfig{preload, splitting, virtual_chunk_location_compression: None, max_concurrent_manifest_fetches_during_commit}
     }
 }
 


### PR DESCRIPTION
Closes #2273

Allow users to tune the concurrency used when updating manifests.

A couple design decisions for feedback:
- **Location: on `RepositoryConfig`** next to existing `max_concurrent_requests` and `get_partial_values_concurrency`.
    - Also considered a keyword argument on each method (commit, flush, etc), but repo config seems more consistent with existing options.
- **Naming: `max_concurrent_manifest_updates`**  -- no strong opinions here
- **Default value: `1`**, matching current behavior.
    - An alternative would be `min(16, available_parallelism())`. Anything higher than roughly 16 doesn't help, `do_flush` runs all nodes on a single tokio task, so their I/O waits are overlapped but the CPU work (decode/merge/rebuild/compress) still serializes on one core.