### PR TITLE
Don't fail when deleting a chunk key that cannot exist

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Fix garbage collection deleting still-referenced transaction logs when the host and object-store clocks are skewed ([#2310](https://github.com/earth-mover/icechunk/pull/2310)).
-- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every store shipped with zarr-python treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#2312](https://github.com/earth-mover/icechunk/pull/2312)).
+- Deleting a chunk key that cannot exist (coordinates outside the chunk grid, missing node, or a group path) is now a no-op instead of raising, matching zarr-python's stores. Writing a chunk outside the grid is still rejected ([#2312](https://github.com/earth-mover/icechunk/pull/2312)).
 - `to_icechunk` no longer passes `synchronizer` and `zarr_version` to xarray's `ZarrStore.open_group`; xarray removed both parameters and passing them made `to_icechunk` fail with a `TypeError` on xarray development versions ([#2312](https://github.com/earth-mover/icechunk/pull/2312)).
 
 ## Python Icechunk Library 2.1.2

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -13,6 +13,7 @@
 - A conditional write whose success response was lost in transit (connection drop, proxy timeout) used to surface as a spurious conflict after the transparent retry's precondition failed against Icechunk's own write: "tag already exists", "config was updated by other session", or a commit parent mismatch. Conditional writes are now stamped with a unique write id and read back on suspicious failures, so a write that landed is recognized as a success ([#2156](https://github.com/earth-mover/icechunk/pull/2156)).
 - Conditional operations on `object_store`-backed storage no longer strip quotes from ETags, which caused endless commit retries against stores that compare ETags exactly, such as `object_store` 0.14.1's `InMemory` and `LocalFileSystem` ([#2289](https://github.com/earth-mover/icechunk/pull/2289)).
 - Fix `to_icechunk` and `icechunk.dask.store_dask` failing with `AttributeError: 'function' object has no attribute 'session'` when the `dask-array` package is installed ([#2292](https://github.com/earth-mover/icechunk/pull/2292)).
+- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every other Zarr store treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#XXXX](https://github.com/earth-mover/icechunk/pull/XXXX)).
 
 ## Python Icechunk Library 2.1.1
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Python Icechunk Library [unreleased]
+
+### Fixes
+
+- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every other Zarr store treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#XXXX](https://github.com/earth-mover/icechunk/pull/XXXX)).
+
 ## Python Icechunk Library 2.1.2
 
 ### Features
@@ -13,7 +19,6 @@
 - A conditional write whose success response was lost in transit (connection drop, proxy timeout) used to surface as a spurious conflict after the transparent retry's precondition failed against Icechunk's own write: "tag already exists", "config was updated by other session", or a commit parent mismatch. Conditional writes are now stamped with a unique write id and read back on suspicious failures, so a write that landed is recognized as a success ([#2156](https://github.com/earth-mover/icechunk/pull/2156)).
 - Conditional operations on `object_store`-backed storage no longer strip quotes from ETags, which caused endless commit retries against stores that compare ETags exactly, such as `object_store` 0.14.1's `InMemory` and `LocalFileSystem` ([#2289](https://github.com/earth-mover/icechunk/pull/2289)).
 - Fix `to_icechunk` and `icechunk.dask.store_dask` failing with `AttributeError: 'function' object has no attribute 'session'` when the `dask-array` package is installed ([#2292](https://github.com/earth-mover/icechunk/pull/2292)).
-- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every other Zarr store treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#XXXX](https://github.com/earth-mover/icechunk/pull/XXXX)).
 
 ## Python Icechunk Library 2.1.1
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every store shipped with zarr-python treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#XXXX](https://github.com/earth-mover/icechunk/pull/XXXX)).
+- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every store shipped with zarr-python treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#2312](https://github.com/earth-mover/icechunk/pull/2312)).
+- `to_icechunk` no longer passes `synchronizer` and `zarr_version` to xarray's `ZarrStore.open_group`; xarray removed both parameters and passing them made `to_icechunk` fail with a `TypeError` on xarray development versions ([#2312](https://github.com/earth-mover/icechunk/pull/2312)).
 
 ## Python Icechunk Library 2.1.2
 

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every other Zarr store treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#XXXX](https://github.com/earth-mover/icechunk/pull/XXXX)).
+- Deleting a store key that cannot hold a chunk no longer raises: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group are all no-ops now, matching how every store shipped with zarr-python treats the deletion of an absent key, and how Icechunk already treats metadata keys. Writing a chunk outside the grid is still rejected ([#XXXX](https://github.com/earth-mover/icechunk/pull/XXXX)).
 
 ## Python Icechunk Library 2.1.2
 

--- a/icechunk-python/python/icechunk/xarray.py
+++ b/icechunk-python/python/icechunk/xarray.py
@@ -132,10 +132,8 @@ class _XarrayDatasetWriter:
             "append_dim": append_dim,
             "write_region": region,
             "safe_chunks": self.safe_chunks,
-            "synchronizer": None,
             "consolidated": False,
             "consolidate_on_close": False,
-            "zarr_version": None,
         }
 
         if Version(xr.__version__) >= Version("2025.06.0"):

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -431,8 +431,14 @@ def test_storage_chunk_sizes_granularity() -> None:
     # storage-key grid is the bug storage_chunk_sizes exists to avoid.
     assert sharded.cdata_shape == (2,)
     assert storage_chunk_sizes(plain) == ((30, 30, 30, 10), (40, 40))
-    empty = zarr.create_array(model, name="e", shape=(0,), chunks=(0,), dtype="i1")
+    empty = zarr.create_array(model, name="e", shape=(0,), chunks=(1,), dtype="i1")
     assert storage_chunk_sizes(empty) == ((),)
+    if Version(zarr.__version__) < Version("3.3.0"):
+        # zarr < 3.3 allows a zero cell size when the dimension is empty
+        cell_zero = zarr.create_array(
+            model, name="z", shape=(0,), chunks=(0,), dtype="i1"
+        )
+        assert storage_chunk_sizes(cell_zero) == ((),)
 
 
 async def test_shift_sharded_model_vs_store() -> None:

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -1,4 +1,5 @@
 import json
+import math
 import pickle
 from collections.abc import Callable
 from typing import Any, TypeVar
@@ -29,7 +30,6 @@ from icechunk.testing.trees import absolute, valid_moves
 from icechunk.testing.utils import update_paths_after_move
 from zarr import Array
 from zarr.core.buffer import default_buffer_prototype
-from zarr.core.common import ceildiv
 from zarr.testing.stateful import ZarrHierarchyStateMachine, split_prefix_name
 
 PROTOTYPE = default_buffer_prototype()
@@ -54,7 +54,7 @@ def storage_chunk_sizes(arr: "Array[Any]") -> tuple[tuple[int, ...], ...]:
     cell = arr.shards or arr.chunks
     # a zero-length dimension holds no chunks, and its cell size may be zero too
     return tuple(
-        tuple(min(c, s - i * c) for i in range(ceildiv(s, c)))
+        tuple(min(c, s - i * c) for i in range(math.ceil(s / c) if s else 0))
         for s, c in zip(arr.shape, cell, strict=True)
     )
 

--- a/icechunk-python/tests/test_zarr/test_stateful.py
+++ b/icechunk-python/tests/test_zarr/test_stateful.py
@@ -29,6 +29,7 @@ from icechunk.testing.trees import absolute, valid_moves
 from icechunk.testing.utils import update_paths_after_move
 from zarr import Array
 from zarr.core.buffer import default_buffer_prototype
+from zarr.core.common import ceildiv
 from zarr.testing.stateful import ZarrHierarchyStateMachine, split_prefix_name
 
 PROTOTYPE = default_buffer_prototype()
@@ -51,8 +52,9 @@ def storage_chunk_sizes(arr: "Array[Any]") -> tuple[tuple[int, ...], ...]:
     if hasattr(arr, "write_chunk_sizes"):
         return arr.write_chunk_sizes  # type: ignore[no-any-return]
     cell = arr.shards or arr.chunks
+    # a zero-length dimension holds no chunks, and its cell size may be zero too
     return tuple(
-        tuple(min(c, s - i * c) for i in range(-(-s // c)))
+        tuple(min(c, s - i * c) for i in range(ceildiv(s, c)))
         for s, c in zip(arr.shape, cell, strict=True)
     )
 
@@ -429,6 +431,8 @@ def test_storage_chunk_sizes_granularity() -> None:
     # storage-key grid is the bug storage_chunk_sizes exists to avoid.
     assert sharded.cdata_shape == (2,)
     assert storage_chunk_sizes(plain) == ((30, 30, 30, 10), (40, 40))
+    empty = zarr.create_array(model, name="e", shape=(0,), chunks=(0,), dtype="i1")
+    assert storage_chunk_sizes(empty) == ((),)
 
 
 async def test_shift_sharded_model_vs_store() -> None:

--- a/icechunk-python/tests/test_zarr/test_store/test_icechunk_store.py
+++ b/icechunk-python/tests/test_zarr/test_store/test_icechunk_store.py
@@ -5,8 +5,10 @@ import pickle
 from pathlib import Path
 from typing import Any, TypeVar
 
+import numpy as np
 import pytest
 
+import zarr
 from icechunk import IcechunkError, IcechunkStore, local_filesystem_storage
 from icechunk.repository import Repository
 from zarr.abc.store import OffsetByteRequest, RangeByteRequest, Store, SuffixByteRequest
@@ -374,6 +376,28 @@ class TestIcechunkStore(StoreTests[IcechunkStore, cpu.Buffer]):
         if not store.supports_deletes:
             pytest.skip("store does not support deletes")
         await store.delete("zarr.json")
+
+    async def test_delete_out_of_grid_chunk_does_not_raise(
+        self, store: IcechunkStore
+    ) -> None:
+        # A sharded array has one key per shard, so an index on the inner chunk
+        # grid (which is what `cdata_shape` counts) names a key that cannot exist.
+        arr = zarr.create_array(
+            store,
+            name="Y",
+            shape=(5,),
+            shards=(4,),
+            chunks=(2,),
+            dtype="i1",
+            fill_value=0,
+        )
+        arr[:] = np.arange(5, dtype="i1")
+        before = sorted(await _collect_aiterator(store.list_prefix("")))
+        assert "Y/c/2" not in before
+
+        await store.delete("Y/c/2")
+
+        assert sorted(await _collect_aiterator(store.list_prefix(""))) == before
 
     async def test_get_partial_values(  # type: ignore[override]
         self,

--- a/icechunk/src/store.rs
+++ b/icechunk/src/store.rs
@@ -531,10 +531,21 @@ impl Store {
                 };
                 Ok(session.delete_node(node.inject()?).await.inject()?)
             }
-            Key::Chunk { node_path, coords } => Ok(session
-                .delete_chunks(&node_path, vec![coords].into_iter())
-                .await
-                .inject()?),
+            Key::Chunk { node_path, coords } => {
+                // As for metadata keys above: a key that cannot exist is not an error
+                // to delete. There is no node, it is not an array, or the coordinates
+                // fall outside the array's chunk grid.
+                match session.delete_chunks(&node_path, vec![coords].into_iter()).await {
+                    Err(SessionError {
+                        kind:
+                            SessionErrorKind::NodeNotFound { .. }
+                            | SessionErrorKind::NotAnArray { .. }
+                            | SessionErrorKind::InvalidIndex { .. },
+                        ..
+                    }) => Ok(()),
+                    res => Ok(res.inject()?),
+                }
+            }
             Key::ZarrV2(_) => Ok(()),
         }
     }
@@ -2110,11 +2121,13 @@ mod tests {
             Err(StoreError{kind: StoreErrorKind::InvalidKey { key }, ..}) if key == "array/foo",
         ));
 
-        assert!(matches!(
-            store.delete("array/c/10/1/1").await,
-            Err(StoreError{kind: StoreErrorKind::SessionError(SessionErrorKind::InvalidIndex { coords, path }),..})
-                if path.to_string() == "/array" && coords == ChunkIndices([10, 1, 1].to_vec())
-        ));
+        store.set("array/c/1/1/1", data.clone()).await.unwrap();
+        // deleting a key that cannot hold a chunk is a no-op, and touches nothing else
+        store.delete("array/c/10/1/1").await.unwrap();
+        store.delete("no/such/node/c/0/0/0").await.unwrap();
+        // the root is a group, not an array
+        store.delete("c/0").await.unwrap();
+        assert_eq!(store.get("array/c/1/1/1", &ByteRange::ALL).await.unwrap(), data);
 
         Ok(())
     }


### PR DESCRIPTION
Address #1921 (but let the auto-closing check that runs on nightly close it)

Every store shipped with zarr-python treats deleting an absent key as a no-op, and zarr's internals rely on that behavior. Icechunk already did so for metadata keys and for missing-but-in-grid chunks. Three cases were exceptions and raised instead: chunk coordinates outside the array's chunk grid, paths with no node, and paths pointing at a group. `Store::delete` now treats all of them as no-ops. Writing a chunk outside the grid is still rejected.

This surfaced through Zarr's stateful hierarchy tests, which draw chunk indices from `cdata_shape`. That counts inner chunks, so for a sharded array it names keys that can never exist — one shard is one key. Those runs failed against Icechunk alone and left the nightly upstream-dev job red.

- Rust: `Store::delete` swallows `NodeNotFound` / `NotAnArray` / `InvalidIndex` for chunk keys, matching the existing metadata-key behavior. Read-only-session and IO errors still propagate.
- Tests: `test_chunk_delete` asserts the three no-op cases and that neighboring chunk data is untouched; a new store test covers the sharded-array key case end to end from Python.

## side fixes

Another nightly upstream-dev failure: `to_icechunk` passed `synchronizer=None` and `zarr_version=None` to xarray's `ZarrStore.open_group`. xarray removed both parameters on their main branch, turning every `to_icechunk` call into a `TypeError`. Both were the defaults in every supported xarray release, so they are simply no longer passed.

`storage_chunk_sizes` in the stateful test helper: it divided by the cell size, which zarr < 3.3 allows to be zero for a zero-length dimension. The division is now guarded so a zero-length dimension yields an empty chunk grid.