### PR TITLE
Prepare v2.2.0

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -95,15 +95,6 @@ jobs:
           name: test-wheels
           path: icechunk-python/dist
 
-      - name: Restore cached hypothesis examples
-        id: restore-hypothesis-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: icechunk-python/.hypothesis/examples/
-          key: cache-hypothesis-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: |
-            cache-hypothesis-${{ runner.os }}-
-
       - name: Install dependencies - ${{ matrix.deps-version.name }}
         env:
           DEPS_NAME: ${{ matrix.deps-version.name }}
@@ -262,6 +253,7 @@ jobs:
 
       - name: Restore cached hypothesis examples
         id: restore-hypothesis-cache
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/examples/

--- a/.github/workflows/python-upstream.yaml
+++ b/.github/workflows/python-upstream.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Restore cached hypothesis examples
         id: restore-hypothesis-cache
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: icechunk-python/.hypothesis/examples/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-arrow-object-store"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-format"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "base32",
  "bytes",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-macros"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "quote",
  "syn 3.0.3",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-python"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-s3"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-storage"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "icechunk-types"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates
-icechunk = { path = "icechunk", version = "2.1.2" }
-icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.1.2", default-features = false }
-icechunk-format = { path = "icechunk-format", version = "2.1.2" }
-icechunk-macros = { path = "icechunk-macros", version = "2.1.2" }
-icechunk-s3 = { path = "icechunk-s3", version = "2.1.2" }
-icechunk-storage = { path = "icechunk-storage", version = "2.1.2" }
-icechunk-types = { path = "icechunk-types", version = "2.1.2" }
+icechunk = { path = "icechunk", version = "2.2.0" }
+icechunk-arrow-object-store = { path = "icechunk-arrow-object-store", version = "2.2.0", default-features = false }
+icechunk-format = { path = "icechunk-format", version = "2.2.0" }
+icechunk-macros = { path = "icechunk-macros", version = "2.2.0" }
+icechunk-s3 = { path = "icechunk-s3", version = "2.2.0" }
+icechunk-storage = { path = "icechunk-storage", version = "2.2.0" }
+icechunk-types = { path = "icechunk-types", version = "2.2.0" }
 
 # External dependencies
 anyhow = "1.0.102"

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -2,10 +2,13 @@
 
 ## Python Icechunk Library [unreleased]
 
+## Python Icechunk Library 2.2.0
+
 ### Features
 
 - The `inspect_*` methods now report a `header` for the file they read: the library version that wrote it, and that file's spec version, file type and compression ([#2347](https://github.com/earth-mover/icechunk/pull/2347)).
 - Add `hf_storage`, a preset for Hugging Face Storage Buckets. It takes the bucket's `namespace`. It sets the gateway endpoint, the region and path-style URLs. The gateway discards user metadata, so Icechunk cannot recover from a lost response to a conditional write ([#2346](https://github.com/earth-mover/icechunk/pull/2346)).
