### PR TITLE
GC: reduce redundant snapshot IO

### DIFF
--- a/icechunk/src/lib.rs
+++ b/icechunk/src/lib.rs
@@ -79,7 +79,15 @@ pub(crate) mod test_utils {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    #[expect(unused_imports)]
+    use std::{collections::HashMap, sync::Arc};
+
+    use bytes::Bytes;
+
+    use crate::{
+        Repository, Storage, asset_manager::AssetManager, format::Path, storage,
+        storage::logging::LoggingStorage,
+    };
+
     use crate::format::format_constants::SpecVersionBin;
 
     #[template]
@@ -87,6 +95,56 @@ pub(crate) mod test_utils {
     #[case::v1(SpecVersionBin::V1)]
     #[case::v2(SpecVersionBin::V2)]
     pub fn spec_version_cases(#[case] spec_version: SpecVersionBin) {}
+
+    /// A V2 repo whose history is `INITIAL -> c0 -> .. -> c4` on `main`, with a
+    /// tag at `c2` and both a tag and a branch at `c4`, so the ancestries of
+    /// the three refs converge.
+    pub(crate) async fn repo_with_converging_refs(
+        backend: &Arc<dyn Storage + Send + Sync>,
+    ) -> Result<Repository, Box<dyn std::error::Error>> {
+        let repo = Repository::create(
+            None,
+            Arc::clone(backend),
+            HashMap::new(),
+            Some(SpecVersionBin::V2),
+            true,
+        )
+        .await?;
+        for i in 0..5u32 {
+            let mut session = repo.writable_session("main").await?;
+            let path: Path = format!("/g{i}").as_str().try_into().unwrap();
+            session.add_group(path, Bytes::new()).await?;
+            let snap = session.commit("commit").max_concurrent_nodes(8).execute().await?;
+            if i == 2 {
+                repo.create_tag("mid", &snap).await?;
+            }
+            if i == 4 {
+                repo.create_tag("tip", &snap).await?;
+                repo.create_branch("other", &snap).await?;
+            }
+        }
+        Ok(repo)
+    }
+
+    /// An `AssetManager` over `backend` that caches nothing, so every fetch
+    /// reaches storage, paired with the [`LoggingStorage`] recording those
+    /// fetches. For tests that count reads.
+    pub(crate) fn logging_asset_manager(
+        backend: &Arc<dyn Storage + Send + Sync>,
+        storage_settings: storage::Settings,
+        spec_version: SpecVersionBin,
+    ) -> (Arc<LoggingStorage>, Arc<AssetManager>) {
+        let logging = Arc::new(LoggingStorage::new(Arc::clone(backend)));
+        let logging_dyn: Arc<dyn Storage + Send + Sync> = Arc::clone(&logging) as _;
+        let asset_manager = Arc::new(AssetManager::new_no_cache(
+            logging_dyn,
+            storage_settings,
+            spec_version,
+            1,
+            100,
+        ));
+        (logging, asset_manager)
+    }
 }
 
 mod private {

--- a/icechunk/src/ops/gc.rs
+++ b/icechunk/src/ops/gc.rs
@@ -26,7 +26,7 @@ use crate::{
         repo_info::{RepoAvailability, RepoInfo, UpdateInfo, UpdateType},
         snapshot::{ManifestFileInfo, Snapshot, SnapshotInfo},
     },
-    ops::pointed_snapshots,
+    ops::{pointed_snapshots, reachable_snapshots_v2},
     refs::{Ref, RefError},
     repository::{RepositoryError, RepositoryErrorKind, RepositoryResult},
     storage::{self, DeleteObjectsResult, ListInfo},
@@ -409,6 +409,14 @@ async fn garbage_collect_one_attempt(
 
     let mut non_pointed_but_new = HashSet::new();
 
+    // The snapshot objects in storage, listed once and reused by the delete
+    // pass below. Values are each object's `(created_at, size_bytes)`: the
+    // first decides retention and the physical delete, the second only feeds
+    // the summary's byte count.
+    // `None` when we never listed them: V1 repos, which don't need the
+    // retention check, and runs that keep snapshots, which don't delete any.
+    let mut listed_snaps: Option<HashMap<SnapshotId, (DateTime<Utc>, u64)>> = None;
+
     let mut all_snaps = HashSet::new();
     let repo_info = if asset_manager.spec_version() > SpecVersionBin::V1 {
         // The retention decision must use the same clock as the physical delete
@@ -416,29 +424,33 @@ async fn garbage_collect_one_attempt(
         // half-deletes a snapshot in the (flushed_at, created_at] window: it is
         // dropped from the repo info (losing its pruned_ancestor_tx_logs
         // references) while its file survives.
-        let created_at_by_id: HashMap<SnapshotId, DateTime<Utc>> =
-            if config.deletes_snapshots() {
+        if config.deletes_snapshots() {
+            listed_snaps = Some(
                 asset_manager
                     .list_snapshots()
                     .await?
-                    .map_ok(|s| (s.id, s.created_at))
+                    .map_ok(|s| (s.id, (s.created_at, s.size_bytes)))
                     .try_collect()
-                    .await?
-            } else {
-                HashMap::new()
-            };
+                    .await?,
+            );
+        }
         let (ri, _) = asset_manager.fetch_repo_info().await?;
+        let reachable = reachable_snapshots_v2(ri.as_ref(), &config.extra_roots)?;
         non_pointed_but_new = ri
             .all_snapshots()?
             .filter_map_ok(|si| {
                 all_snaps.insert(si.id.clone());
+                if reachable.contains(&si.id) {
+                    return None;
+                }
                 // A snapshot not visible in the listing yet cannot be deleted by
                 // this run either, so it is retained.
-                if created_at_by_id.get(&si.id).is_none_or(|c| *c >= snap_deadline) {
-                    Some(si.id)
-                } else {
-                    None
-                }
+                let old_enough_to_drop = listed_snaps.as_ref().is_some_and(|listed| {
+                    listed
+                        .get(&si.id)
+                        .is_some_and(|(created_at, _)| *created_at < snap_deadline)
+                });
+                if old_enough_to_drop { None } else { Some(si.id) }
             })
             .try_collect()?;
 
@@ -447,14 +459,20 @@ async fn garbage_collect_one_attempt(
         None
     };
 
-    let pointed_snaps =
-        pointed_snapshots(Arc::clone(&asset_manager), &config.extra_roots).await?;
+    let pointed_snaps = pointed_snapshots(
+        Arc::clone(&asset_manager),
+        repo_info.clone(),
+        &config.extra_roots,
+        config.max_snapshots_in_memory,
+    )
+    .await?;
     let am = Arc::clone(&asset_manager);
-    let non_pointed_snaps = stream::iter(non_pointed_but_new.into_iter().map(Ok))
-        .and_then(move |id| {
+    let non_pointed_snaps = stream::iter(non_pointed_but_new)
+        .map(move |id| {
             let am = Arc::clone(&am);
             async move { am.fetch_snapshot(&id).await }
-        });
+        })
+        .buffer_unordered(config.max_snapshots_in_memory.get() as usize);
 
     let (keep_chunks, keep_manifests, mut keep_snapshots) = find_retained(
         Arc::clone(&asset_manager),
@@ -491,7 +509,22 @@ async fn garbage_collect_one_attempt(
             .await?;
         }
         debug!("Garbage collecting snapshots");
-        let res = gc_snapshots(asset_manager.as_ref(), config, &keep_snapshots).await?;
+        let res = match listed_snaps.take() {
+            Some(listed) => {
+                let candidates = stream::iter(listed.into_iter().map(
+                    |(id, (created_at, size_bytes))| {
+                        Ok(ListInfo { id, created_at, size_bytes })
+                    },
+                ));
+                gc_snapshots(asset_manager.as_ref(), config, &keep_snapshots, candidates)
+                    .await?
+            }
+            None => {
+                let candidates = asset_manager.list_snapshots().await?;
+                gc_snapshots(asset_manager.as_ref(), config, &keep_snapshots, candidates)
+                    .await?
+            }
+        };
         summary.snapshots_deleted = res.deleted_objects;
         summary.bytes_deleted += res.deleted_bytes;
     }
@@ -762,16 +795,16 @@ pub async fn gc_manifests(
     }
 }
 
-#[instrument(skip(asset_manager,  config, keep_ids), fields(keep_ids.len = keep_ids.len()))]
+/// `snapshots` are the delete candidates
+#[instrument(skip(asset_manager,  config, keep_ids, snapshots), fields(keep_ids.len = keep_ids.len()))]
 pub async fn gc_snapshots(
     asset_manager: &AssetManager,
     config: &GCConfig,
     keep_ids: &HashSet<SnapshotId>,
+    snapshots: impl Stream<Item = RepositoryResult<ListInfo<SnapshotId>>> + Send,
 ) -> GCResult<DeleteObjectsResult> {
     info!("Deleting snapshots");
-    let to_delete = asset_manager
-        .list_snapshots()
-        .await?
+    let to_delete = snapshots
         .inspect_err(|e| error!("Deleting snapshots: {e}"))
         .filter_map(move |snapshot| {
             ready(snapshot.ok().and_then(|snapshot| {
@@ -1255,4 +1288,69 @@ async fn expire_v2_one_attempt(
 
     debug!("Expiration done");
     Ok(ExpireResult { released_snapshots, edited_snapshots, deleted_refs: deleted_tags })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap as StdHashMap;
+
+    use chrono::Duration;
+    use icechunk_macros::tokio_test;
+
+    use super::*;
+    use crate::{
+        Storage,
+        format::SNAPSHOTS_FILE_PATH,
+        storage::new_in_memory_storage,
+        test_utils::{logging_asset_manager, repo_with_converging_refs},
+    };
+
+    /// GC must read each snapshot at most once. Snapshots newer than the
+    /// metadata cutoff used to be fetched twice: once walking the ref
+    /// ancestries and again as (supposedly) non-pointed but new.
+    #[tokio_test]
+    async fn test_gc_reads_each_snapshot_once() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let backend: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+        let repo = repo_with_converging_refs(&backend).await?;
+        let (logging, asset_manager) = logging_asset_manager(
+            &backend,
+            repo.storage_settings().clone(),
+            SpecVersionBin::V2,
+        );
+
+        // a cutoff in the past leaves every snapshot newer than the deadline,
+        // which is what put them all in `non_pointed_but_new`
+        let cutoff = Utc::now() - Duration::hours(1);
+        let config = GCConfig::clean_all(
+            cutoff,
+            cutoff,
+            None,
+            NonZeroU16::new(10).unwrap(),
+            NonZeroUsize::new(1_000_000_000).unwrap(),
+            NonZeroU16::new(10).unwrap(),
+            true,
+        );
+        garbage_collect(Arc::clone(&asset_manager), &config, None, 10).await?;
+
+        let snapshot_prefix = format!("{SNAPSHOTS_FILE_PATH}/");
+        let mut reads_per_snapshot: StdHashMap<String, usize> = StdHashMap::new();
+        let mut snapshot_listings = 0;
+        for (op, path) in logging.fetch_operations() {
+            if op == "list_objects" {
+                if path == SNAPSHOTS_FILE_PATH {
+                    snapshot_listings += 1;
+                }
+            } else if path.starts_with(&snapshot_prefix) {
+                *reads_per_snapshot.entry(path).or_default() += 1;
+            }
+        }
+        assert_eq!(snapshot_listings, 1, "the snapshots prefix was listed twice");
+        let repeated: Vec<_> =
+            reads_per_snapshot.iter().filter(|(_, n)| **n > 1).collect();
+        assert!(repeated.is_empty(), "snapshots read more than once: {repeated:?}");
+        // 5 commits plus the initial snapshot
+        assert_eq!(reads_per_snapshot.len(), 6);
+        Ok(())
+    }
 }

--- a/icechunk/src/ops/mod.rs
+++ b/icechunk/src/ops/mod.rs
@@ -1,6 +1,6 @@
 //! Repository maintenance operations.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, num::NonZeroU16, sync::Arc};
 
 use async_stream::try_stream;
 use futures::{Stream, StreamExt as _, TryStreamExt as _, stream};
@@ -42,37 +42,44 @@ pub fn all_roots_v2<'a>(
     Ok(res)
 }
 
+/// Ids of every snapshot reachable from a ref or an `extra_roots` entry,
+/// computed from `repo_info` alone (no IO).
 #[instrument(skip_all)]
-pub async fn pointed_snapshots_v2<'a>(
-    asset_manager: Arc<AssetManager>,
-    extra_roots: &'a HashSet<SnapshotId>,
-) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + 'a> {
+pub fn reachable_snapshots_v2(
+    repo_info: &RepoInfo,
+    extra_roots: &HashSet<SnapshotId>,
+) -> RepositoryResult<HashSet<SnapshotId>> {
     let mut seen: HashSet<SnapshotId> = HashSet::new();
-    let (repo_info, _) = asset_manager.fetch_repo_info().await?;
-    let res = try_stream! {
-
-        let roots = all_roots_v2(repo_info.as_ref(), extra_roots)?;
-        for pointed_snap_id in roots {
-            let pointed_snap_id = pointed_snap_id?;
-            if ! seen.contains(&pointed_snap_id)
-            {
-                let parents = repo_info.ancestry(&pointed_snap_id).inject()?;
-                for snap_info in parents {
-                    let snap_id = snap_info.inject()?.id;
-                    let snap: Arc<Snapshot> = asset_manager.fetch_snapshot(&snap_id).await?;
-                    if seen.insert(snap_id) { // it's a new snapshot
-                        yield snap
-                    } else {
-                        // as soon as we find a repeated snapshot
-                        // there is no point in continuing to retrieve
-                        // the rest of the ancestry, it must be already
-                        // retrieved from other ref
-                        break
-                    }
+    for pointed_snap_id in all_roots_v2(repo_info, extra_roots)? {
+        let pointed_snap_id = pointed_snap_id?;
+        if !seen.contains(&pointed_snap_id) {
+            for snap_info in repo_info.ancestry(&pointed_snap_id).inject()? {
+                if !seen.insert(snap_info.inject()?.id) {
+                    // the rest of the ancestry came in with the snapshot we already have
+                    break;
                 }
             }
         }
-    };
+    }
+    Ok(seen)
+}
+
+/// Fetches up to `max_concurrent_fetches` snapshots at a time, in no
+/// particular order.
+#[instrument(skip_all)]
+pub fn pointed_snapshots_v2(
+    asset_manager: Arc<AssetManager>,
+    repo_info: &RepoInfo,
+    extra_roots: &HashSet<SnapshotId>,
+    max_concurrent_fetches: NonZeroU16,
+) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + use<>> {
+    let ids = reachable_snapshots_v2(repo_info, extra_roots)?;
+    let res = stream::iter(ids)
+        .map(move |id| {
+            let asset_manager = Arc::clone(&asset_manager);
+            async move { asset_manager.fetch_snapshot(&id).await }
+        })
+        .buffer_unordered(max_concurrent_fetches.get() as usize);
     Ok(res)
 }
 
@@ -134,16 +141,34 @@ pub async fn all_roots_v1<'a>(
     Ok(roots)
 }
 
+/// `repo_info` is ignored for V1 repos, which have no repo info object. For V2
+/// it is fetched when not supplied; pass the one you already hold to keep the
+/// walk consistent with anything else you derived from it.
+///
+/// `max_concurrent_fetches` only applies to V2: a V1 ancestry is a pointer
+/// chase through the snapshot files, so its reads stay sequential.
 pub async fn pointed_snapshots<'a>(
     asset_manager: Arc<AssetManager>,
+    repo_info: Option<Arc<RepoInfo>>,
     extra_roots: &'a HashSet<SnapshotId>,
+    max_concurrent_fetches: NonZeroU16,
 ) -> RepositoryResult<impl Stream<Item = RepositoryResult<Arc<Snapshot>>> + 'a> {
     match asset_manager.spec_version() {
         SpecVersionBin::V1 => {
             Ok(pointed_snapshots_v1(asset_manager, extra_roots).await?.left_stream())
         }
         SpecVersionBin::V2 => {
-            Ok(pointed_snapshots_v2(asset_manager, extra_roots).await?.right_stream())
+            let repo_info = match repo_info {
+                Some(repo_info) => repo_info,
+                None => asset_manager.fetch_repo_info().await?.0,
+            };
+            Ok(pointed_snapshots_v2(
+                asset_manager,
+                repo_info.as_ref(),
+                extra_roots,
+                max_concurrent_fetches,
+            )?
+            .right_stream())
         }
     }
 }
@@ -153,13 +178,18 @@ mod tests {
     use futures::TryStreamExt as _;
     use std::{
         collections::{HashMap, HashSet},
+        num::NonZeroU16,
         sync::Arc,
     };
 
     use bytes::Bytes;
 
     use crate::{
-        Repository, format::Path, new_in_memory_storage, ops::pointed_snapshots,
+        Repository, Storage,
+        format::{Path, SNAPSHOTS_FILE_PATH, format_constants::SpecVersionBin},
+        new_in_memory_storage,
+        ops::pointed_snapshots,
+        test_utils::{logging_asset_manager, repo_with_converging_refs},
     };
 
     #[tokio::test]
@@ -178,13 +208,52 @@ mod tests {
         let snap = session.commit("commit").max_concurrent_nodes(8).execute().await?;
         repo.create_tag("tag2", &snap).await?;
 
-        let all_snaps =
-            pointed_snapshots(Arc::clone(repo.asset_manager()), &HashSet::new())
-                .await?
-                .try_collect::<Vec<_>>()
-                .await?;
+        let all_snaps = pointed_snapshots(
+            Arc::clone(repo.asset_manager()),
+            None,
+            &HashSet::new(),
+            NonZeroU16::new(10).unwrap(),
+        )
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
 
         assert_eq!(all_snaps.len(), 3);
+        Ok(())
+    }
+
+    /// Refs whose ancestries converge must not re-read the snapshot they
+    /// converge on: every reachable snapshot is fetched exactly once.
+    #[tokio::test]
+    async fn test_pointed_snapshots_v2_fetches_each_snapshot_once()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let backend: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+        let repo = repo_with_converging_refs(&backend).await?;
+        let (logging, asset_manager) = logging_asset_manager(
+            &backend,
+            repo.storage_settings().clone(),
+            SpecVersionBin::V2,
+        );
+
+        let all_snaps = pointed_snapshots(
+            asset_manager,
+            None,
+            &HashSet::new(),
+            NonZeroU16::new(10).unwrap(),
+        )
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
+
+        // 5 commits plus the initial snapshot
+        assert_eq!(all_snaps.len(), 6);
+
+        let snapshot_reads = logging
+            .fetch_operations()
+            .into_iter()
+            .filter(|(_, path)| path.starts_with(SNAPSHOTS_FILE_PATH))
+            .count();
+        assert_eq!(snapshot_reads, 6);
         Ok(())
     }
 }

--- a/icechunk/src/ops/stats.rs
+++ b/icechunk/src/ops/stats.rs
@@ -160,10 +160,11 @@ async fn unique_manifest_infos<'a>(
     max_snapshots_in_memory: NonZeroU16,
 ) -> RepositoryResult<impl TryStream<Ok = ManifestFileInfo, Error = RepositoryError> + 'a>
 {
-    let all_snaps = pointed_snapshots(asset_manager, extra_roots)
-        .await?
-        .map(ready)
-        .buffer_unordered(max_snapshots_in_memory.get() as usize);
+    let all_snaps =
+        pointed_snapshots(asset_manager, None, extra_roots, max_snapshots_in_memory)
+            .await?
+            .map(ready)
+            .buffer_unordered(max_snapshots_in_memory.get() as usize);
     let all_manifest_infos = all_snaps
         // this could be slightly optimized by not collecting all manifest info records into a vec
         // but we don't expect too many, and they are small anyway


### PR DESCRIPTION
- pointed snapshots were fetched again as `non_pointed_but_new`, which filtered by age only
- `pointed_snapshots_v2` fetched each ancestor before checking `seen`
- V2 snapshot fetches were serial; they now use `buffer_unordered`
- the snapshots prefix was listed twice; the first listing is reused