### PR TITLE
Fix docs readme

### DIFF
--- a/icechunk-python/docs/README.md
+++ b/icechunk-python/docs/README.md
@@ -16,23 +16,10 @@ This repository uses [uv](https://docs.astral.sh/uv/) to manage dependencies.
 - **Fedora/RHEL**: `sudo dnf install cairo-devel`
 - **Windows**: Download from [cairographics.org](https://cairographics.org/download/)
 
-### Running
-
-From the `icechunk-python` directory:
-
-```bash
-
-pixi run docs-serve
-```
-
-> [!TIP]
-> You can use the optional `--dirty` flag to only rebuild changed files, although you may need to restart if you make changes to `mkdocs.yaml`.
-
 ### Building
 
-```bash
-pixi run docs-build
-```
+Please see the ["Building Documentation" section of the Icechunk contributor's guide](https://icechunk.io/en/stable/reference/contributing/#building-documentation) for the most up-to-date build instructions.
+
 
 Builds output to: `docs/.site` directory.
 

--- a/icechunk-python/docs/README.md
+++ b/icechunk-python/docs/README.md
@@ -16,9 +16,9 @@ This repository uses [uv](https://docs.astral.sh/uv/) to manage dependencies.
 - **Fedora/RHEL**: `sudo dnf install cairo-devel`
 - **Windows**: Download from [cairographics.org](https://cairographics.org/download/)
 
-### Building
+### Building and Running
 
-Please see the ["Building Documentation" section of the Icechunk contributor's guide](https://icechunk.io/en/stable/reference/contributing/#building-documentation) for the most up-to-date build instructions.
+Please see the ["Building Documentation" section of the Icechunk contributor's guide](https://icechunk.io/en/stable/reference/contributing/#building-documentation) for the most up-to-date build and dev server instructions.
 
 
 Builds output to: `docs/.site` directory.


### PR DESCRIPTION
When working with @ianhi and @zqianem on reviewing Icechunk docs at SciPy26, the build instructions on the docs README were not functional (the pixi commands specified were not configured). The docs build instructions listed in the contributors guide worked for us, so updating the README to point to the contributors guide to prevent future instruction fragmentation.

Commands that did not work (in `icechunk-python/`):
```bash
pixi run docs-build
pixi run docs-serve
```

Commands that did work (from root project folder) that were found in contributors guide: 
```bash
just docs-build
just docs-serve
```