+- Add `branch` (`list`, `create`, `delete`), `tag` (`list`, `create`, `delete`) and `ancestry` subcommands to the `icechunk` command line interface ([#2299](https://github.com/earth-mover/icechunk/pull/2299)).
 
 ### Fixes
 
@@ -15,6 +18,10 @@
 - Writing a chunk with length 0 is now rejected instead of being committed. A chunk must decode to the full chunk shape, so no valid chunk is ever zero bytes long, and such a chunk could only fail once it was read back — long after the commit that introduced it. This is how a sparse GeoTIFF's unstored tiles (`offset = 0, byteCount = 0`) used to reach a repository. Applies to inline, virtual and materialized chunks alike, which means Icechunk deliberately rejects an empty write at a chunk key where a plain key-value store would accept it, in the same way it already rejects invalid zarr keys and invalid metadata. To record that a chunk is not stored at all, delete it rather than writing a zero-length one; it then reads back as the array's fill value ([#2328](https://github.com/earth-mover/icechunk/issues/2328)).
 - Object metadata keys no longer contain `_`: they are now `icspecver`, `icclient`, `icfiletype`, `iccompalg` and `icechunkwriteid`. S3 gateways fronted by nginx dropped the old names, which failed writes with `AccessDenied: There were headers present in the request which were not signed`. The old names stay available as `*_DEPRECATED` constants ([#2354](https://github.com/earth-mover/icechunk/pull/2354)).
 - S3 endpoints whose URL includes a path no longer fail with `NoSuchBucket`. Hugging Face Storage Buckets use such a URL: `https://s3.hf.co/<namespace>`. The AWS SDK joins the endpoint path and the bucket name without a separator. Requests therefore addressed `/<namespace><bucket>/<key>`. Icechunk now appends the missing `/`. Endpoints without a path, such as Tigris, R2 and MinIO, keep the same behavior ([#2346](https://github.com/earth-mover/icechunk/pull/2346)).
+
+### Performance
+
+- Writing to a store no longer copies the NumPy buffer: `set` and `set_if_not_exists` pass the buffer through instead of converting it to `bytes`. `PyStore.set` and `PyStore.set_if_not_exists` now accept `BytesLike` ([#2332](https://github.com/earth-mover/icechunk/pull/2332)).
 
 ## Python Icechunk Library 2.1.2
 

--- a/icechunk-arrow-object-store/Cargo.toml
+++ b/icechunk-arrow-object-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-arrow-object-store"
-version = "2.1.2"
+version = "2.2.0"
 description = "Apache Arrow object_store storage backend for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-format/Cargo.toml
+++ b/icechunk-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-format"
-version = "2.1.2"
+version = "2.2.0"
 description = "Binary format types and serialization for the Icechunk storage engine"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-js/index.js
+++ b/icechunk-js/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-android-arm64')
         const bindingPackageVersion = require('@earthmover/icechunk-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-android-arm-eabi')
         const bindingPackageVersion = require('@earthmover/icechunk-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-win32-x64-gnu')
         const bindingPackageVersion = require('@earthmover/icechunk-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-win32-x64-msvc')
         const bindingPackageVersion = require('@earthmover/icechunk-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-win32-ia32-msvc')
         const bindingPackageVersion = require('@earthmover/icechunk-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-win32-arm64-msvc')
         const bindingPackageVersion = require('@earthmover/icechunk-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@earthmover/icechunk-darwin-universal')
       const bindingPackageVersion = require('@earthmover/icechunk-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-darwin-x64')
         const bindingPackageVersion = require('@earthmover/icechunk-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-darwin-arm64')
         const bindingPackageVersion = require('@earthmover/icechunk-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-freebsd-x64')
         const bindingPackageVersion = require('@earthmover/icechunk-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-freebsd-arm64')
         const bindingPackageVersion = require('@earthmover/icechunk-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-x64-musl')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-x64-gnu')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-arm64-musl')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-arm64-gnu')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-arm-musleabihf')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-loong64-musl')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-loong64-gnu')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-riscv64-musl')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@earthmover/icechunk-linux-riscv64-gnu')
           const bindingPackageVersion = require('@earthmover/icechunk-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-linux-ppc64-gnu')
         const bindingPackageVersion = require('@earthmover/icechunk-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-linux-s390x-gnu')
         const bindingPackageVersion = require('@earthmover/icechunk-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-openharmony-arm64')
         const bindingPackageVersion = require('@earthmover/icechunk-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-openharmony-x64')
         const bindingPackageVersion = require('@earthmover/icechunk-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@earthmover/icechunk-openharmony-arm')
         const bindingPackageVersion = require('@earthmover/icechunk-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/icechunk-js/package.json
+++ b/icechunk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthmover/icechunk",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "JavaScript/TypeScript bindings for Icechunk",
   "main": "index.js",
   "repository": {

--- a/icechunk-macros/Cargo.toml
+++ b/icechunk-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "icechunk-macros"
 description = "Support and helper macros for the Icechunk library"
-version = "2.1.2"
+version = "2.2.0"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"
 homepage = "https://icechunk.io"

--- a/icechunk-python/Cargo.toml
+++ b/icechunk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-python"
-version = "2.1.2"
+version = "2.2.0"
 description = "Transactional storage engine for Zarr designed for use on cloud object storage"
 readme = "README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-s3/Cargo.toml
+++ b/icechunk-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-s3"
-version = "2.1.2"
+version = "2.2.0"
 description = "Native AWS S3 storage backend for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-storage/Cargo.toml
+++ b/icechunk-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-storage"
-version = "2.1.2"
+version = "2.2.0"
 description = "Storage trait and shared types for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk-types/Cargo.toml
+++ b/icechunk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk-types"
-version = "2.1.2"
+version = "2.2.0"
 description = "Shared foundational types for icechunk"
 readme = "../README.md"
 repository = "https://github.com/earth-mover/icechunk"

--- a/icechunk/Cargo.toml
+++ b/icechunk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icechunk"
-version = "2.1.2"
+version = "2.2.0"
 description = "Transactional storage engine for Zarr designed for use on cloud object storage"
 readme = "README.md"
 repository = "https://github.com/earth-mover/icechunk"


### PR DESCRIPTION
- Update changelog with some missing PRs
- Ran `just ci-js` to regenerate the JS bindings
- Only reuse hypothesis DB on `main`/`nightly`