### PR TITLE
Limit what github actions are cached

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -42,8 +42,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/dependency-check.yaml
+++ b/.github/workflows/dependency-check.yaml
@@ -43,8 +43,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/publish-rust-library.yml
+++ b/.github/workflows/publish-rust-library.yml
@@ -33,8 +33,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -34,8 +34,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -83,8 +82,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -155,8 +153,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
           environments: py314t
@@ -191,8 +188,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
           environments: py314t
@@ -251,8 +247,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -335,8 +330,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -371,8 +365,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -411,8 +404,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -456,8 +448,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -484,8 +475,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -44,8 +44,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -242,8 +241,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -59,8 +59,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 
@@ -198,8 +197,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/rust-upstream.yaml
+++ b/.github/workflows/rust-upstream.yaml
@@ -45,13 +45,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: "zarrs_icechunk -> target"
-          shared-key: "upstream-zarrs"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
+      # No cargo cache: the build is dominated by icechunk itself, which is a path
+      # dependency and never cached, so the 800 MB entry saved no measurable time.
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}

--- a/.github/workflows/rust-upstream.yaml
+++ b/.github/workflows/rust-upstream.yaml
@@ -50,8 +50,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          cache: false
           activate-environment: true
           manifest-path: icechunk-python/pyproject.toml
 

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -51,8 +51,9 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          cache: true
-          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          # The win-64 env cache is 1.8 GB of the 10 GiB repo budget and saves ~1.5 min,
+          # while the rust caches it evicts are worth 10+ min each.
+          cache: false
           manifest-path: icechunk-python/pyproject.toml
           # environment activation doesn't work on windows
           # https://github.com/prefix-dev/setup-pixi/issues/122#issuecomment-2326495414

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -51,8 +51,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
-          # The win-64 env cache is 1.8 GB of the 10 GiB repo budget and saves ~1.5 min,
-          # while the rust caches it evicts are worth 10+ min each.
           cache: false
           manifest-path: icechunk-python/pyproject.toml
           # environment activation doesn't work on windows


### PR DESCRIPTION
- set `cache: false` for all `setup-pixi` uses, it is actually faster to let pixi rebuild them than restoring the cache from GHA...
- disable rust cache in `zarrs-upstream`, since the icechunk target wasn't being reused anyway