### PR TITLE
Re-enable xarray timedelta/datetime roundtrip tests on xarray >= 2026.7.0

### DIFF
--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -129,9 +129,6 @@ filterwarnings = [
   "ignore::ResourceWarning",
   "ignore:Unused async fixture loop scope:pytest.PytestWarning",
   "ignore:.*does not have a Zarr V3 specification.*",
-  # Recent NumPy deprecates the 'generic' timedelta unit; raised transitively at
-  # collection. Remove once upstream deps stop using bare-int timedelta.
-  "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning",
 ]
 
 # remap wheel-venv site-packages paths to the source tree; applied on `coverage combine`

--- a/icechunk-python/pyproject.toml
+++ b/icechunk-python/pyproject.toml
@@ -129,6 +129,9 @@ filterwarnings = [
   "ignore::ResourceWarning",
   "ignore:Unused async fixture loop scope:pytest.PytestWarning",
   "ignore:.*does not have a Zarr V3 specification.*",
+  # xarray < 2026.7.0 raises this on import under numpy >= 2.5; remove when the
+  # minimum supported xarray reaches 2026.7.0
+  "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning",
 ]
 
 # remap wheel-venv site-packages paths to the source tree; applied on `coverage combine`

--- a/icechunk-python/tests/run_xarray_backends_tests.py
+++ b/icechunk-python/tests/run_xarray_backends_tests.py
@@ -105,18 +105,6 @@ class IcechunkStoreBase(SpecVersionMixin, ZarrBase):
             unpickled = pickle.loads(raw_pickle)
             assert_identical(expected["foo"], unpickled)
 
-    # Upstream xarray time-coding breaks against recent NumPy (int64 * timedelta64
-    # overflow, datetime decode). No released xarray is compatible yet; re-enable
-    # once xarray ships a fix.
-    def test_roundtrip_timedelta_data(self, *args: Any, **kwargs: Any) -> None:
-        pytest.skip("xarray/NumPy timedelta64 incompatibility")
-
-    def test_roundtrip_timedelta_data_via_dtype(self, *args: Any, **kwargs: Any) -> None:
-        pytest.skip("xarray/NumPy timedelta64 incompatibility")
-
-    def test_roundtrip_numpy_datetime_data(self, *args: Any, **kwargs: Any) -> None:
-        pytest.skip("xarray/NumPy datetime decode incompatibility")
-
 
 class TestIcechunkStoreFilesystem(IcechunkStoreBase):
     @contextlib.contextmanager

--- a/icechunk-python/tests/run_xarray_backends_tests.py
+++ b/icechunk-python/tests/run_xarray_backends_tests.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 import xarray as xr
 import zarr
@@ -104,6 +105,21 @@ class IcechunkStoreBase(SpecVersionMixin, ZarrBase):
             # unpickled DataArray?
             unpickled = pickle.loads(raw_pickle)
             assert_identical(expected["foo"], unpickled)
+
+    # xarray < 2026.7.0 time-coding is incompatible with numpy >= 2.5
+    # (int64 * timedelta64 overflow, datetime decode failures)
+    if Version(xr.__version__) < Version("2026.7.0"):
+
+        def test_roundtrip_timedelta_data(self, *args: Any, **kwargs: Any) -> None:
+            pytest.skip("xarray/NumPy timedelta64 incompatibility")
+
+        def test_roundtrip_timedelta_data_via_dtype(
+            self, *args: Any, **kwargs: Any
+        ) -> None:
+            pytest.skip("xarray/NumPy timedelta64 incompatibility")
+
+        def test_roundtrip_numpy_datetime_data(self, *args: Any, **kwargs: Any) -> None:
+            pytest.skip("xarray/NumPy datetime decode incompatibility")
 
 
 class TestIcechunkStoreFilesystem(IcechunkStoreBase):


### PR DESCRIPTION
#2229 skipped the xarray timedelta/datetime roundtrip tests because no released
xarray was compatible with numpy >= 2.5 time-coding (int64 * timedelta64
overflow, datetime decode failures, and a generic-unit timedelta
DeprecationWarning raised at import).

xarray 2026.7.0 ships the fix, so this re-enables the tests — but only where
the fix exists. Our minimum supported xarray (2025.07.1) still hits all of the
above when installed alongside current numpy, which is exactly what the
minimum-versions CI matrix does. A plain revert of #2229 therefore fails those
jobs (54 xarray-backends failures + 4 collection errors in `test_dask.py`).

Changes:
- `run_xarray_backends_tests.py`: the three skip overrides
  (`test_roundtrip_timedelta_data`, `test_roundtrip_timedelta_data_via_dtype`,
  `test_roundtrip_numpy_datetime_data`) are now defined only when
  `xarray < 2026.7.0`. On newer xarray the upstream tests run for real.
- `pyproject.toml`: the generic-timedelta `DeprecationWarning` filter stays
  (old xarray raises it on import under numpy >= 2.5); it's inert on newer
  xarray.

Both can be dropped once the minimum supported xarray reaches 2026.7.0.

Closes #2230