### PR TITLE
More GHA caching, clean remaining zizmor warnings

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -11,7 +11,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # don't cancel main runs: the post-job cache saves only happen there
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -38,16 +39,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          # The rust cache includes a dep on the Python version (when building icechunk-python)
-          # so we need to bump the version here whenever Python version is updated
-          # Currently: 3.12
-          prefix-key: "rust-py312"
-          shared-key: "rust"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
@@ -55,6 +46,18 @@ jobs:
           cache-write: ${{ github.ref == 'refs/heads/main' }}
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
+
+      # Runs after setup-pixi so the cache key hashes the pixi-pinned rustc,
+      # not the runner image's drifting rustup stable
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # The rust cache includes a dep on the Python version (when building icechunk-python)
+          # so we need to bump the version here whenever Python version is updated
+          # Currently: 3.12
+          prefix-key: "rust-py312"
+          shared-key: "code-quality"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Prepare pixi for development
         run: |
@@ -71,10 +74,6 @@ jobs:
       - name: Run clippy linting
         run: |
           just profile=ci lint
-
-      - name: Run doc tests
-        run: |
-          just profile=ci doctest
 
       - name: Python mypy type checking
         run: |

--- a/.github/workflows/detect-unused-dependencies.yaml
+++ b/.github/workflows/detect-unused-dependencies.yaml
@@ -3,11 +3,21 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   detect-unused-dependencies:
+    name: Detect unused dependencies
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Machete
         uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2

--- a/.github/workflows/js-ci.yaml
+++ b/.github/workflows/js-ci.yaml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:
@@ -72,6 +75,8 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -79,7 +84,7 @@ jobs:
           cache: yarn
           cache-dependency-path: icechunk-js/yarn.lock
       - name: Install
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable # zizmor: ignore[superfluous-actions] installs non-default targets
         with:
           toolchain: ${{ matrix.settings.rust || 'stable' }}
           targets: ${{ matrix.settings.target }}
@@ -100,13 +105,13 @@ jobs:
         with:
           tool: cargo-zigbuild
       - name: Setup toolchain
-        run: ${{ matrix.settings.setup }}
+        run: ${{ matrix.settings.setup }} # zizmor: ignore[template-injection] static workflow-defined matrix value
         if: ${{ matrix.settings.setup }}
         shell: bash
       - name: Install dependencies
         run: yarn install
       - name: Build
-        run: ${{ matrix.settings.build }}
+        run: ${{ matrix.settings.build }} # zizmor: ignore[template-injection] static workflow-defined matrix value
         shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -139,6 +144,8 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -176,6 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -205,6 +214,8 @@ jobs:
         working-directory: ./icechunk-js
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -236,14 +247,16 @@ jobs:
       run:
         working-directory: ./icechunk-js
     permissions:
-      contents: write
-      id-token: write
+      contents: write # to publish the release
+      id-token: write # for npm provenance attestation
     needs:
       - test-macOS-windows-binding
       - test-linux-binding
       - test-wasi
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/js-ci.yaml
+++ b/.github/workflows/js-ci.yaml
@@ -83,17 +83,11 @@ jobs:
         with:
           toolchain: ${{ matrix.settings.rust || 'stable' }}
           targets: ${{ matrix.settings.target }}
