### PR TITLE
Use storage `created_at` instead of host `flushed_at` during GC

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Garbage collection judged repo-info retention of an unreachable snapshot by its host-stamped `flushed_at`, but file deletion by the storage `created_at`. A snapshot falling between the two timestamps was dropped from the repo info — deleting the transaction logs its `pruned_ancestor_tx_logs` still referenced — while its snapshot file survived. Both decisions now use the storage `created_at` ([#2310](https://github.com/earth-mover/icechunk/pull/2310)).
+- Fix garbage collection deleting still-referenced transaction logs when the host and object-store clocks are skewed ([#2310](https://github.com/earth-mover/icechunk/pull/2310)).
 
 ## Python Icechunk Library 2.1.2
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Python Icechunk Library [unreleased]
+
+### Fixes
+
+- Garbage collection judged repo-info retention of an unreachable snapshot by its host-stamped `flushed_at`, but file deletion by the storage `created_at`. A snapshot falling between the two timestamps was dropped from the repo info — deleting the transaction logs its `pruned_ancestor_tx_logs` still referenced — while its snapshot file survived. Both decisions now use the storage `created_at` ([#2310](https://github.com/earth-mover/icechunk/pull/2310)).
+
 ## Python Icechunk Library 2.1.2
 
 ### Features

--- a/icechunk/src/ops/gc.rs
+++ b/icechunk/src/ops/gc.rs
@@ -411,12 +411,35 @@ async fn garbage_collect_one_attempt(
 
     let mut all_snaps = HashSet::new();
     let repo_info = if asset_manager.spec_version() > SpecVersionBin::V1 {
+        // The retention decision must use the same clock as the physical delete
+        // (storage created_at, see must_delete_snapshot). Judging it by flushed_at
+        // half-deletes a snapshot in the (flushed_at, created_at] window: it is
+        // dropped from the repo info (losing its pruned_ancestor_tx_logs
+        // references) while its file survives.
+        let created_at_by_id: HashMap<SnapshotId, DateTime<Utc>> =
+            if config.deletes_snapshots() {
+                asset_manager
+                    .list_snapshots()
+                    .await?
+                    .inspect_err(|e| error!("Listing snapshots: {e}"))
+                    .filter_map(|snap| ready(snap.ok().map(|s| (s.id, s.created_at))))
+                    .collect()
+                    .await
+            } else {
+                HashMap::new()
+            };
         let (ri, _) = asset_manager.fetch_repo_info().await?;
         non_pointed_but_new = ri
             .all_snapshots()?
             .filter_map_ok(|si| {
                 all_snaps.insert(si.id.clone());
-                if si.flushed_at >= snap_deadline { Some(si.id) } else { None }
+                // A snapshot not visible in the listing yet cannot be deleted by
+                // this run either, so it is retained.
+                if created_at_by_id.get(&si.id).is_none_or(|c| *c >= snap_deadline) {
+                    Some(si.id)
+                } else {
+                    None
+                }
             })
             .try_collect()?;
 

--- a/icechunk/src/ops/gc.rs
+++ b/icechunk/src/ops/gc.rs
@@ -421,10 +421,9 @@ async fn garbage_collect_one_attempt(
                 asset_manager
                     .list_snapshots()
                     .await?
-                    .inspect_err(|e| error!("Listing snapshots: {e}"))
-                    .filter_map(|snap| ready(snap.ok().map(|s| (s.id, s.created_at))))
-                    .collect()
-                    .await
+                    .map_ok(|s| (s.id, s.created_at))
+                    .try_collect()
+                    .await?
             } else {
                 HashMap::new()
             };

--- a/icechunk/tests/test_gc.rs
+++ b/icechunk/tests/test_gc.rs
@@ -23,6 +23,7 @@ use icechunk::{
     refs::Ref,
     repository::VersionInfo,
     session::get_chunk,
+    storage::latency::LatencyStorage,
 };
 use icechunk_macros::tokio_test;
 use pretty_assertions::assert_eq;
@@ -742,6 +743,85 @@ async fn test_gc_deletes_only_unreferenced_expired_tx_logs()
     // ...while the unreferenced ones are gone.
     assert!(asset_manager.fetch_transaction_log(&d).await.is_err());
     assert!(asset_manager.fetch_transaction_log(&e).await.is_err());
+    Ok(())
+}
+
+/// A snapshot whose host-stamped `flushed_at` and storage `created_at` straddle
+/// the GC cutoff must be retained in the repo info, because the file-delete
+/// gate (`created_at < cutoff`) keeps its file. Gating the repo-info decision
+/// on `flushed_at` instead half-deletes it: the snapshot vanishes from the repo
+/// info — losing its `pruned_ancestor_tx_logs` references, whose tx logs are
+/// then deleted — while its file survives on disk.
+#[tokio_test]
+async fn test_gc_retains_snapshot_between_flushed_and_created_at()
+-> Result<(), Box<dyn std::error::Error>> {
+    let inner: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+    // Write latency widens the (flushed_at, created_at] window the cutoff must
+    // land in.
+    let storage: Arc<dyn Storage + Send + Sync> =
+        Arc::new(LatencyStorage::new(inner, 20, 0));
+    let repo = Repository::create(None, Arc::clone(&storage), HashMap::new(), None, true)
+        .await?;
+    let am = Arc::clone(repo.asset_manager());
+
+    let a = commit_group(&repo, "main", "/a").await?;
+    repo.create_branch("feat", &a).await?;
+    let b = commit_group(&repo, "feat", "/b").await?;
+    let c = commit_group(&repo, "feat", "/c").await?;
+
+    // Expire /b (both branch tips are protected): /c is re-parented to the
+    // root, harvesting pruned_ancestor_tx_logs = [a, b].
+    let result = expire(
+        Arc::clone(&am),
+        Utc::now() + chrono::Duration::days(1),
+        ExpiredRefAction::Ignore,
+        ExpiredRefAction::Ignore,
+        None,
+        100,
+    )
+    .await?;
+    assert_eq!(result.released_snapshots.len(), 1);
+    assert!(result.edited_snapshots.contains(&c));
+
+    // Make /c unreachable; it stays in the repo info carrying its pruned refs.
+    repo.delete_branch("feat").await?;
+
+    // Cutoff exactly at /c's storage created_at: too new for the file gate,
+    // while its flushed_at (earlier by at least the write latency) is expired.
+    let c_created_at = am
+        .list_snapshots()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .find(|s| s.id == c)
+        .expect("snapshot /c not listed")
+        .created_at;
+    let (repo_info, _) = am.fetch_repo_info().await?;
+    assert!(repo_info.find_snapshot(&c)?.flushed_at < c_created_at);
+
+    let gc_config = GCConfig::clean_all(
+        c_created_at,
+        c_created_at,
+        None,
+        NonZeroU16::new(50).unwrap(),
+        NonZeroUsize::new(512 * 1024 * 1024).unwrap(),
+        NonZeroU16::new(500).unwrap(),
+        false,
+    );
+    let summary = garbage_collect(Arc::clone(&am), &gc_config, None, 100).await?;
+
+    // Only /b's snapshot file is deleted; /c's file is too new.
+    assert_eq!(summary.snapshots_deleted, 1);
+    // No tx log is deleted: /b's is referenced by /c's pruned refs, and /c is
+    // retained.
+    assert_eq!(summary.transaction_logs_deleted, 0);
+
+    // /c is still a repo snapshot, pruned refs intact, and /b's log fetchable.
+    let (repo_info, _) = am.fetch_repo_info().await?;
+    let kept = repo_info.find_snapshot(&c)?;
+    assert_eq!(kept.pruned_ancestor_tx_logs, vec![a.clone(), b.clone()]);
+    am.fetch_transaction_log(&b).await?;
     Ok(())
 }
 


### PR DESCRIPTION
First noticed this when using macOS for development, now it also appeared on a nightly stateful test (VersionControlTest, run [30410732472](https://github.com/earth-mover/icechunk/actions/runs/30410732472/job/90445972311)).

On macOS it was caused by drift in the VM clock where the rustfs container was running (mostly from closing the laptop lid and opening again later). #2167 fixed the failing test, but not the underlying problem.

Add a test mirroring the hypothesis example that triggered the bug.

---

`garbage_collect_one_attempt` does repo-info retention of unreachable snapshots on the host-stamped `flushed_at`, while file deletion uses the storage `created_at` (LIST mtime). A snapshot whose timestamps straddle the cutoff was half-deleted: dropped from the repo info (losing its `pruned_ancestor_tx_logs` references, whose transaction logs were then deleted), while its snapshot file survived on disk.