### PR TITLE
Pull the MinIO image from quay.io

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -100,7 +100,7 @@ services:
   # (see icechunk/tests/test_key_layout.rs and #2239).
   minio:
     container_name: icechunk_minio
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     hostname: minio
     healthcheck:
       test: curl -f http://127.0.0.1:9000/minio/health/live


### PR DESCRIPTION
Docker Hub no longer serves `minio/minio`: the repository returns 404. Every job that runs `just contup` now fails at the image pull, and so does the local recipe. The same release tag exists on `quay.io` as a multi-arch manifest, so the compose file pulls it from there.