-      - name: Cache cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.napi-rs
-            .cargo-cache
-            target/
-          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
+          key: ${{ matrix.settings.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         if: ${{ contains(matrix.settings.target, 'musl') }}
         with:

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -12,7 +12,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # don't cancel main runs: the post-job cache saves only happen there
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -278,7 +278,7 @@ jobs:
 
       - name: Save cached hypothesis directory
         id: save-hypothesis-cache
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: icechunk-python/.hypothesis/

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Restore cached hypothesis directory
         id: restore-hypothesis-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/
           key: cache-hypothesis-${{ runner.os }}-${{ github.run_id }}
@@ -245,7 +245,7 @@ jobs:
 
       - name: Restore cached hypothesis directory
         id: restore-hypothesis-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/
           key: cache-hypothesis-${{ runner.os }}-shard${{ matrix.shard-id }}-${{ github.run_id }}
@@ -279,7 +279,7 @@ jobs:
       - name: Save cached hypothesis directory
         id: save-hypothesis-cache
         if: always() && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/
           key: cache-hypothesis-${{ runner.os }}-shard${{ matrix.shard-id }}-${{ github.run_id }}
@@ -332,7 +332,7 @@ jobs:
         run: just coverage-report-python
 
       - name: Upload Python coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage_python.lcov

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -69,13 +69,17 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate version for main
         if: ${{ github.event_name == 'schedule' || inputs.branch != 'support/v1.x' }}
         id: version-main
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          USE_GIT_VERSION: ${{ inputs.use_git_version }}
         run: |
           # Version generation logic for main (v2.x)
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.use_git_version }}" == "true" ]]; then
+          if [[ "$EVENT_NAME" == "schedule" ]] || [[ "$USE_GIT_VERSION" == "true" ]]; then
             # Match only v2.* tags to avoid confusion with v1.x tags
             if ! git describe --tags --match "v2.*" >/dev/null 2>&1; then
               echo "❌ ERROR: No v2.* tags found. Please create v2.0.0-alpha.0 tag first."
@@ -99,13 +103,17 @@ jobs:
         with:
           ref: support/v1.x
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate version for support/v1.x
         if: ${{ github.event_name == 'schedule' || inputs.branch == 'support/v1.x' }}
         id: version-v1
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          USE_GIT_VERSION: ${{ inputs.use_git_version }}
         run: |
           # Version generation logic for support/v1.x (v1.x)
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.use_git_version }}" == "true" ]]; then
+          if [[ "$EVENT_NAME" == "schedule" ]] || [[ "$USE_GIT_VERSION" == "true" ]]; then
             # Match only v1.* tags to avoid confusion with v2.x tags
             if ! git describe --tags --match "v1.*" >/dev/null 2>&1; then
               echo "❌ ERROR: No v1.* tags found"
@@ -123,6 +131,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   linux:
+    name: Build linux wheels
     runs-on: ${{ matrix.platform.runner }}
     needs: version
     strategy:
@@ -149,6 +158,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Stand up docker services
         run: |
           docker compose up -d
@@ -165,9 +175,11 @@ jobs:
           python-version: '3.12'
       - name: Update version in Cargo.toml
         if: ${{ github.event_name == 'schedule' || inputs.use_git_version == true }}
+        env:
+          VERSION: ${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}
+          BRANCH: ${{ matrix.branch }}
         run: |
-          VERSION="${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}"
-          echo "Using version: $VERSION for branch ${{ matrix.branch }}"
+          echo "Using version: $VERSION for branch $BRANCH"
           sed -i 's/^version = ".*"/version = "'$VERSION'"/' Cargo.toml
       - name: Build wheels
         uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
@@ -184,6 +196,7 @@ jobs:
           path: icechunk-python/dist
 
   musllinux:
+    name: Build musllinux wheels
     runs-on: ${{ matrix.platform.runner }}
     needs: version
     strategy:
@@ -202,14 +215,17 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.x
       - name: Update version in Cargo.toml
         if: ${{ github.event_name == 'schedule' || inputs.use_git_version == true }}
+        env:
+          VERSION: ${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}
+          BRANCH: ${{ matrix.branch }}
         run: |
-          VERSION="${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}"
-          echo "Using version: $VERSION for branch ${{ matrix.branch }}"
+          echo "Using version: $VERSION for branch $BRANCH"
           sed -i 's/^version = ".*"/version = "'$VERSION'"/' Cargo.toml
       - name: Build wheels
         uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
@@ -226,6 +242,7 @@ jobs:
           path: icechunk-python/dist
 
   windows:
+    name: Build windows wheels
     runs-on: ${{ matrix.platform.runner }}
     needs: version
     # aws-lc-sys compiles AWS-LC's C source, which uses C11 atomics. MSVC only enables
