### PR TITLE
Honor storage_class in the object_store backends

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Update tests to deal with Tigris and other stores listing whole-second timestamps ([#2368](https://github.com/earth-mover/icechunk/pull/2368)).
+- `storage_class`, `metadata_storage_class` and `chunks_storage_class` now apply to the `object_store` backends — `gcs_storage`, `azure_storage` and `s3_object_store_storage`. They were silently ignored there; only `s3_storage`, `tigris_storage` and `r2_storage` honored them. The value is passed to the provider unchanged, so use its own names (`NEARLINE` on GCS, `Cool` on Azure). The local filesystem backend has no storage classes and keeps ignoring the setting ([#904](https://github.com/earth-mover/icechunk/issues/904), [#2364](https://github.com/earth-mover/icechunk/issues/2364)).
 
 ## Python Icechunk Library 2.2.0
 

--- a/icechunk-arrow-object-store/src/lib.rs
+++ b/icechunk-arrow-object-store/src/lib.rs
@@ -579,6 +579,17 @@ impl Storage for ObjectStorage {
             }
         };
 
+        // The storage class is not user metadata, so it is sent regardless of
+        // `unsafe_use_metadata`, as the native S3 backend does. `object_store`
+        // maps it to the provider's header (`x-amz-storage-class`,
+        // `x-goog-storage-class`, `x-ms-access-tier`).
+        if let Some(klass) = settings.storage_class()
+            && self.backend.supports_storage_class()
+        {
+            attributes
+                .insert(Attribute::StorageClass, AttributeValue::from(klass.clone()));
+        }
+
         let mode = self.get_put_mode(settings, previous_version);
         let is_conditional = !matches!(mode, PutMode::Overwrite);
         let write_id =
@@ -928,6 +939,13 @@ pub trait ObjectStoreBackend: Debug + Display + Sync + Send {
         false
     }
 
+    /// Whether `Settings::storage_class` is sent with writes. Backends without
+    /// storage tiers return `false` and the setting is ignored; the local
+    /// filesystem must, because `object_store` rejects any put attribute there.
+    fn supports_storage_class(&self) -> bool {
+        true
+    }
+
     fn create_location_if_needed(&self) -> Result<(), StorageError> {
         Ok(())
     }
@@ -1027,6 +1045,10 @@ impl ObjectStoreBackend for LocalFileSystemObjectStoreBackend {
 
     fn artificially_sort_refs_in_mem(&self) -> bool {
         true
+    }
+
+    fn supports_storage_class(&self) -> bool {
+        false
     }
 
     fn default_settings(&self) -> Settings {
@@ -1722,8 +1744,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        Bytes, ObjectPath, ObjectStorage, ReadbackOutcome, Settings, Storage as _,
-        VersionedUpdateResult,
+        Attribute, Attributes, Bytes, GetOptions, ObjectPath, ObjectStorage,
+        ReadbackOutcome, Role, Settings, Storage as _, VersionedUpdateResult,
     };
     #[cfg(feature = "http")]
     use super::{NonZeroU16, RetriesSettings, Url};
@@ -1828,6 +1850,109 @@ mod tests {
             .await
             .unwrap();
         assert!(not_modified.is_none());
+    }
+
+    /// HEAD `path` on the underlying `object_store` and return the attributes
+    /// it holds. The in-memory store keeps put attributes, so this observes
+    /// exactly what `put_object` sent.
+    #[expect(clippy::unwrap_used)]
+    async fn stored_attributes(
+        store: &ObjectStorage,
+        settings: &Settings,
+        path: &str,
+    ) -> Attributes {
+        let client = store.get_client(settings, Role::Read).await.unwrap();
+        let opts = GetOptions { head: true, ..Default::default() };
+        client.get_opts(&store.prefixed_path(path), opts).await.unwrap().attributes
+    }
+
+    #[tokio_test]
+    async fn storage_class_is_sent_even_without_metadata() {
+        // The storage class is not user metadata: it must reach the object
+        // store even when `unsafe_use_metadata` is off, which is the case that
+        // used to drop it (attributes were only set inside that guard).
+        let store = ObjectStorage::new_in_memory().await.unwrap();
+        let settings = Settings {
+            storage_class: Some("STANDARD_IA".to_string()),
+            unsafe_use_metadata: Some(false),
+            ..Settings::default()
+        };
+        let path = "chunks/with-class";
+        store
+            .put_object(
+                &settings,
+                path,
+                Bytes::from_static(b"payload"),
+                Some("application/octet-stream"),
+                vec![("k".to_string(), "v".to_string())],
+                None,
+            )
+            .await
+            .unwrap()
+            .must_write()
+            .unwrap();
+
+        let attributes = stored_attributes(&store, &settings, path).await;
+        assert_eq!(
+            attributes.get(&Attribute::StorageClass).map(|v| v.as_ref()),
+            Some("STANDARD_IA")
+        );
+        // ...while everything that *is* metadata stayed behind the guard.
+        assert_eq!(attributes.len(), 1);
+    }
+
+    #[tokio_test]
+    async fn no_storage_class_attribute_when_unset() {
+        let store = ObjectStorage::new_in_memory().await.unwrap();
+        let settings = store.default_settings().await.unwrap();
+        let path = "chunks/without-class";
+        store
+            .put_object(
+                &settings,
+                path,
+                Bytes::from_static(b"payload"),
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .unwrap()
+            .must_write()
+            .unwrap();
+
+        let attributes = stored_attributes(&store, &settings, path).await;
+        assert!(attributes.get(&Attribute::StorageClass).is_none());
+    }
+
+    #[tokio_test]
+    async fn local_filesystem_ignores_storage_class() {
+        // `object_store`'s `LocalFileSystem` rejects any put attribute with
+        // `NotImplemented`, and a filesystem has no storage tiers anyway, so a
+        // configured class must be dropped rather than fail every write.
+        let tmp_dir = TempDir::new().unwrap();
+        let store = ObjectStorage::new_local_filesystem(tmp_dir.path()).await.unwrap();
+        let settings = Settings {
+            storage_class: Some("STANDARD_IA".to_string()),
+            ..store.default_settings().await.unwrap()
+        };
+        let path = "chunks/on-disk";
+        store
+            .put_object(
+                &settings,
+                path,
+                Bytes::from_static(b"payload"),
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .unwrap()
+            .must_write()
+            .unwrap();
+
+        let on_disk =
+            std::fs::read(tmp_dir.path().join("chunks").join("on-disk")).unwrap();
+        assert_eq!(on_disk, b"payload");
     }
 
     #[cfg(feature = "http")]

--- a/icechunk-python/python/icechunk/_icechunk_python.pyi
+++ b/icechunk-python/python/icechunk/_icechunk_python.pyi
@@ -1548,18 +1548,18 @@ class StorageSettings:
         storage_class: str | None
             Store all objects using this object store storage class.
             If None the object store default will be used.
-            Currently not supported in GCS.
+            The value is passed to the provider as is, so use its own names:
+            for example STANDARD_IA on S3, NEARLINE on GCS, Cool on Azure.
+            Ignored by the local filesystem backend, which has no storage classes.
             Example: STANDARD_IA
             Default: None
 
         metadata_storage_class: str | None
             Store metadata objects using this object store storage class.
-            Currently not supported in GCS.
             Default: None (falls back to `storage_class`)
 
         chunks_storage_class: str | None
             Store chunk objects using this object store storage class.
-            Currently not supported in GCS.
             Default: None (falls back to `storage_class`)
 
         minimum_size_for_multipart_upload: int | None

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -21,8 +21,8 @@ use icechunk::{
     storage::{
         self, ConcurrencySettings, ETag, Generation, RepositoryCreation, S3Storage,
         StorageErrorKind, StorageResult, VersionInfo, VersionedUpdateResult, mk_client,
-        new_http_storage, new_in_memory_storage, new_redirect_storage, new_s3_storage,
-        s3_storage,
+        new_http_storage, new_in_memory_storage, new_redirect_storage,
+        new_s3_object_store_storage, new_s3_storage, s3_storage,
     },
 };
 use icechunk_arrow_object_store::object_store::azure::AzureConfigKey;
@@ -1130,6 +1130,38 @@ async fn test_storage_classes() -> Result<(), Box<dyn std::error::Error>> {
     }
     let prefix = common::get_random_prefix("test_storage_classes");
     let st = common::make_aws_integration_storage(prefix.clone())?;
+    check_storage_classes(st, &prefix).await
+}
+
+/// Same as [`test_storage_classes`] but through the `object_store` backend,
+/// which used to drop the storage class on the floor.
+#[tokio_test]
+async fn test_storage_classes_object_store() -> Result<(), Box<dyn std::error::Error>> {
+    if let Ok(e) = env::var("AWS_BUCKET")
+        && !e.is_empty()
+    {
+    } else {
+        return Ok(());
+    }
+    let prefix = common::get_random_prefix("test_storage_classes_object_store");
+    let st = new_s3_object_store_storage(
+        common::get_aws_integration_options()?,
+        common::get_aws_integration_bucket()?,
+        Some(prefix.clone()),
+        Some(common::get_aws_integration_credentials()?),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await?;
+    check_storage_classes(st, &prefix).await
+}
+
+/// Write two objects as `STANDARD_IA` and one with the default class, then
+/// list the prefix with the AWS SDK and check the classes S3 recorded.
+async fn check_storage_classes(
+    st: Arc<dyn Storage + Send + Sync>,
+    prefix: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let client = mk_client(
         &common::get_aws_integration_options()?,
         common::get_aws_integration_credentials()?,


### PR DESCRIPTION
<!-- TODO(elyall): per AI_USAGE_POLICY.md, rewrite this in your own words and add your AI-use disclosure before marking ready for review. -->

Option (0) from #2364. Closes #904.

## What

`StorageSettings.storage_class` / `metadata_storage_class` / `chunks_storage_class` were only applied by the native S3 backend (`s3_storage`, `tigris_storage`, `r2_storage`). The `object_store` backend (`gcs_storage`, `azure_storage`, `s3_object_store_storage`) built its `PutOptions.attributes` entirely inside the `unsafe_use_metadata` guard and never set `Attribute::StorageClass`, so the setting was silently ignored there.

`put_object` now inserts `Attribute::StorageClass` from `settings.storage_class()` outside that guard (the class is not user metadata). `object_store` maps it to `x-amz-storage-class` / `x-goog-storage-class` / `x-ms-access-tier`.

## Local filesystem

`object_store`'s `LocalFileSystem` returns `NotImplemented` for any non-empty put attributes, so an unconditional insert would fail every write on a local repo whose config sets a class. I added `ObjectStoreBackend::supports_storage_class()` (default `true`) and the local filesystem backend returns `false`, so the setting is ignored there as it is today. Happy to switch this to an explicit error if you'd rather not ignore it silently.

## Tests

- Unit (`icechunk-arrow-object-store`, in-memory / tempdir): the class reaches the store even with `unsafe_use_metadata = false` and nothing else leaks past the guard; no attribute when unset; local filesystem still writes with a class configured.
- Integration: `test_storage_classes_object_store` mirrors the existing AWS-gated `test_storage_classes` through `new_s3_object_store_storage`, sharing a helper. Only runs when `AWS_BUCKET` is set.
- Not yet verified against real GCS or Azure.

## Docs

- `_icechunk_python.pyi`: dropped "Currently not supported in GCS", noted provider-specific class names and the local filesystem exception.
- Changelog entry under Fixes.

`cargo fmt --check`, `just lint` (`-D warnings`, Rust 1.96) and the test suites pass locally.
