### PR TITLE
Reduce ReadTheDocs build time, CI cache sizes

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -224,7 +224,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard-id: [0, 1, 2]
+        # Explicit partition keyed on test cost: each heavy stateful machine
+        # anchors a shard, cheap property tests ride along on the second
+        # xdist worker. The last shard collects everything not claimed by the
+        # others, so new hypothesis tests always run somewhere.
+        include:
+          - shard-id: zarr-hierarchy
+            targets: tests/test_zarr/test_stateful.py
+          - shard-id: repo-ops
+            targets: tests/test_stateful_repo_ops.py tests/test_store_properties.py
+          - shard-id: rest
+            targets: >-
+              --ignore=tests/test_zarr/test_stateful.py
+              --ignore=tests/test_stateful_repo_ops.py
+              --ignore=tests/test_store_properties.py
+              tests integration_tests
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -254,16 +268,16 @@ jobs:
             cache-hypothesis-${{ runner.os }}-shard${{ matrix.shard-id }}-
 
       - name: Install dependencies
-        run: just install-test-wheel test pytest-shard
+        run: just install-test-wheel test
 
-      - name: Run hypothesis tests (shard ${{ matrix.shard-id }}/3)
+      - name: Run hypothesis tests (${{ matrix.shard-id }})
         env:
           HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY: "1"
           NOCOLOR: 1
-          SHARD_ID: ${{ matrix.shard-id }}
+          PYTEST_TARGETS: ${{ matrix.targets }}
           # sysmon core: coverage's default C tracer slows hypothesis workloads badly
           COVERAGE_CORE: sysmon
-        run: just coverage=true pytest-venv -m hypothesis --num-shards=3 --shard-id="$SHARD_ID"
+        run: just coverage=true pytest-venv -m hypothesis $PYTEST_TARGETS
 
       - name: Stash coverage data for aggregation
         env:

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -228,12 +228,16 @@ jobs:
         # anchors a shard, cheap property tests ride along on the second
         # xdist worker. The last shard collects everything not claimed by the
         # others, so new hypothesis tests always run somewhere.
+        # Ids stay numeric to keep the hypothesis caches keyed on them.
         include:
-          - shard-id: zarr-hierarchy
+          - shard-id: 0
+            label: zarr-hierarchy
             targets: tests/test_zarr/test_stateful.py
-          - shard-id: repo-ops
+          - shard-id: 1
+            label: repo-ops
             targets: tests/test_stateful_repo_ops.py tests/test_store_properties.py
-          - shard-id: rest
+          - shard-id: 2
+            label: rest
             targets: >-
               --ignore=tests/test_zarr/test_stateful.py
               --ignore=tests/test_stateful_repo_ops.py
@@ -270,7 +274,7 @@ jobs:
       - name: Install dependencies
         run: just install-test-wheel test
 
-      - name: Run hypothesis tests (${{ matrix.shard-id }})
+      - name: "Run hypothesis tests (shard ${{ matrix.shard-id }}: ${{ matrix.label }})"
         env:
           HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY: "1"
           NOCOLOR: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,15 @@ repos:
 
   - repo: local
     hooks:
+      # icechunk-python's readme is what PyPI renders, and it cannot point outside
+      # the package directory, so it is a copy that must not drift.
+      - id: readme-sync
+        name: "icechunk-python/README.md matches the root README.md"
+        entry: diff README.md icechunk-python/README.md
+        language: system
+        files: ^(README\.md|icechunk-python/README\.md)$
+        pass_filenames: false
+
       - id: rust-pre-commit-fast
         name: "Fast Rust checks (format, lint)"
         entry: just pre-commit-fast

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,5 +11,5 @@ build:
       - asdf global pixi latest
     build:
       html:
-        - pixi run -m icechunk-python/pyproject.toml just profile=ci develop
+        - pixi run -m icechunk-python/pyproject.toml just profile=docs develop --no-default-features
         - DISABLE_MKDOCS_2_WARNING=true pixi run -m icechunk-python/pyproject.toml just docs-build --site-dir $READTHEDOCS_OUTPUT/html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,16 @@ debug = 0
 [profile.ci.package."*"]
 opt-level = 1
 
+# The docs builder starts from an empty cargo cache on every build and only
+# needs an importable extension module, so nothing here trades compile time
+# for runtime speed.
+[profile.docs]
+inherits = "ci"
+incremental = false
+
+[profile.docs.package."*"]
+opt-level = 0
+
 # For convenience with cargo-samply
 [profile.samply]
 inherits = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,10 @@ debug = true
 inherits = "dev"
 opt-level = 0
 debug = 0
+# Jobs build once from a restored cache, so incremental state is never reused.
+incremental = false
+# Only the symbol table goes; llvm-cov reads its own sections, so coverage is unaffected.
+strip = "symbols"
 
 # Dependencies tend to cache better between runs,
 # enable a small bit of optimization in this case.
@@ -223,7 +227,6 @@ opt-level = 1
 # for runtime speed.
 [profile.docs]
 inherits = "ci"
-incremental = false
 
 [profile.docs.package."*"]
 opt-level = 0

--- a/icechunk-python/README.md
+++ b/icechunk-python/README.md
@@ -10,7 +10,7 @@
 
 ---
 > [!TIP]
-> **Icechunk 1.0 is released!** Better API, more performance and stability
+> **Icechunk 2.0 is released!** Better consistency, performance, and reliability for tensor storage
 ---
 
 Icechunk is an open-source (Apache 2.0), transactional storage engine for tensor / ND-array data designed for use on cloud object storage.


### PR DESCRIPTION
Couple independent changes, but too small for a PR for each one.

RTD was failing lately because it was hitting the build time limit. Using `opt-level = 0` there which should be much faster, and we don't really need any optimization for docs. Should be ~65% faster and stay inside limits.

Set `incremental = false` and `strip = "symbols"` to reduce cache size, they should be ~30% smaller now. Incremental doesn't help much in CI (better for local dev), and `strip` doesn't mess with coverage or any other checks we do in CI.

Partition the hypothesis shards explicitly, instead of using `pytest-shard`. It was too imbalanced, and hypothesis was the longest running part of CI. A fallback catches any new hypothesis tests, and we can rebalance again later.

Bring the `README` pre-commit check from #2144 so `icechunk-python/README.md` and `README.md` stay in sync. They can't be symlinks without generating issues, so at least this catches inconsistencies.