### PR TITLE
Stop mkdocs-jupyter from probing plain markdown pages

### DIFF
--- a/icechunk-python/docs/mkdocs.yml
+++ b/icechunk-python/docs/mkdocs.yml
@@ -148,6 +148,10 @@ plugins:
   - mkdocs-jupyter:
       include_source: True
       # include: ["*.ipynb"] # Default: ["*.py", "*.ipynb"]
+      # skip jupytext probing of plain .md pages: mkdocstrings "::: module"
+      # directives look like pandoc markdown and trigger pandoc subprocess
+      # conversions where pandoc is installed (e.g. RTD builders)
+      ignore: ["*.md"]
   - markdown-exec
   - redirects:
       redirect_maps:


### PR DESCRIPTION
mkdocs-jupyter was using pandoc (not installed locally in pixi/nix dev envs, but available in RTD) to process all the markdown files in the docs, which caused longer running times in RTD.

There is only one notebook (`glad-ingest.ipynb`) that needs `mkdocs-jupyter`, and nothing in the markdown files, so ignore them.
