### PR TITLE
CI: fix cargo-deny (2026-08-19)

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -25,8 +25,12 @@ jobs:
   run:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    env:
+      HAS_SLACK_TOKEN: ${{ secrets.SLACK_APP_TOKEN != '' }}
     steps:
-      - uses: earth-mover/pr-review-bot@159af5b9dffde3f3ac3c85b005b248ea1b8b50c7 # main
+      # Fork PRs run without secrets; the bot cannot post to Slack there.
+      - if: ${{ env.HAS_SLACK_TOKEN == 'true' }}
+        uses: earth-mover/pr-review-bot@159af5b9dffde3f3ac3c85b005b248ea1b8b50c7 # main
         with:
           channel: C07C8TCQQRG
           board-name: Icechunk PR Board

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -527,7 +527,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
@@ -1472,7 +1472,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2163,7 +2163,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.17",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -2707,7 +2707,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3212,7 +3212,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3952,7 +3952,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4243,7 +4243,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.17",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -4390,7 +4390,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4468,7 +4468,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4907,7 +4907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5111,7 +5111,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -24,14 +24,10 @@ ignore = [
   # rustls-webpki v0.101.7 has a panic related to certificate list revocation.
   # we don't enable the `clr` feature that would trigger it.
   "RUSTSEC-2026-0104",
-  # quick-xml < 0.41.0 DoS advisories (quadratic attribute check / unbounded
-  # namespace allocation): transitive dep via object_store, used only to parse
-  # XML LIST/multipart responses from the S3/GCS/Azure endpoint. No upgrade path
-  # until object_store releases with quick-xml 0.41 (already on their main
-  # branch, unreleased as of 0.14.0). DoS-only (CVSS C:N/I:N/A:H), reachable
-  # only by a malicious/compromised object-store endpoint.
-  "RUSTSEC-2026-0194",
-  "RUSTSEC-2026-0195",
+  # h2 unbounded empty DATA frames (low severity): patched only in h2 >= 0.4.16.
+  # The h2 0.3 line is a transitive dep via aws-smithy-http-client -> hyper 0.14
+  # with no patched release. No upgrade path until the AWS SDK drops that stack.
+  "RUSTSEC-2026-0258",
 ]
 
 [licenses]


### PR DESCRIPTION
- `h2` bump to `0.4.17`
- only run PR review bot when slack token is present
- ignore `RUSTSEC-2026-0258` because it is in a transitive dependency and out of our control