### PR TITLE
Don't strip quotes when doing conditional operations in object_store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2251,7 +2251,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2707,7 +2707,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3212,7 +3212,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3296,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -3878,9 +3878,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -3911,7 +3911,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3949,9 +3949,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4380,7 +4380,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4458,7 +4458,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5090,7 +5090,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6043,7 +6043,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Justfile
+++ b/Justfile
@@ -417,7 +417,7 @@ zarrs-upstream-clone zarrs_dir="zarrs_icechunk":
 zarrs-upstream-patch zarrs_dir="zarrs_icechunk":
   icechunk_path=$(realpath icechunk)
   if ! grep -q 'icechunk = { path' {{zarrs_dir}}/Cargo.toml; then
-    sed -i '/^\[patch\.crates-io\]/a icechunk = { path = "'"$icechunk_path"'" }' {{zarrs_dir}}/Cargo.toml
+    sed -i.bak $'/^\\[patch\\.crates-io\\]/a\\\nicechunk = { path = "'"$icechunk_path"'" }' {{zarrs_dir}}/Cargo.toml && rm {{zarrs_dir}}/Cargo.toml.bak
   fi
   # empty [workspace] table so cargo doesn't adopt the enclosing icechunk workspace
   if ! grep -q '^\[workspace\]' {{zarrs_dir}}/Cargo.toml; then

--- a/icechunk-arrow-object-store/src/lib.rs
+++ b/icechunk-arrow-object-store/src/lib.rs
@@ -14,7 +14,6 @@ use futures::{
 use http::header::{HeaderName, HeaderValue};
 #[cfg(feature = "s3")]
 use icechunk_storage::s3_config::{S3Credentials, S3Options};
-use icechunk_storage::strip_quotes;
 use icechunk_storage::{
     ConcurrencySettings, DeleteObjectsResult, ETag, Generation, GetModifiedResult,
     ListInfo, RepositoryCreation, RetriesSettings, Settings, Storage, StorageError,
@@ -649,7 +648,7 @@ impl Storage for ObjectStorage {
             // object_store has no conditional copy, so we do a conditional GET
             // (verifying the source etag) followed by a PUT.
             let opts = GetOptions {
-                if_match: version.etag().map(|e| strip_quotes(e).into()),
+                if_match: version.etag().map(|e| e.into()),
                 ..Default::default()
             };
             let result =
@@ -862,7 +861,7 @@ impl ObjectStorage {
             range,
             if_none_match: previous_version
                 .as_ref()
-                .and_then(|v| v.etag().map(|e| strip_quotes(e).into())),
+                .and_then(|v| v.etag().map(|e| e.into())),
             ..Default::default()
         };
         let res =
@@ -1722,9 +1721,12 @@ mod tests {
     use icechunk_macros::tokio_test;
     use tempfile::TempDir;
 
+    use super::{
+        Bytes, ObjectPath, ObjectStorage, ReadbackOutcome, Settings, Storage,
+        VersionedUpdateResult,
+    };
     #[cfg(feature = "http")]
     use super::{NonZeroU16, RetriesSettings, Url};
-    use super::{ObjectPath, ObjectStorage, ReadbackOutcome, Settings};
 
     #[tokio_test]
     async fn test_serialize_object_store() {
@@ -1787,6 +1789,45 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(outcome, ReadbackOutcome::NotOurs);
+    }
+
+    #[tokio_test]
+    async fn conditional_copy_and_get_roundtrip_etag() {
+        // Etags must round-trip verbatim into if_match/if_none_match:
+        // object_store compares them by exact string equality, so stripping
+        // quotes turns every conditional copy into a spurious conflict.
+        let store = ObjectStorage::new_in_memory().await.unwrap();
+        let settings = store.default_settings().await.unwrap();
+        let path = "conditional-roundtrip";
+        let version = match store
+            .put_object(
+                &settings,
+                path,
+                Bytes::from_static(b"payload"),
+                None,
+                Default::default(),
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            VersionedUpdateResult::Updated { new_version } => new_version,
+            VersionedUpdateResult::NotOnLatestVersion => {
+                panic!("unconditional put must succeed")
+            }
+        };
+
+        let copied = store
+            .copy_object(&settings, path, "conditional-roundtrip-copy", None, &version)
+            .await
+            .unwrap();
+        assert!(matches!(copied, VersionedUpdateResult::Updated { .. }));
+
+        let not_modified = store
+            .get_object_range_conditional(&settings, path, None, Some(&version))
+            .await
+            .unwrap();
+        assert!(not_modified.is_none());
     }
 
     #[cfg(feature = "http")]

--- a/icechunk-arrow-object-store/src/lib.rs
+++ b/icechunk-arrow-object-store/src/lib.rs
@@ -1722,7 +1722,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        Bytes, ObjectPath, ObjectStorage, ReadbackOutcome, Settings, Storage,
+        Bytes, ObjectPath, ObjectStorage, ReadbackOutcome, Settings, Storage as _,
         VersionedUpdateResult,
     };
     #[cfg(feature = "http")]


### PR DESCRIPTION
Fix #2202 

A combination of #2156 and object_store updated to `0.14.1`, especially https://github.com/apache/arrow-rs-object-store/issues/769, which fixed `InMemory` and `LocalFileSystem` handling of ETags (quoting them properly, and doing exact string matching expecting quotes). We were at `0.14.0`, bumped it too after confirming the fix works in both versions.

Fix the `sed` use in the `zarrs-upstream-patch` Just task to be compatible with GNU and BSD (macOS) versions.