### PR TITLE
Fix manifest.fbs comment for compression_algorithm = 0

### DIFF
--- a/icechunk-format/flatbuffers/manifest.fbs
+++ b/icechunk-format/flatbuffers/manifest.fbs
@@ -77,7 +77,7 @@ table Manifest {
   location_dictionary: [uint8];
 
   // Compression algorithm for compressed_location fields.
-  // 0 = none (compressed_location contains raw bytes),
+  // 0 = none: locations are stored uncompressed in ChunkRef.location.
   // 1 = zstd dictionary compression (use location_dictionary).
   // Introduced in spec version 2.
   compression_algorithm: uint8 = 1;


### PR DESCRIPTION
Fixes the incorrect schema comment reported in https://github.com/earth-mover/icechunk/issues/2220: the comment on `compression_algorithm` claimed `0` means `compressed_location` holds raw bytes, but the implementation never does that. Uncompressed locations go in the plain `ChunkRef.location` field. This just updates the comment to match the implementation.