@@ -249,16 +266,19 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
       - name: Update version in Cargo.toml
         if: ${{ github.event_name == 'schedule' || inputs.use_git_version == true }}
+        env:
+          VERSION: ${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}
+          BRANCH: ${{ matrix.branch }}
         run: |
-          $VERSION = "${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}"
-          Write-Host "Using version: $VERSION for branch ${{ matrix.branch }}"
-          (Get-Content Cargo.toml) -replace '^version = ".*"', "version = `"$VERSION`"" | Set-Content Cargo.toml
+          Write-Host "Using version: $env:VERSION for branch $env:BRANCH"
+          (Get-Content Cargo.toml) -replace '^version = ".*"', "version = `"$env:VERSION`"" | Set-Content Cargo.toml
         shell: powershell
       - name: Build wheels
         uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
@@ -274,6 +294,7 @@ jobs:
           path: icechunk-python/dist
 
   macos:
+    name: Build macos wheels
     runs-on: ${{ matrix.platform.runner }}
     needs: version
     strategy:
@@ -292,14 +313,17 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.x
       - name: Update version in Cargo.toml
         if: ${{ github.event_name == 'schedule' || inputs.use_git_version == true }}
+        env:
+          VERSION: ${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}
+          BRANCH: ${{ matrix.branch }}
         run: |
-          VERSION="${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}"
-          echo "Using version: $VERSION for branch ${{ matrix.branch }}"
+          echo "Using version: $VERSION for branch $BRANCH"
           sed -i '' 's/^version = ".*"/version = "'$VERSION'"/' Cargo.toml
       - name: Build wheels
         uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
@@ -315,6 +339,7 @@ jobs:
           path: icechunk-python/dist
 
   sdist:
+    name: Build sdist
     runs-on: ubuntu-latest
     needs: version
     strategy:
@@ -328,11 +353,14 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Update version in Cargo.toml
         if: ${{ github.event_name == 'schedule' || inputs.use_git_version == true }}
+        env:
+          VERSION: ${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}
+          BRANCH: ${{ matrix.branch }}
         run: |
-          VERSION="${{ matrix.branch == 'main' && needs.version.outputs.version-main || needs.version.outputs.version-v1 }}"
-          echo "Using version: $VERSION for branch ${{ matrix.branch }}"
+          echo "Using version: $VERSION for branch $BRANCH"
           sed -i 's/^version = ".*"/version = "'$VERSION'"/' Cargo.toml
       - name: Build sdist
         uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
@@ -381,8 +409,14 @@ jobs:
 
       - name: Warn about failed build jobs
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        env:
+          R_LINUX: ${{ needs.linux.result }}
+          R_MUSL: ${{ needs.musllinux.result }}
+          R_WIN: ${{ needs.windows.result }}
+          R_MAC: ${{ needs.macos.result }}
+          R_SDIST: ${{ needs.sdist.result }}
         run: |
-          echo "::warning title=Incomplete nightly build::Some wheel build jobs failed; uploading only the wheels that built successfully. linux=${{ needs.linux.result }} musllinux=${{ needs.musllinux.result }} windows=${{ needs.windows.result }} macos=${{ needs.macos.result }} sdist=${{ needs.sdist.result }}"
+          echo "::warning title=Incomplete nightly build::Some wheel build jobs failed; uploading only the wheels that built successfully. linux=$R_LINUX musllinux=$R_MUSL windows=$R_WIN macos=$R_MAC sdist=$R_SDIST"
 
       - name: Ensure there is something to upload
         run: |

--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -90,7 +90,8 @@ jobs:
           HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY: "1"
           HYPOTHESIS_PROFILE: ${{ github.event_name == 'pull_request' && 'ci' || 'nightly' }}
         run: |
-          just hypothesis_profile="$HYPOTHESIS_PROFILE" python-upstream-pytest
+          # later flag wins over the recipe's default --hypothesis-profile=nightly
+          just python-upstream-pytest "--hypothesis-profile=$HYPOTHESIS_PROFILE"
 
       # explicitly save the cache so it gets updated, also do this even if it fails.
       - name: Save cached hypothesis directory

