### PR TITLE
GC: list object-id prefixes concurrently on S3

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -2,6 +2,10 @@
 
 ## Python Icechunk Library [unreleased]
 
+### Performance
+
+- On S3-compatible storage, garbage collection now lists chunks, manifests, snapshots and transaction logs with 32 concurrent listings, one per possible first character of the object id. Before, each prefix was one serial chain of 1000-key pages: about 56,000 sequential requests for a repository with 56 million chunks. GCS, Azure and local storage still use one listing ([#TBD](https://github.com/earth-mover/icechunk/pull/TBD)).
+
 ### Fixes
 
 - Update tests to deal with Tigris and other stores listing whole-second timestamps ([#2368](https://github.com/earth-mover/icechunk/pull/2368)).

--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -4,7 +4,7 @@
 
 ### Performance
 
-- On S3-compatible storage, garbage collection now lists chunks, manifests, snapshots and transaction logs with 32 concurrent listings, one per possible first character of the object id. Before, each prefix was one serial chain of 1000-key pages: about 56,000 sequential requests for a repository with 56 million chunks. GCS, Azure and local storage still use one listing ([#TBD](https://github.com/earth-mover/icechunk/pull/TBD)).
+- On S3-compatible storage, garbage collection now lists chunks, manifests, snapshots and transaction logs with 32 concurrent listings, one per possible first character of the object id. Before, each prefix was one serial chain of 1000-key pages: about 56,000 sequential requests for a repository with 56 million chunks. GCS, Azure and local storage still use one listing ([#2371](https://github.com/earth-mover/icechunk/pull/2371)).
 
 ### Fixes
 

--- a/icechunk-format/src/lib.rs
+++ b/icechunk-format/src/lib.rs
@@ -204,6 +204,13 @@ impl<const SIZE: usize, T: FileTypeTag> From<&ObjectId<SIZE, T>> for String {
     }
 }
 
+/// The Crockford base32 alphabet. The string form of every [`ObjectId`] starts with
+/// one of these characters, so a listing split on them covers every object id.
+pub const OBJECT_ID_FIRST_CHARS: [&str; 32] = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G",
+    "H", "J", "K", "M", "N", "P", "Q", "R", "S", "T", "V", "W", "X", "Y", "Z",
+];
+
 impl<const SIZE: usize, T: FileTypeTag> From<[u8; SIZE]> for ObjectId<SIZE, T> {
     fn from(value: [u8; SIZE]) -> Self {
         ObjectId::new(value)
@@ -715,6 +722,21 @@ mod tests {
             .unwrap(),
             sid,
         );
+    }
+
+    #[icechunk_macros::test]
+    fn test_object_id_first_chars_are_every_possible_first_char() {
+        // The first character encodes the top 5 bits of the first byte.
+        let first_chars: std::collections::BTreeSet<String> = (0..=u8::MAX)
+            .map(|first_byte| {
+                let mut buf = [0u8; 12];
+                buf[0] = first_byte;
+                String::from(&SnapshotId::new(buf))[..1].to_string()
+            })
+            .collect();
+        let expected: std::collections::BTreeSet<String> =
+            OBJECT_ID_FIRST_CHARS.iter().map(|c| (*c).to_string()).collect();
+        assert_eq!(first_chars, expected);
     }
 
     #[icechunk_macros::test]

--- a/icechunk-s3/src/lib.rs
+++ b/icechunk-s3/src/lib.rs
@@ -555,6 +555,37 @@ impl S3Storage {
         self.key_for(layout, relpath.strip_prefix('/').unwrap_or(relpath))
     }
 
+    /// Lists the keys that start with `key_prefix`. Ids are relative to `id_root`.
+    async fn list_keys(
+        &self,
+        settings: &Settings,
+        key_prefix: String,
+        id_root: String,
+    ) -> BoxStream<'static, StorageResult<ListInfo<String>>> {
+        let mut req = self
+            .get_client(settings)
+            .await
+            .list_objects_v2()
+            .bucket(self.bucket.clone())
+            .prefix(key_prefix);
+
+        if self.config.requester_pays {
+            req = req.request_payer(aws_sdk_s3::types::RequestPayer::Requester);
+        }
+
+        req.into_paginator()
+            .send()
+            .into_stream_03x()
+            .map_err(obj_store_error)
+            .try_filter_map(|page| {
+                let contents = page.contents.map(|cont| stream::iter(cont).map(Ok));
+                ready(Ok(contents))
+            })
+            .try_flatten()
+            .and_then(move |object| ready(object_to_list_info(id_root.as_str(), &object)))
+            .boxed()
+    }
+
     /// Resolve this repository's [`KeyLayout`], probing storage at most once.
     async fn layout(&self, settings: &Settings) -> StorageResult<KeyLayout> {
         self.key_layout.get_or_try_init(|| self.probe_layout(settings)).await.copied()
@@ -1089,32 +1120,28 @@ impl Storage for S3Storage {
     ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
         let layout = self.layout(settings).await?;
         let prefix = self.list_prefix(layout, prefix);
-        let mut req = self
-            .get_client(settings)
-            .await
-            .list_objects_v2()
-            .bucket(self.bucket.clone())
-            .prefix(prefix.clone());
+        Ok(self.list_keys(settings, prefix.clone(), prefix).await)
+    }
 
-        if self.config.requester_pays {
-            req = req.request_payer(aws_sdk_s3::types::RequestPayer::Requester);
+    #[instrument(skip(self, settings, id_prefixes))]
+    async fn list_objects_with_id_prefixes<'a>(
+        &'a self,
+        settings: &Settings,
+        prefix: &str,
+        id_prefixes: &[&str],
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        let layout = self.layout(settings).await?;
+        let prefix = self.list_prefix(layout, prefix);
+        let mut listings = Vec::with_capacity(id_prefixes.len());
+        for id_prefix in id_prefixes {
+            let key_prefix = if prefix.is_empty() || prefix.ends_with('/') {
+                format!("{prefix}{id_prefix}")
+            } else {
+                format!("{prefix}/{id_prefix}")
+            };
+            listings.push(self.list_keys(settings, key_prefix, prefix.clone()).await);
         }
-
-        let stream = req
-            .into_paginator()
-            .send()
-            .into_stream_03x()
-            .map_err(obj_store_error)
-            .try_filter_map(|page| {
-                let contents = page.contents.map(|cont| stream::iter(cont).map(Ok));
-                ready(Ok(contents))
-            })
-            .try_flatten()
-            .and_then(move |object| {
-                let prefix = prefix.clone();
-                ready(object_to_list_info(prefix.as_str(), &object))
-            });
-        Ok(stream.boxed())
+        Ok(stream::select_all(listings).boxed())
     }
 
     #[instrument(skip(self, batch))]

--- a/icechunk-storage/src/storage.rs
+++ b/icechunk-storage/src/storage.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use core::fmt;
 use futures::{
     Stream, StreamExt as _, TryStreamExt as _,
+    future::ready,
     stream::{self, BoxStream, FuturesOrdered},
 };
 use itertools::Itertools as _;
@@ -561,6 +562,25 @@ pub trait Storage: fmt::Debug + Display + sealed::Sealed + Sync + Send {
         settings: &Settings,
         prefix: &str,
     ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>>;
+
+    /// Like [`Storage::list_objects`], limited to ids starting with one of `id_prefixes`.
+    /// Unordered. Override to list each id prefix concurrently; the default filters.
+    async fn list_objects_with_id_prefixes<'a>(
+        &'a self,
+        settings: &Settings,
+        prefix: &str,
+        id_prefixes: &[&str],
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        let id_prefixes: Vec<String> =
+            id_prefixes.iter().map(|id_prefix| (*id_prefix).to_string()).collect();
+        Ok(self
+            .list_objects(settings, prefix)
+            .await?
+            .try_filter(move |info| {
+                ready(id_prefixes.iter().any(|id_prefix| info.id.starts_with(id_prefix)))
+            })
+            .boxed())
+    }
 
     async fn delete_batch(
         &self,

--- a/icechunk/src/asset_manager.rs
+++ b/icechunk/src/asset_manager.rs
@@ -42,8 +42,9 @@ use crate::{
     config::CachingConfig,
     format::{
         CHUNKS_FILE_PATH, CONFIG_FILE_PATH, ChunkId, ChunkOffset, IcechunkFormatError,
-        IcechunkFormatErrorKind, MANIFESTS_FILE_PATH, ManifestId, OVERWRITTEN_FILES_PATH,
-        REPO_INFO_FILE_PATH, SNAPSHOTS_FILE_PATH, SnapshotId, TRANSACTION_LOGS_FILE_PATH,
+        IcechunkFormatErrorKind, MANIFESTS_FILE_PATH, ManifestId, OBJECT_ID_FIRST_CHARS,
+        OVERWRITTEN_FILES_PATH, REPO_INFO_FILE_PATH, SNAPSHOTS_FILE_PATH, SnapshotId,
+        TRANSACTION_LOGS_FILE_PATH,
         format_constants::{
             self, CompressionAlgorithmBin, FileHeader, FileTypeBin, SpecVersionBin,
             parse_file_header,
@@ -1015,48 +1016,45 @@ impl AssetManager {
     pub async fn list_chunks(
         &self,
     ) -> RepositoryResult<BoxStream<'_, RepositoryResult<ListInfo<ChunkId>>>> {
-        Ok(translate_list_infos(
-            self.storage
-                .list_objects(&self.storage_settings, CHUNKS_FILE_PATH)
-                .await
-                .inject()?
-                .map(|r| r.inject()),
-        ))
+        self.list_object_ids(CHUNKS_FILE_PATH).await
     }
 
     #[instrument(skip(self))]
     pub async fn list_manifests(
         &self,
     ) -> RepositoryResult<BoxStream<'_, RepositoryResult<ListInfo<ManifestId>>>> {
-        Ok(translate_list_infos(
-            self.storage
-                .list_objects(&self.storage_settings, MANIFESTS_FILE_PATH)
-                .await
-                .inject()?
-                .map(|r| r.inject()),
-        ))
+        self.list_object_ids(MANIFESTS_FILE_PATH).await
     }
 
     #[instrument(skip(self))]
     pub async fn list_snapshots(
         &self,
     ) -> RepositoryResult<BoxStream<'_, RepositoryResult<ListInfo<SnapshotId>>>> {
-        Ok(translate_list_infos(
-            self.storage
-                .list_objects(&self.storage_settings, SNAPSHOTS_FILE_PATH)
-                .await
-                .inject()?
-                .map(|r| r.inject()),
-        ))
+        self.list_object_ids(SNAPSHOTS_FILE_PATH).await
     }
 
     #[instrument(skip(self))]
     pub async fn list_transaction_logs(
         &self,
     ) -> RepositoryResult<BoxStream<'_, RepositoryResult<ListInfo<SnapshotId>>>> {
+        self.list_object_ids(TRANSACTION_LOGS_FILE_PATH).await
+    }
+
+    /// Unordered: storage can list each possible first character of the id concurrently.
+    async fn list_object_ids<'a, Id>(
+        &'a self,
+        prefix: &str,
+    ) -> RepositoryResult<BoxStream<'a, RepositoryResult<ListInfo<Id>>>>
+    where
+        Id: for<'b> TryFrom<&'b str> + Send + std::fmt::Debug + 'a,
+    {
         Ok(translate_list_infos(
             self.storage
-                .list_objects(&self.storage_settings, TRANSACTION_LOGS_FILE_PATH)
+                .list_objects_with_id_prefixes(
+                    &self.storage_settings,
+                    prefix,
+                    &OBJECT_ID_FIRST_CHARS,
+                )
                 .await
                 .inject()?
                 .map(|r| r.inject()),

--- a/icechunk/src/ops/gc.rs
+++ b/icechunk/src/ops/gc.rs
@@ -1350,7 +1350,7 @@ mod tests {
         let mut reads_per_snapshot: StdHashMap<String, usize> = StdHashMap::new();
         let mut snapshot_listings = 0;
         for (op, path) in logging.fetch_operations() {
-            if op == "list_objects" {
+            if matches!(op.as_str(), "list_objects" | "list_objects_with_id_prefixes") {
                 if path == SNAPSHOTS_FILE_PATH {
                     snapshot_listings += 1;
                 }

--- a/icechunk/src/storage/latency.rs
+++ b/icechunk/src/storage/latency.rs
@@ -134,6 +134,16 @@ impl Storage for LatencyStorage {
         self.backend.list_objects(settings, prefix).await
     }
 
+    async fn list_objects_with_id_prefixes<'a>(
+        &'a self,
+        settings: &Settings,
+        prefix: &str,
+        id_prefixes: &[&str],
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        self.sleep_for_read().await;
+        self.backend.list_objects_with_id_prefixes(settings, prefix, id_prefixes).await
+    }
+
     async fn delete_batch(
         &self,
         settings: &Settings,

--- a/icechunk/src/storage/logging.rs
+++ b/icechunk/src/storage/logging.rs
@@ -113,6 +113,19 @@ impl Storage for LoggingStorage {
         self.backend.list_objects(settings, prefix).await
     }
 
+    async fn list_objects_with_id_prefixes<'a>(
+        &'a self,
+        settings: &Settings,
+        prefix: &str,
+        id_prefixes: &[&str],
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        self.fetch_log
+            .lock()
+            .expect("poison lock")
+            .push(("list_objects_with_id_prefixes".to_string(), prefix.to_string()));
+        self.backend.list_objects_with_id_prefixes(settings, prefix, id_prefixes).await
+    }
+
     async fn delete_batch(
         &self,
         settings: &Settings,

--- a/icechunk/src/storage/redirect.rs
+++ b/icechunk/src/storage/redirect.rs
@@ -379,6 +379,18 @@ impl Storage for RedirectStorage {
         self.backend().await?.list_objects(settings, prefix).await
     }
 
+    async fn list_objects_with_id_prefixes<'a>(
+        &'a self,
+        settings: &Settings,
+        prefix: &str,
+        id_prefixes: &[&str],
+    ) -> StorageResult<BoxStream<'a, StorageResult<ListInfo<String>>>> {
+        self.backend()
+            .await?
+            .list_objects_with_id_prefixes(settings, prefix, id_prefixes)
+            .await
+    }
+
     async fn delete_batch(
         &self,
         settings: &Settings,

--- a/icechunk/tests/test_storage.rs
+++ b/icechunk/tests/test_storage.rs
@@ -638,6 +638,36 @@ async fn test_list_objects() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio_test]
+async fn test_list_objects_with_id_prefixes() -> Result<(), Box<dyn std::error::Error>> {
+    with_storage(Permission::Modify, |_, storage| async move {
+        let settings = storage.default_settings().await?;
+        for path in
+            ["foo/0a", "foo/0b", "foo/1a", "foo/Za", "foo/bar/0c", "foo0/0d", "0e"]
+        {
+            storage
+                .put_object(&settings, path, Bytes::new(), None, Default::default(), None)
+                .await?
+                .must_write()?;
+        }
+
+        for prefix in ["foo", "foo/"] {
+            let mut obs: Vec<_> = storage
+                .list_objects_with_id_prefixes(&settings, prefix, &["0", "Z"])
+                .await?
+                .map_ok(|li| li.id)
+                .try_collect()
+                .await?;
+            obs.sort();
+            assert_eq!(obs, vec!["0a".to_string(), "0b".to_string(), "Za".to_string()]);
+        }
+
+        Ok(())
+    })
+    .await?;
+    Ok(())
+}
+
+#[tokio_test]
 async fn conditional_create_conflicts_with_existing()
 -> Result<(), Box<dyn std::error::Error>> {
     // Exercises the readback's `NotOurWrite` branch (metadata-enabled


### PR DESCRIPTION
>  This is claude but it mostly makes sense and I don't want to edit out the deep rusty bits i dont quite get.

GC lists `chunks/`, `manifests/`, `snapshots/` and `transactions/` as one serial chain of 1000-key ListObjectsV2 pages. For a repository with 56 million chunks that is about 56,000 sequential requests. At roughly 0.15 s per page, the chunk listing alone takes more than two hours. #2358 made the snapshot reads concurrent; this listing is the remaining serial part.

Object ids are Crockford base32, so an id starts with one of 32 characters. This PR lists each of them concurrently:

- `Storage::list_objects_with_id_prefixes(settings, prefix, id_prefixes)` returns the objects under `prefix` whose ids start with one of `id_prefixes`, unordered. The default filters a single `list_objects`, so every backend returns the same set.
- `S3Storage` overrides it with one ListObjectsV2 per `<prefix>/<id_prefix>`, merged with `select_all`. Ids stay relative to `prefix`.
- The latency, logging and redirect wrappers forward the call.
- `OBJECT_ID_FIRST_CHARS` in `icechunk-format`, with a test that it is exactly the set of possible first characters of an `ObjectId`.
- `AssetManager::list_{chunks,manifests,snapshots,transaction_logs}` use it, so every GC listing pass is split. No caller depends on listing order.

Not in this PR: object_store backends (GCS, Azure, local) keep one listing. object_store cannot list a partial path segment. `list_with_offset` could split them, but only on backends that return keys in order.

Tests: `test_list_objects_with_id_prefixes` on every `with_storage` backend, the GC tests (including minio), and the new format test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
