### PR TITLE
fix: report actual_parent in `reset_branch_v2` conflict error

### DIFF
--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -2479,6 +2479,38 @@ mod tests {
         Ok(())
     }
 
+    /// `reset_branch` used to report `from_snapshot_id` as both the expected and
+    /// the actual parent, so a real conflict printed as `(Some(X)) != (Some(X))`.
+    #[tokio::test]
+    async fn test_reset_branch_conflict_reports_actual_parent()
+    -> Result<(), Box<dyn Error>> {
+        let storage: Arc<dyn Storage + Send + Sync> = new_in_memory_storage().await?;
+        let repo = Repository::create(
+            None,
+            Arc::clone(&storage),
+            HashMap::new(),
+            Some(SpecVersionBin::V2),
+            true,
+        )
+        .await?;
+
+        let tip = repo.lookup_branch("main").await?;
+        let stale = SnapshotId::random();
+        let err = repo.reset_branch("main", &tip, Some(&stale)).await.unwrap_err();
+
+        assert!(
+            matches!(
+                &err.kind,
+                RepositoryErrorKind::Conflict {
+                    expected_parent: Some(expected),
+                    actual_parent: Some(actual),
+                } if expected == &stale && actual == &tip
+            ),
+            "expected a conflict naming the real branch tip, got: {err}"
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_manifest_preload_default_condition() {
         let condition =

--- a/icechunk/src/repository.rs
+++ b/icechunk/src/repository.rs
@@ -1363,13 +1363,16 @@ impl Repository {
         from_snapshot_id: Option<&SnapshotId>,
     ) -> RepositoryResult<()> {
         let do_update = |repo_info: Arc<RepoInfo>, backup_path: &str, _| {
-            if let Some(from_snapshot_id) = from_snapshot_id
-                && &repo_info.resolve_branch(branch).inject()? != from_snapshot_id
-            {
-                return Err(RepositoryError::capture(RepositoryErrorKind::Conflict {
-                    expected_parent: Some(from_snapshot_id.clone()),
-                    actual_parent: Some(from_snapshot_id.clone()),
-                }));
+            if let Some(from_snapshot_id) = from_snapshot_id {
+                let actual_parent = repo_info.resolve_branch(branch).inject()?;
+                if &actual_parent != from_snapshot_id {
+                    return Err(RepositoryError::capture(
+                        RepositoryErrorKind::Conflict {
+                            expected_parent: Some(from_snapshot_id.clone()),
+                            actual_parent: Some(actual_parent),
+                        },
+                    ));
+                }
             }
             let num_updates = self.config.num_updates_per_repo_info_file();
 


### PR DESCRIPTION
I recently encountered the following counter-intuitive error in a reset branch operation (note that the id is the same on both sides of the inequality statement). This PR changes the report to show the actual parent tip, rather than the expected parent twice.

```
2026-09-03T21:34:45 [ERROR] IcechunkError:   x branch update conflict: `(Some(66ZQG62FHEZDGXHMRJF0)) != (Some(66ZQG62FHEZDGXHMRJF0))`
2026-09-03T21:34:45 |
2026-09-03T21:34:45 | context:
2026-09-03T21:34:45 |    0: icechunk::asset_manager::update_repo_info_internal
2026-09-03T21:34:45 |            with skip_online_check=false
2026-09-03T21:34:45 |              at icechunk/src/asset_manager.rs:815
2026-09-03T21:34:45 |    1: icechunk::asset_manager::update_repo_info
2026-09-03T21:34:45 |              at icechunk/src/asset_manager.rs:784
2026-09-03T21:34:45 |    2: icechunk::repository::reset_branch_v2
2026-09-03T21:34:45 |            with branch="main" to_snapshot_id=E7F0SPKAMCV3P52TY4G0 from_snapshot_id=Some(66ZQG62FHEZDGXHMRJF0)
2026-09-03T21:34:45 |              at icechunk/src/repository.rs:1358
2026-09-03T21:34:45 |    3: icechunk::repository::reset_branch
2026-09-03T21:34:45 |            with branch="main" to_snapshot_id=E7F0SPKAMCV3P52TY4G0 from_snapshot_id=Some(66ZQG62FHEZDGXHMRJF0)
2026-09-03T21:34:45 |              at icechunk/src/repository.rs:1316
2026-09-03T21:34:45 |
2026-09-03T21:34:45 `-> branch update conflict: `(Some(66ZQG62FHEZDGXHMRJF0)) != (Some(66ZQG62FHEZDGXHMRJF0))`
    self._repository.reset_branch(branch, snapshot_id, from_snapshot_id)_tip)rate
```