--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -94,7 +94,7 @@ jobs:
       # explicitly save the cache so it gets updated, also do this even if it fails.
       - name: Save cached hypothesis directory
         id: save-hypothesis-cache
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: icechunk-python/.hypothesis/

--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Restore cached hypothesis directory
         id: restore-hypothesis-cache
         if: always()
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/
           key: cache-hypothesis-${{ runner.os }}-${{ github.run_id }}
@@ -88,14 +88,15 @@ jobs:
         if: steps.setup.outcome == 'success'
         env:
           HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY: "1"
+          HYPOTHESIS_PROFILE: ${{ github.event_name == 'pull_request' && 'ci' || 'nightly' }}
         run: |
-          just python-upstream-pytest
+          just hypothesis_profile="$HYPOTHESIS_PROFILE" python-upstream-pytest
 
       # explicitly save the cache so it gets updated, also do this even if it fails.
       - name: Save cached hypothesis directory
         id: save-hypothesis-cache
         if: always() && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/
           key: cache-hypothesis-${{ runner.os }}-${{ github.run_id }}
@@ -217,7 +218,7 @@ jobs:
 
       - name: Generate and publish the pytest report
         if: needs.build.outputs.pytest-outcome == 'failure'
-        uses: xarray-contrib/issue-from-pytest-log@87351a8f864e969567cda22a25a2f214cbe2340f # v1
+        uses: xarray-contrib/issue-from-pytest-log@87351a8f864e969567cda22a25a2f214cbe2340f # v1.6.0
         with:
           log-path: icechunk-python/output-pytest-log.jsonl
 
@@ -292,7 +293,7 @@ jobs:
           path: xarray-backends-logs
 
       - name: Generate and publish the xarray backends report
-        uses: xarray-contrib/issue-from-pytest-log@87351a8f864e969567cda22a25a2f214cbe2340f # v1
+        uses: xarray-contrib/issue-from-pytest-log@87351a8f864e969567cda22a25a2f214cbe2340f # v1.6.0
         with:
           log-path: xarray-backends-logs/output-pytest-log.jsonl
           issue-title: "Nightly Xarray backends tests failed"

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -167,7 +167,7 @@ jobs:
           just profile=ci coverage=${coverage} coverage-report
 
       - name: Upload Rust coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -14,7 +14,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # don't cancel main runs: the post-job cache saves only happen there
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -187,16 +188,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-        with:
-          # The rust cache includes a dep on the Python version (when building icechunk-python)
-          # so we need to bump the version here whenever Python version is updated
-          # Currently: 3.12
-          prefix-key: "rust-py312"
-          shared-key: "rust"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
@@ -205,11 +196,25 @@ jobs:
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
+      # Runs after setup-pixi so the cache key hashes the pixi-pinned rustc,
+      # not the runner image's drifting rustup stable
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          # The rust cache includes a dep on the Python version (when building icechunk-python)
+          # so we need to bump the version here whenever Python version is updated
+          # Currently: 3.12
+          prefix-key: "rust-py312"
+          # reuses code-quality's cache for the overlapping ci-profile deps;
+          # never saves, so the key always holds code-quality's artifacts
+          shared-key: "code-quality"
+          save-if: false
+
       - name: Compile shuttle tests
-        run: just shuttle-test --no-run
+        run: just profile=ci shuttle-test --no-run
 
       - name: Run shuttle tests
-        run: just shuttle-test -- --nocapture
+        run: just profile=ci shuttle-test -- --nocapture
 
   wasm-build:
     name: WASM Build

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -10,7 +10,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # don't cancel main runs: the post-job cache saves only happen there
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,7 @@ repos:
     rev: v1.24.1
     hooks:
     - id: zizmor
