### PR TITLE
Explicit minimum pixi version and CI tweaks

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -60,6 +60,10 @@ jobs:
         run: |
           just profile=ci develop
 
+      - name: Check pixi version pins
+        run: |
+          just check-pixi-version
+
       - name: Run formatting checks
         run: |
           just format --check

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -255,6 +255,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: wasm-${{ env.MSRV }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run wasm build check
         run: just wasm-build

--- a/Justfile
+++ b/Justfile
@@ -84,9 +84,10 @@ ci-python-check:
   just check-xarray-docs
 
 [group('ci')]
-[doc("Reproduce code-quality.yaml: develop, format check, clippy, doctests, mypy, pre-commit")]
+[doc("Reproduce code-quality.yaml: develop, pixi version check, format check, clippy, doctests, mypy, pre-commit")]
 ci-code-quality $RUSTFLAGS="-D warnings":
   just profile=ci develop
+  just check-pixi-version
   just format "--check"
   just profile=ci lint
   just profile=ci doctest
@@ -242,9 +243,20 @@ check *args:
 [doc("Check Cargo.toml rust-version matches the contributing docs (pass an expected MSRV to pin it)")]
 check-msrv expected="":
   msrv=$(sed -n 's/^rust-version = "\(.*\)"$/\1/p' Cargo.toml)
-  test -n "$msrv"
-  test -z "{{expected}}" || test "$msrv" = "{{expected}}"
+  pysemver check "$msrv"
+  test -z "{{expected}}" || test "$(pysemver compare "$msrv" "{{expected}}")" = 0
   grep -F "The current MSRV is \`$msrv\`" icechunk-python/docs/docs/reference/contributing.md
+
+[group('lint')]
+[script]
+[doc("Check pixi versions in CI workflows and docs satisfy requires-pixi in icechunk-python/pyproject.toml")]
+check-pixi-version:
+  min=$(sed -n 's/^requires-pixi = ">=\(.*\)"$/\1/p' icechunk-python/pyproject.toml)
+  grep -h 'PIXI_VERSION:' .github/workflows/*.y*ml | sed 's/.*PIXI_VERSION: "v\(.*\)".*/\1/' | while read -r ver; do
+    test "$(pysemver compare "$ver" "$min")" -ge 0
+  done
+  docver=$(sed -n 's/.*at least pixi version `\([0-9.]*\)`.*/\1/p' icechunk-python/docs/README.md)
+  test "$(pysemver compare "$docver" "$min")" -ge 0
 
 [group('lint')]
 [doc("Format all Rust files (pass `--check` to verify only)")]

--- a/Justfile
+++ b/Justfile
@@ -255,7 +255,7 @@ check-pixi-version:
   grep -h 'PIXI_VERSION:' .github/workflows/*.y*ml | sed 's/.*PIXI_VERSION: "v\(.*\)".*/\1/' | while read -r ver; do
     test "$(pysemver compare "$ver" "$min")" -ge 0
   done
-  docver=$(sed -n 's/.*at least pixi version `\([0-9.]*\)`.*/\1/p' icechunk-python/docs/README.md)
+  docver=$(sed -n 's/.*at least pixi version `\([0-9.]*\)`.*/\1/p' icechunk-python/docs/docs/reference/contributing.md)
   test "$(pysemver compare "$docver" "$min")" -ge 0
 
 [group('lint')]

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,7 @@
                   pkgs.awscli2
                   pkgs.google-cloud-sdk
                   pkgs.just # script launcher with a make flavor
+                  python.pkgs.semver # pysemver, for `just check-msrv`/`check-pixi-version`
                   pkgs.alejandra # nix code formatter
                   pkgs.markdownlint-cli2
                   pkgs.flatbuffers

--- a/icechunk-python/docs/README.md
+++ b/icechunk-python/docs/README.md
@@ -6,15 +6,9 @@ Built with [MkDocs](https://www.mkdocs.org/) using [Material for MkDocs](https:/
 
 ### Prerequisites
 
-This repository uses [uv](https://docs.astral.sh/uv/) to manage dependencies.
+This repository uses [pixi](https://pixi.prefix.dev/) to manage dependencies.
 
-**System dependencies**: The documentation build requires Cairo graphics library for image processing:
-
-- **macOS**: `brew install cairo`
-  - If MkDocs fails to find Cairo, set: `export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`
-- **Ubuntu/Debian**: `sudo apt-get install libcairo2-dev`
-- **Fedora/RHEL**: `sudo dnf install cairo-devel`
-- **Windows**: Download from [cairographics.org](https://cairographics.org/download/)
+Currently you need at least pixi version `0.72.0` to build the docs.
 
 ### Building and Running
 

--- a/icechunk-python/docs/README.md
+++ b/icechunk-python/docs/README.md
@@ -4,16 +4,9 @@ Built with [MkDocs](https://www.mkdocs.org/) using [Material for MkDocs](https:/
 
 ## Developing
 
-### Prerequisites
-
-This repository uses [pixi](https://pixi.prefix.dev/) to manage dependencies.
-
-Currently you need at least pixi version `0.72.0` to build the docs.
-
 ### Building and Running
 
 Please see the ["Building Documentation" section of the Icechunk contributor's guide](https://icechunk.io/en/stable/reference/contributing/#building-documentation) for the most up-to-date build and dev server instructions.
-
 
 Builds output to: `docs/.site` directory.
 

--- a/icechunk-python/docs/docs/reference/contributing.md
+++ b/icechunk-python/docs/docs/reference/contributing.md
@@ -52,6 +52,8 @@ We use [pixi](https://pixi.prefix.dev/latest/) to manage both the python and rus
         ```
         This is used e.g. in the [Readthedocs build](https://github.com/earth-mover/icechunk/blob/main/.readthedocs.yaml).
 
+    Currently you need at least pixi version `0.72.0` for development.
+
 === "uv"
 
     The easiest way to get started is with [uv](https://docs.astral.sh/uv/), which handles virtual environments and dependencies:

--- a/icechunk-python/pixi.lock
+++ b/icechunk-python/pixi.lock
@@ -41,7 +41,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
@@ -198,7 +197,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
@@ -382,7 +380,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
@@ -545,7 +542,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
@@ -679,7 +675,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h637d24d_0.conda

--- a/icechunk-python/pixi.lock
+++ b/icechunk-python/pixi.lock
@@ -41,6 +41,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
@@ -197,6 +198,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
@@ -380,6 +382,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
@@ -542,6 +545,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
@@ -675,6 +679,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h637d24d_0.conda
@@ -855,6 +860,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.96.1-h38e4360_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-hd145fbb_1.conda
@@ -1173,6 +1179,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.96.1-hf6ec828_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.1-hcb83491_2.conda
@@ -1607,6 +1614,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.96.1-h2c6d0dc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/github-releases/linux-64/cargo-release-1.1.2-hb0f4dca_0.conda
@@ -1934,6 +1942,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.96.1-hbe8e118_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.34-h96c1060_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/github-releases/linux-aarch64/cargo-release-1.1.2-he8cfe8b_0.conda
@@ -2150,6 +2159,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.96.1-h17fc481_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.10.1-h5d51246_2.conda
@@ -2453,6 +2463,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.96.1-h38e4360_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.3-h9b4a110_4.conda
@@ -2646,6 +2657,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.96.1-hf6ec828_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
@@ -2923,6 +2935,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.14.6-h92d6c8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.96.1-h2c6d0dc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/github-releases/linux-64/cargo-release-1.1.2-hb0f4dca_0.conda
@@ -3108,6 +3121,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.14.6-h92d6c8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.96.1-hbe8e118_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.34-h96c1060_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/github-releases/linux-aarch64/cargo-release-1.1.2-he8cfe8b_0.conda
@@ -3198,6 +3212,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.14.6-h92d6c8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.96.1-h17fc481_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.10.3-h0a1c2aa_4.conda
@@ -8501,6 +8516,19 @@ packages:
   run_exports: {}
   size: 4971
   timestamp: 1771434195389
+- conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
+  sha256: bea67173ed67c73cf16691ef72e58059492ac1ed1c880cfbeb6f1295c5add7d6
+  md5: 8e7be844ccb9706a999a337e056606ab
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/semver?source=hash-mapping
+  run_exports: {}
+  size: 22532
+  timestamp: 1767294175877
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
   sha256: 08c50c314b331730eeb8f87c39a45e5426a5463e078392ab283e2552d753443e
   md5: b04e3a97151611d6a35c8c068b2a03a2

--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -216,6 +216,7 @@ platforms = [
   "win-64",
   "osx-64",
 ]
+requires-pixi = ">=0.72"
 
 [tool.pixi.feature.docs.dependencies]
 cairo = ">=1.18.4,<2"

--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -209,6 +209,7 @@ icechunk = "icechunk._icechunk_python:cli_entrypoint"
 
 [tool.pixi.workspace]
 channels = ["conda-forge", "https://prefix.dev/github-releases"]
+requires-pixi = ">=0.72.0"
 platforms = [
   "osx-arm64",
   { platform = "linux-64", glibc = "2.34" },
@@ -216,7 +217,6 @@ platforms = [
   "win-64",
   "osx-64",
 ]
-requires-pixi = ">=0.72"
 
 [tool.pixi.feature.docs.dependencies]
 cairo = ">=1.18.4,<2"
@@ -265,3 +265,6 @@ py314t = { features = [
   "dev",
   "test",
 ]}
+
+[tool.pixi.dependencies]
+semver = ">=3.0.4,<4"

--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -243,6 +243,7 @@ samply = ">=0.13.1,<0.14"
 cargo-release = ">=1.1.2,<2"
 cargo-llvm-cov = ">=0.8.4,<0.9"
 nodejs = ">=22.23.1,<23"
+semver = ">=3.0.4,<4"
 
 [tool.pixi.feature.build.target.linux-64.dependencies]
 sysroot_linux-64 = ">=2.34"
@@ -265,6 +266,3 @@ py314t = { features = [
   "dev",
   "test",
 ]}
-
-[tool.pixi.dependencies]
-semver = ">=3.0.4,<4"


### PR DESCRIPTION
- Use `requires-pixi` to fail gracefully with pointers on how to update Pixi, instead of showing cryptic errors from new pixi syntax
- Follow caching conventions from other CI jobs and only update on `main`