### PR TITLE
Binary search over manifest files

### DIFF
--- a/Changelog.python.md
+++ b/Changelog.python.md
@@ -2,6 +2,10 @@
 
 ## Python Icechunk Library [unreleased]
 
+### Performance
+
+- Speed up commits and session opening in repositories with many manifests by using binary search instead of linear scans to look up manifest metadata.
+
 ## Python Icechunk Library 2.2.0
 
 ### Features

--- a/icechunk-format/src/snapshot.rs
+++ b/icechunk-format/src/snapshot.rs
@@ -732,16 +732,15 @@ impl Snapshot {
     ) -> IcechunkResult<Option<ManifestFileInfo>> {
         let root = self.root();
         if let Some(mf2) = root.manifest_files_v2() {
-            mf2.iter()
-                .find(|mf| mf.id().is_some_and(|mid| mid.0 == id.0))
-                .map(|mf| (&mf).try_into())
-                .transpose()
+            lookup_index_by_key(mf2, Some(id.0), |mf, id| {
+                mf.id().map(|mid| mid.0).cmp(id)
+            })
+            .map(|index| (&mf2.get(index)).try_into())
+            .transpose()
         } else {
-            Ok(root
-                .manifest_files()
-                .iter()
-                .find(|mi| mi.id().0 == id.0)
-                .map(|man| man.into()))
+            let mf1 = root.manifest_files();
+            Ok(lookup_index_by_key(mf1, id.0, |mf, id| mf.id().0.cmp(id))
+                .map(|index| mf1.get(index).into()))
         }
     }
 }
@@ -971,6 +970,49 @@ mod tests {
         serialize_and_deserialize_node_snapshot - node_snapshot,
         serialize_and_deserialize_manifest_file_info - manifest_file_info
     );
+
+    #[icechunk_macros::test]
+    fn test_manifest_info() -> IcechunkResult<()> {
+        let manifest_id = |value: u32| {
+            let mut bytes = [0; 12];
+            bytes[8..].copy_from_slice(&value.to_be_bytes());
+            ManifestId::new(bytes)
+        };
+
+        for spec_version in [SpecVersionBin::V1, SpecVersionBin::V2] {
+            for count in [0, 1, 4096] {
+                // Reverse the input to exercise snapshot construction's ID sorting.
+                let manifests: Vec<_> = (1..=count)
+                    .rev()
+                    .map(|i| ManifestFileInfo {
+                        id: manifest_id(2 * i),
+                        size_bytes: u64::from(i) * 100,
+                        num_chunk_refs: i,
+                    })
+                    .collect();
+                let snapshot = Snapshot::from_iter(
+                    None,
+                    None,
+                    spec_version,
+                    "",
+                    None,
+                    manifests.clone(),
+                    None,
+                    iter::empty(),
+                )?;
+
+                for manifest in manifests {
+                    assert_eq!(snapshot.manifest_info(&manifest.id)?, Some(manifest));
+                }
+                // Misses before, between, and after the stored IDs.
+                assert_eq!(snapshot.manifest_info(&manifest_id(0))?, None);
+                for i in 0..=count {
+                    assert_eq!(snapshot.manifest_info(&manifest_id(2 * i + 1))?, None);
+                }
+            }
+        }
+        Ok(())
+    }
 
     #[icechunk_macros::test]
     fn test_get_node() -> Result<(), Box<dyn std::error::Error>> {

--- a/icechunk-format/src/snapshot.rs
+++ b/icechunk-format/src/snapshot.rs
@@ -731,6 +731,7 @@ impl Snapshot {
         id: &ManifestId,
     ) -> IcechunkResult<Option<ManifestFileInfo>> {
         let root = self.root();
+        // Both manifest vectors are sorted by id in from_iter, as required by snapshot.fbs.
         if let Some(mf2) = root.manifest_files_v2() {
             lookup_index_by_key(mf2, Some(id.0), |mf, id| {
                 mf.id().map(|mid| mid.0).cmp(id)


### PR DESCRIPTION
Speed up manifest metadata lookup during commits, reads, and manifest preloading in repositories with many manifests by using binary search instead of linear scans.

This was motivated by commit times on a store w/ hundreds of thousands of total manifest files reaching roughly 90 seconds. Even though the commits touched only a couple hundred manifest files, finding which manifests to update became the bottleneck. I tried to reduce the number of manifests by making splits larger, but that increases the amount of download, merge, upload work to do per commit, making that portion of work the bottleneck.