-      # ignored files: detect-unused-dependencies,js-ci,python-ci
-      files: \.github\/workflows\/(code-quality|dependency-check|python-check|python-upstream|publish-rust-library|rust-ci|rust-upstream|windows-check)\.ya?ml
+      files: \.github\/workflows\/(code-quality|dependency-check|detect-unused-dependencies|js-ci|python-check|python-ci|python-upstream|publish-rust-library|rust-ci|rust-upstream|windows-check)\.ya?ml
       args:
         - "--no-progress" # https://github.com/zizmorcore/zizmor/issues/582
         - "--pedantic"

--- a/Justfile
+++ b/Justfile
@@ -4,9 +4,6 @@ profile := "dev"
 # Enable coverage instrumentation: override with `just coverage=true build-wheels` (default: false)
 coverage := "false"
 
-# Hypothesis profile for `just python-upstream-pytest`: override with `just hypothesis_profile=ci python-upstream-pytest` (default: nightly)
-hypothesis_profile := "nightly"
-
 # Settings can't interpolate variables, so the interpreter preamble below
 # reads these through exported env vars.
 export JUST_COVERAGE := coverage
@@ -589,7 +586,7 @@ python-upstream-describe: python-upstream-setup
 python-upstream-pytest *args: python-upstream-setup
   cd icechunk-python
   source .venv/bin/activate
-  pytest -n 4 --hypothesis-profile={{hypothesis_profile}} --report-log output-pytest-log.jsonl "$@"
+  pytest -n 4 --hypothesis-profile=nightly --report-log output-pytest-log.jsonl "$@"
 
 [group('upstream')]
 [doc("Run full xarray-upstream checks")]

--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,9 @@ profile := "dev"
 # Enable coverage instrumentation: override with `just coverage=true build-wheels` (default: false)
 coverage := "false"
 
+# Hypothesis profile for `just python-upstream-pytest`: override with `just hypothesis_profile=ci python-upstream-pytest` (default: nightly)
+hypothesis_profile := "nightly"
+
 # Settings can't interpolate variables, so the interpreter preamble below
 # reads these through exported env vars.
 export JUST_COVERAGE := coverage
@@ -587,7 +590,7 @@ python-upstream-describe: python-upstream-setup
 python-upstream-pytest *args: python-upstream-setup
   cd icechunk-python
   source .venv/bin/activate
-  pytest -n 4 --hypothesis-profile=nightly --report-log output-pytest-log.jsonl "$@"
+  pytest -n 4 --hypothesis-profile={{hypothesis_profile}} --report-log output-pytest-log.jsonl "$@"
 
 [group('upstream')]
 [doc("Run full xarray-upstream checks")]

--- a/Justfile
+++ b/Justfile
@@ -52,7 +52,7 @@ default:
 # variable overrides (same pattern as pre-commit-ci).
 
 [group('ci')]
-[doc("Reproduce rust-ci.yaml's rust job (Linux lane); needs docker. Other jobs: shuttle-test, wasm-build + wasm-proxy-test")]
+[doc("Reproduce rust-ci.yaml's rust job (Linux lane); needs docker. Other jobs: profile=ci shuttle-test, wasm-build + wasm-proxy-test")]
 ci-rust $RUSTFLAGS="-D warnings":
   just check-msrv
   just contup
@@ -87,13 +87,12 @@ ci-python-check:
   just check-xarray-docs
 
 [group('ci')]
-[doc("Reproduce code-quality.yaml: develop, pixi version check, format check, clippy, doctests, mypy, pre-commit")]
+[doc("Reproduce code-quality.yaml: develop, pixi version check, format check, clippy, mypy, pre-commit")]
 ci-code-quality $RUSTFLAGS="-D warnings":
   just profile=ci develop
   just check-pixi-version
   just format "--check"
   just profile=ci lint
-  just profile=ci doctest
   just mypy
   just py-pre-commit
 


### PR DESCRIPTION
Another round of CI cleanup:

- fix zizmor warnings for the workflows that were still ignored. Now they are all passing
- Tweak GHA caching, avoid cancelling runs on main because they would not save updated ones, and churn due to env vars from `setup-pixi`
- when running upstream tests in a PR (triggered by using the `test-upstream` label) use the `ci` hypothesis profile instead of `nightly` (which takes hours to run)